### PR TITLE
fix: truncate v3 export path segments to avoid ENAMETOOLONG

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ If the action writes `.github/workflows/ci.yml`, provide a credential source tha
 
 Collections are exported in the Postman Collection v3 format, producing a multi-file YAML directory structure under `postman/collections/`. Each collection (Baseline, Smoke, Contract) gets its own directory containing `collection.yaml` and nested folder/request YAML files. The `.postman/resources.yaml` manifest maps each v3 collection directory to its Postman UID.
 
+Folder and request **names are truncated to 120 characters** per path segment when writing files (with an ellipsis). That avoids `ENAMETOOLONG` when Postman item names are very long (for example, copied from long OpenAPI operation summaries).
+
 ## Inputs
 
 | Input | Default | Notes |

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24024,9 +24024,16 @@ function extractDescription(value) {
   }
   return void 0;
 }
+var MAX_PATH_SEGMENT_CHARS = 120;
 function sanitizePathSegment(value, fallback) {
-  const normalized = value.replace(/[<>:"/\\|?*\u0000-\u001f]/g, " ").replace(/\s+/g, " ").trim();
-  return normalized || fallback;
+  let normalized = value.replace(/[<>:"/\\|?*\u0000-\u001f]/g, " ").replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return fallback;
+  }
+  if (normalized.length > MAX_PATH_SEGMENT_CHARS) {
+    normalized = `${normalized.slice(0, MAX_PATH_SEGMENT_CHARS - 1)}\u2026`;
+  }
+  return normalized;
 }
 function buildUniqueRef(baseName, kind, usedRefs) {
   const fallback = kind === "folder" ? "Folder" : "Request";

--- a/src/postman-v3/converter.ts
+++ b/src/postman-v3/converter.ts
@@ -234,12 +234,21 @@ function extractDescription(value: PostmanDescription): string | undefined {
   return undefined;
 }
 
-function sanitizePathSegment(value: string, fallback: string): string {
-  const normalized = value
+/** Keep each folder/request segment short so nested paths stay under OS limits (ENAMETOOLONG). */
+export const MAX_PATH_SEGMENT_CHARS = 120;
+
+export function sanitizePathSegment(value: string, fallback: string): string {
+  let normalized = value
     .replace(/[<>:"/\\|?*\u0000-\u001f]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
-  return normalized || fallback;
+  if (!normalized) {
+    return fallback;
+  }
+  if (normalized.length > MAX_PATH_SEGMENT_CHARS) {
+    normalized = `${normalized.slice(0, MAX_PATH_SEGMENT_CHARS - 1)}…`;
+  }
+  return normalized;
 }
 
 function buildUniqueRef(

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_PATH_SEGMENT_CHARS,
+  sanitizePathSegment
+} from '../src/postman-v3/converter.js';
+
+describe('sanitizePathSegment', () => {
+  it('truncates long request names to avoid ENAMETOOLONG on export', () => {
+    const long = 'x'.repeat(500);
+    const out = sanitizePathSegment(long, 'fallback');
+    expect(out.length).toBe(MAX_PATH_SEGMENT_CHARS);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('truncates GoodLeap-style OpenAPI summaries used as Postman request names', () => {
+    const endSession =
+      'End the current AAT session and clean up any artifacts. This should be called at the end of an AAT test to ensure that the session is properly closed and data is cleaned up. If no AAT test is running, it will simply return a message indicating that there is no session to end.';
+    const endAll =
+      'End all tests that are currently running in AAT and purge their data. This is a safety measure in case something goes wrong and tests are left running, which can cause issues for other tests and data pollution. This can be hooked into a pipeline that runs periodically to ensure a clean state in AAT.';
+    expect(endSession.length).toBeGreaterThan(255);
+    expect(endAll.length).toBeGreaterThan(255);
+    for (const raw of [endSession, endAll]) {
+      const out = sanitizePathSegment(raw, 'fallback');
+      expect(out.length).toBe(MAX_PATH_SEGMENT_CHARS);
+      expect(out.endsWith('…')).toBe(true);
+    }
+  });
+
+  it('preserves short names', () => {
+    expect(sanitizePathSegment('List pets', 'fallback')).toBe('List pets');
+  });
+});


### PR DESCRIPTION
Long Postman request/folder names (e.g. from OpenAPI summaries) produced filesystem paths that exceeded OS limits. Sanitize path segments to 120 characters with ellipsis during Collection v3 export.