### PR TITLE
feat: add CLI entry point for cross-CI platform support

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -1334,14 +1334,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path2 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path2 && path2[0] !== "/") {
-          path2 = `/${path2}`;
+        if (path3 && path3[0] !== "/") {
+          path3 = `/${path3}`;
         }
-        return new URL(`${origin}${path2}`);
+        return new URL(`${origin}${path3}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1792,39 +1792,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path2, origin }
+          request: { method, path: path3, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path2);
+        debuglog("sending request to %s %s/%s", method, origin, path3);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path2, origin },
+          request: { method, path: path3, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path2,
+          path3,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path2, origin }
+          request: { method, path: path3, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path2);
+        debuglog("trailers received from %s %s/%s", method, origin, path3);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path2, origin },
+          request: { method, path: path3, origin },
           error
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path2,
+          path3,
           error.message
         );
       });
@@ -1873,9 +1873,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path2, origin }
+            request: { method, path: path3, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path2);
+          debuglog("sending request to %s %s/%s", method, origin, path3);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1938,7 +1938,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path2,
+        path: path3,
         method,
         body,
         headers,
@@ -1953,11 +1953,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path2 !== "string") {
+        if (typeof path3 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path2[0] !== "/" && !(path2.startsWith("http://") || path2.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path2)) {
+        } else if (invalidPathRegex.test(path3)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -2023,7 +2023,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path2, query) : path2;
+        this.path = query ? buildURL(path3, query) : path3;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6542,7 +6542,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request) {
-      const { method, path: path2, host, upgrade, blocking, reset } = request;
+      const { method, path: path3, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util.isFormDataLike(body)) {
@@ -6608,7 +6608,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path2} HTTP/1.1\r
+      let header = `${method} ${path3} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -7134,7 +7134,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path: path2, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -7201,7 +7201,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path2;
+      headers[HTTP2_HEADER_PATH] = path3;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7554,9 +7554,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path2 = search ? `${pathname}${search}` : pathname;
+        const path3 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path2;
+        this.opts.path = path3;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8790,10 +8790,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path2 = "/",
+          path: path3 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path2;
+        opts.path = origin + path3;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10714,20 +10714,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path2) {
-      if (typeof path2 !== "string") {
-        return path2;
+    function safeUrl(path3) {
+      if (typeof path3 !== "string") {
+        return path3;
       }
-      const pathSegments = path2.split("?");
+      const pathSegments = path3.split("?");
       if (pathSegments.length !== 2) {
-        return path2;
+        return path3;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path2, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path2);
+    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path3);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10749,7 +10749,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path2 }) => matchValue(safeUrl(path2), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10787,9 +10787,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path2, method, body, headers, query } = opts;
+      const { path: path3, method, body, headers, query } = opts;
       return {
-        path: path2,
+        path: path3,
         method,
         body,
         headers,
@@ -11095,7 +11095,7 @@ var require_mock_interceptor = __commonJS({
 var require_mock_client = __commonJS({
   "node_modules/undici/lib/mock/mock-client.js"(exports2, module2) {
     "use strict";
-    var { promisify } = require("node:util");
+    var { promisify: promisify2 } = require("node:util");
     var Client = require_client();
     var { buildMockDispatch } = require_mock_utils();
     var {
@@ -11135,7 +11135,7 @@ var require_mock_client = __commonJS({
         return new MockInterceptor(opts, this[kDispatches]);
       }
       async [kClose]() {
-        await promisify(this[kOriginalClose])();
+        await promisify2(this[kOriginalClose])();
         this[kConnected] = 0;
         this[kMockAgent][Symbols.kClients].delete(this[kOrigin]);
       }
@@ -11148,7 +11148,7 @@ var require_mock_client = __commonJS({
 var require_mock_pool = __commonJS({
   "node_modules/undici/lib/mock/mock-pool.js"(exports2, module2) {
     "use strict";
-    var { promisify } = require("node:util");
+    var { promisify: promisify2 } = require("node:util");
     var Pool = require_pool();
     var { buildMockDispatch } = require_mock_utils();
     var {
@@ -11188,7 +11188,7 @@ var require_mock_pool = __commonJS({
         return new MockInterceptor(opts, this[kDispatches]);
       }
       async [kClose]() {
-        await promisify(this[kOriginalClose])();
+        await promisify2(this[kOriginalClose])();
         this[kConnected] = 0;
         this[kMockAgent][Symbols.kClients].delete(this[kOrigin]);
       }
@@ -11252,10 +11252,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path2, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path2,
+            Path: path3,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -16136,9 +16136,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path2) {
-      for (let i = 0; i < path2.length; ++i) {
-        const code = path2.charCodeAt(i);
+    function validateCookiePath(path3) {
+      for (let i = 0; i < path3.length; ++i) {
+        const code = path3.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18778,11 +18778,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path2 = opts.path;
+          let path3 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path2 = `/${path2}`;
+            path3 = `/${path3}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path2);
+          url = new URL(util.parseOrigin(url).origin + path3);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -19709,7 +19709,7 @@ var require_summary = __commonJS({
     exports2.summary = exports2.markdownSummary = exports2.SUMMARY_DOCS_URL = exports2.SUMMARY_ENV_VAR = void 0;
     var os_1 = require("os");
     var fs_1 = require("fs");
-    var { access, appendFile, writeFile: writeFile2 } = fs_1.promises;
+    var { access, appendFile, writeFile: writeFile3 } = fs_1.promises;
     exports2.SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
     exports2.SUMMARY_DOCS_URL = "https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary";
     var Summary = class {
@@ -19767,7 +19767,7 @@ var require_summary = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
           const filePath = yield this.filePath();
-          const writeFunc = overwrite ? writeFile2 : appendFile;
+          const writeFunc = overwrite ? writeFile3 : appendFile;
           yield writeFunc(filePath, this._buffer, { encoding: "utf8" });
           return this.emptyBuffer();
         });
@@ -20001,7 +20001,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path2 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -20011,7 +20011,7 @@ var require_path_utils = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path2.sep);
+      return pth.replace(/[/\\]/g, path3.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -20075,7 +20075,7 @@ var require_io_util = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
     var fs2 = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
@@ -20124,7 +20124,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
+            const upperExt = path3.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -20148,11 +20148,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
+                const directory = path3.dirname(filePath);
+                const upperName = path3.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
+                    filePath = path3.join(directory, actualName);
                     break;
                   }
                 }
@@ -20247,7 +20247,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path2 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -20256,7 +20256,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path3.join(dest, path3.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -20268,7 +20268,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path2.relative(source, newDest) === "") {
+          if (path3.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -20281,7 +20281,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
+            dest = path3.join(dest, path3.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -20292,7 +20292,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path2.dirname(dest));
+        yield mkdirP(path3.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -20355,7 +20355,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path3.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -20368,12 +20368,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path2.sep)) {
+        if (tool.includes(path3.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path2.delimiter)) {
+          for (const p of process.env.PATH.split(path3.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -20381,7 +20381,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path3.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -20497,7 +20497,7 @@ var require_toolrunner = __commonJS({
     var os = __importStar(require("os"));
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
@@ -20712,7 +20712,7 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
           return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
@@ -21212,7 +21212,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -21240,7 +21240,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path3.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
     function getInput2(name, options) {
@@ -21377,18 +21377,24 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// src/index.ts
-var index_exports = {};
-__export(index_exports, {
-  createRepoSyncDependencies: () => createRepoSyncDependencies,
-  getInput: () => getInput,
-  readActionInputs: () => readActionInputs,
-  resolveInputs: () => resolveInputs,
-  resolvePostmanApiKeyAndTeamId: () => resolvePostmanApiKeyAndTeamId,
-  runAction: () => runAction,
-  runRepoSync: () => runRepoSync
+// src/cli.ts
+var cli_exports = {};
+__export(cli_exports, {
+  ConsoleReporter: () => ConsoleReporter,
+  createCliDependencies: () => createCliDependencies,
+  createCliExec: () => createCliExec,
+  normalizeCliFlag: () => normalizeCliFlag,
+  parseCliArgs: () => parseCliArgs,
+  runCli: () => runCli,
+  toDotenv: () => toDotenv
 });
-module.exports = __toCommonJS(index_exports);
+module.exports = __toCommonJS(cli_exports);
+var import_node_child_process = require("node:child_process");
+var import_promises = require("node:fs/promises");
+var import_node_path = __toESM(require("node:path"), 1);
+var import_node_util = require("node:util");
+
+// src/index.ts
 var core2 = __toESM(require_core(), 1);
 var exec = __toESM(require_exec(), 1);
 var import_node_fs = require("node:fs");
@@ -24635,10 +24641,10 @@ function sanitizeHeaders(headers, secretValues) {
 }
 
 // src/lib/github/github-api-client.ts
-function buildErrorMessage(method, path2, response, body, masker) {
+function buildErrorMessage(method, path3, response, body, masker) {
   const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
   const sanitizedBody = masker(body || "");
-  return sanitizedBody ? masker(`${method} ${path2} failed with ${status} - ${sanitizedBody}`) : masker(`${method} ${path2} failed with ${status} - [REDACTED]`);
+  return sanitizedBody ? masker(`${method} ${path3} failed with ${status} - ${sanitizedBody}`) : masker(`${method} ${path3} failed with ${status} - [REDACTED]`);
 }
 var GitHubApiClient = class {
   apiBase;
@@ -24688,18 +24694,18 @@ var GitHubApiClient = class {
     }
     return ordered;
   }
-  isVariablesEndpoint(path2) {
-    return path2.startsWith(`/repos/${this.owner}/${this.repo}/actions/variables`);
+  isVariablesEndpoint(path3) {
+    return path3.startsWith(`/repos/${this.owner}/${this.repo}/actions/variables`);
   }
-  canUseFallback(path2) {
-    return this.isVariablesEndpoint(path2) || path2.includes(`/repos/${this.owner}/${this.repo}/contents`) || path2.includes("/dispatches");
+  canUseFallback(path3) {
+    return this.isVariablesEndpoint(path3) || path3.includes(`/repos/${this.owner}/${this.repo}/contents`) || path3.includes("/dispatches");
   }
-  async requestWithToken(path2, init, token) {
+  async requestWithToken(path3, init, token) {
     const normalizedToken = String(token || "").trim();
     if (!normalizedToken) {
-      throw new Error(`Missing GitHub auth token for request ${path2}`);
+      throw new Error(`Missing GitHub auth token for request ${path3}`);
     }
-    return this.fetchImpl(`${this.apiBase}${path2}`, {
+    return this.fetchImpl(`${this.apiBase}${path3}`, {
       ...init,
       headers: {
         Accept: "application/vnd.github+json",
@@ -24709,28 +24715,28 @@ var GitHubApiClient = class {
       }
     });
   }
-  async request(path2, init = {}) {
+  async request(path3, init = {}) {
     const orderedTokens = this.getTokenOrder();
     if (orderedTokens.length === 0) {
       throw new Error("No GitHub auth token configured");
     }
-    const first = await this.requestWithToken(path2, init, orderedTokens[0]);
-    if (orderedTokens.length < 2 || !this.canUseFallback(path2)) {
+    const first = await this.requestWithToken(path3, init, orderedTokens[0]);
+    if (orderedTokens.length < 2 || !this.canUseFallback(path3)) {
       return first;
     }
-    const isVariableGet404 = first.status === 404 && (!init.method || init.method === "GET") && this.isVariablesEndpoint(path2);
+    const isVariableGet404 = first.status === 404 && (!init.method || init.method === "GET") && this.isVariablesEndpoint(path3);
     if (first.status !== 403 && !isVariableGet404) {
       return first;
     }
-    return this.requestWithToken(path2, init, orderedTokens[1]);
+    return this.requestWithToken(path3, init, orderedTokens[1]);
   }
   async setRepositoryVariable(name, value) {
     if (!value) {
       throw new Error(`Repo variable ${name} is empty`);
     }
-    const path2 = `/repos/${this.repository}/actions/variables`;
+    const path3 = `/repos/${this.repository}/actions/variables`;
     const body = JSON.stringify({ name, value: String(value) });
-    const createResponse = await this.request(path2, {
+    const createResponse = await this.request(path3, {
       method: "POST",
       body
     });
@@ -24753,12 +24759,12 @@ var GitHubApiClient = class {
     }
     const text = await createResponse.text().catch(() => "");
     throw new Error(
-      buildErrorMessage("POST", path2, createResponse, text, this.secretMasker)
+      buildErrorMessage("POST", path3, createResponse, text, this.secretMasker)
     );
   }
   async getRepositoryVariable(name) {
-    const path2 = `/repos/${this.repository}/actions/variables/${name}`;
-    const response = await this.request(path2, {
+    const path3 = `/repos/${this.repository}/actions/variables/${name}`;
+    const response = await this.request(path3, {
       method: "GET"
     });
     if (response.status === 404) {
@@ -24767,7 +24773,7 @@ var GitHubApiClient = class {
     if (!response.ok) {
       const text = await response.text().catch(() => "");
       throw new Error(
-        buildErrorMessage("GET", path2, response, text, this.secretMasker)
+        buildErrorMessage("GET", path3, response, text, this.secretMasker)
       );
     }
     const data = await response.json();
@@ -24910,8 +24916,8 @@ function normalizeRepoUrl(url) {
   const sshMatch = raw.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch) {
     const host = sshMatch[1];
-    const path2 = sshMatch[2];
-    return `https://${host}/${path2}`;
+    const path3 = sshMatch[2];
+    return `https://${host}/${path3}`;
   }
   return raw.replace(/\.git$/, "");
 }
@@ -25170,8 +25176,8 @@ var PostmanAssetsClient = class {
     this.fetchImpl = options.fetchImpl ?? fetch;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
-  async request(path2, init = {}) {
-    const url = path2.startsWith("http") ? path2 : `${this.baseUrl}${path2}`;
+  async request(path3, init = {}) {
+    const url = path3.startsWith("http") ? path3 : `${this.baseUrl}${path3}`;
     const response = await this.fetchImpl(url, {
       ...init,
       headers: {
@@ -25706,8 +25712,8 @@ async function upsertEnvironments(inputs, dependencies) {
   }
   return envUids;
 }
-function ensureDir(path2) {
-  (0, import_node_fs.mkdirSync)(path2, { recursive: true });
+function ensureDir(path3) {
+  (0, import_node_fs.mkdirSync)(path3, { recursive: true });
 }
 var VOLATILE_KEYS = /* @__PURE__ */ new Set([
   "createdAt",
@@ -25736,9 +25742,9 @@ function stripVolatileFields(obj) {
   }
   return obj;
 }
-function writeJsonFile(path2, content, normalize2 = false) {
+function writeJsonFile(path3, content, normalize2 = false) {
   const data = normalize2 ? stripVolatileFields(content) : content;
-  (0, import_node_fs.writeFileSync)(path2, JSON.stringify(data, null, 2));
+  (0, import_node_fs.writeFileSync)(path3, JSON.stringify(data, null, 2));
 }
 function buildResourcesManifest(workspaceId, collectionMap) {
   const manifest = {
@@ -26241,15 +26247,258 @@ if (entrypoint && currentModulePath === entrypoint) {
     core2.setFailed(String(error));
   });
 }
+
+// src/cli.ts
+var execFileAsync = (0, import_node_util.promisify)(import_node_child_process.execFile);
+var ConsoleReporter = class {
+  info(message) {
+    console.error(message);
+  }
+  warning(message) {
+    console.error(`warning: ${message}`);
+  }
+  setOutput(_name, _value) {
+  }
+  setSecret(_secret) {
+  }
+};
+function readFlag(argv, name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === `--${name}`) {
+      return argv[index + 1];
+    }
+    if (arg?.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return void 0;
+}
+function normalizeCliFlag(name) {
+  return `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+}
+function toCommandLabel(commandLine, args, secretMasker) {
+  return secretMasker([commandLine, ...args].join(" "));
+}
+function createCliExec(secretMasker) {
+  return {
+    getExecOutput: async (commandLine, args = [], options) => {
+      const commandLabel = toCommandLabel(commandLine, args, secretMasker);
+      process.stderr.write(`[command] ${commandLabel}
+`);
+      try {
+        const result = await execFileAsync(commandLine, args, {
+          cwd: options?.cwd,
+          env: options?.env ?? process.env,
+          encoding: "utf8",
+          maxBuffer: 20 * 1024 * 1024,
+          windowsHide: true
+        });
+        const stdout = String(result.stdout ?? "");
+        const stderr = String(result.stderr ?? "");
+        if (stdout) {
+          process.stderr.write(secretMasker(stdout));
+        }
+        if (stderr) {
+          process.stderr.write(secretMasker(stderr));
+        }
+        return {
+          exitCode: 0,
+          stdout,
+          stderr
+        };
+      } catch (error) {
+        const execError = error;
+        const stdout = String(execError.stdout ?? "");
+        const stderr = String(execError.stderr ?? "");
+        const fallbackMessage = execError.message ? `${execError.message}
+` : "";
+        if (stdout) {
+          process.stderr.write(secretMasker(stdout));
+        }
+        if (stderr) {
+          process.stderr.write(secretMasker(stderr));
+        } else if (fallbackMessage) {
+          process.stderr.write(secretMasker(fallbackMessage));
+        }
+        const exitCode = typeof execError.code === "number" ? execError.code : Number.parseInt(String(execError.code ?? "1"), 10) || 1;
+        if (!options?.ignoreReturnCode) {
+          throw new Error(`Command failed with exit code ${exitCode}: ${commandLabel}`);
+        }
+        return {
+          exitCode,
+          stdout,
+          stderr
+        };
+      }
+    }
+  };
+}
+function parseCliArgs(argv, env = process.env) {
+  const inputNames = [
+    "project-name",
+    "workspace-id",
+    "baseline-collection-id",
+    "smoke-collection-id",
+    "contract-collection-id",
+    "environments-json",
+    "repo-url",
+    "integration-backend",
+    "workspace-link-enabled",
+    "environment-sync-enabled",
+    "system-env-map-json",
+    "environment-uids-json",
+    "env-runtime-urls-json",
+    "artifact-dir",
+    "repo-write-mode",
+    "repository",
+    "current-ref",
+    "github-head-ref",
+    "github-ref-name",
+    "committer-name",
+    "committer-email",
+    "postman-api-key",
+    "postman-access-token",
+    "github-token",
+    "gh-fallback-token",
+    "github-auth-mode",
+    "ci-workflow-base64",
+    "generate-ci-workflow",
+    "monitor-type",
+    "ci-workflow-path",
+    "org-mode",
+    "monitor-id",
+    "mock-url",
+    "monitor-cron",
+    "ssl-client-cert",
+    "ssl-client-key",
+    "ssl-client-passphrase",
+    "ssl-extra-ca-certs",
+    "team-id"
+  ];
+  const inputEnv = { ...env };
+  for (const name of inputNames) {
+    const value = readFlag(argv, name);
+    if (value !== void 0) {
+      inputEnv[normalizeCliFlag(name)] = value;
+    }
+  }
+  return {
+    inputEnv,
+    resultJsonPath: readFlag(argv, "result-json") ?? "postman-repo-sync-result.json",
+    dotenvPath: readFlag(argv, "dotenv-path")
+  };
+}
+function toDotenv(outputs) {
+  return Object.entries(outputs).map(([key, value]) => [
+    `POSTMAN_REPO_SYNC_${key.replace(/-/g, "_").toUpperCase()}`,
+    String(value ?? "")
+  ]).map(([key, value]) => `${key}=${JSON.stringify(value)}`).join("\n");
+}
+async function writeOptionalFile(filePath, content) {
+  if (!filePath) {
+    return;
+  }
+  const workspaceRoot = import_node_path.default.resolve(process.cwd());
+  const resolved = import_node_path.default.resolve(workspaceRoot, filePath);
+  const relative = import_node_path.default.relative(workspaceRoot, resolved);
+  if (relative.startsWith("..") || import_node_path.default.isAbsolute(relative)) {
+    throw new Error(`Output path must stay within workspace: ${filePath}`);
+  }
+  await (0, import_promises.mkdir)(import_node_path.default.dirname(resolved), { recursive: true });
+  await (0, import_promises.writeFile)(resolved, content, "utf8");
+}
+function createCliDependencies(inputs, resolved) {
+  const secretMasker = createSecretMasker([
+    resolved.apiKey,
+    inputs.postmanAccessToken,
+    inputs.githubToken,
+    inputs.ghFallbackToken,
+    inputs.sslClientCert,
+    inputs.sslClientKey,
+    inputs.sslClientPassphrase,
+    inputs.sslExtraCaCerts
+  ]);
+  const cliExec = createCliExec(secretMasker);
+  return createRepoSyncDependencies(
+    inputs,
+    resolved,
+    {
+      core: new ConsoleReporter(),
+      exec: cliExec
+    },
+    {
+      secretMasker
+    }
+  );
+}
+async function runCli(argv = process.argv.slice(2), runtime = {}) {
+  const env = runtime.env ?? process.env;
+  const config = parseCliArgs(argv, env);
+  const inputs = resolveInputs(config.inputEnv);
+  const reporter = new ConsoleReporter();
+  const initialMasker = createSecretMasker([
+    inputs.postmanApiKey,
+    inputs.postmanAccessToken,
+    inputs.githubToken,
+    inputs.ghFallbackToken,
+    inputs.sslClientCert,
+    inputs.sslClientKey,
+    inputs.sslClientPassphrase,
+    inputs.sslExtraCaCerts
+  ]);
+  const resolvingExec = createCliExec(initialMasker);
+  const resolved = await resolvePostmanApiKeyAndTeamId(
+    inputs,
+    reporter,
+    resolvingExec,
+    initialMasker,
+    {
+      persistGeneratedApiKeySecret: false,
+      env
+    }
+  );
+  const dependencies = createCliDependencies(inputs, resolved);
+  if (!dependencies.github) {
+    dependencies.core.info("GitHub variable persistence disabled for this run");
+  }
+  if (inputs.environmentSyncEnabled && !dependencies.internalIntegration) {
+    dependencies.core.warning(
+      "Skipping system environment association because postman-access-token is not configured"
+    );
+  }
+  if (inputs.workspaceLinkEnabled && !dependencies.internalIntegration) {
+    dependencies.core.warning(
+      "Skipping workspace linking because postman-access-token is not configured"
+    );
+  }
+  const result = await (runtime.executeRepoSync ?? runRepoSync)(inputs, dependencies);
+  await writeOptionalFile(config.resultJsonPath, JSON.stringify(result, null, 2));
+  await writeOptionalFile(config.dotenvPath, toDotenv(result));
+  const writeStdout = runtime.writeStdout ?? ((chunk) => process.stdout.write(chunk));
+  writeStdout(`${JSON.stringify(result, null, 2)}
+`);
+}
+var currentModulePath2 = typeof __filename === "string" ? __filename : "";
+var entrypoint2 = process.argv[1];
+if (entrypoint2 && currentModulePath2 === entrypoint2) {
+  runCli().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}
+`);
+    process.exitCode = 1;
+  });
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
-  createRepoSyncDependencies,
-  getInput,
-  readActionInputs,
-  resolveInputs,
-  resolvePostmanApiKeyAndTeamId,
-  runAction,
-  runRepoSync
+  ConsoleReporter,
+  createCliDependencies,
+  createCliExec,
+  normalizeCliFlag,
+  parseCliArgs,
+  runCli,
+  toDotenv
 });
 /*! Bundled license information:
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "Public open-alpha Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",
+  "bin": {
+    "postman-repo-sync": "dist/cli.cjs"
+  },
   "files": [
     "action.yml",
     "dist"
   ],
   "scripts": {
-    "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.cjs",
-    "check:dist": "npm run build && git diff --exit-code -- dist/index.cjs",
+    "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/cli.cjs",
+    "check:dist": "npm run build && git diff --exit-code -- dist",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,312 @@
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  createRepoSyncDependencies,
+  resolveInputs,
+  resolvePostmanApiKeyAndTeamId,
+  runRepoSync,
+  type ExecLike,
+  type RepoSyncDependencies,
+  type ResolvedInputs
+} from './index.js';
+import { createSecretMasker } from './lib/secrets.js';
+
+interface CliConfig {
+  inputEnv: NodeJS.ProcessEnv;
+  resultJsonPath: string;
+  dotenvPath?: string;
+}
+
+interface CliRuntime {
+  env?: NodeJS.ProcessEnv;
+  executeRepoSync?: typeof runRepoSync;
+  writeStdout?: (chunk: string) => void;
+}
+
+const execFileAsync = promisify(execFile);
+
+type ReporterCore = RepoSyncDependencies['core'];
+
+export class ConsoleReporter implements ReporterCore {
+  public info(message: string): void {
+    console.error(message);
+  }
+
+  public warning(message: string): void {
+    console.error(`warning: ${message}`);
+  }
+
+  public setOutput(_name: string, _value: string): void {
+  }
+
+  public setSecret(_secret: string): void {
+  }
+}
+
+function readFlag(argv: string[], name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === `--${name}`) {
+      return argv[index + 1];
+    }
+    if (arg?.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return undefined;
+}
+
+export function normalizeCliFlag(name: string): string {
+  return `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
+}
+
+function toCommandLabel(
+  commandLine: string,
+  args: string[],
+  secretMasker: (value: string) => string
+): string {
+  return secretMasker([commandLine, ...args].join(' '));
+}
+
+export function createCliExec(secretMasker: (value: string) => string): ExecLike {
+  return {
+    getExecOutput: async (commandLine, args = [], options) => {
+      const commandLabel = toCommandLabel(commandLine, args, secretMasker);
+      process.stderr.write(`[command] ${commandLabel}\n`);
+
+      try {
+        const result = await execFileAsync(commandLine, args, {
+          cwd: options?.cwd,
+          env: options?.env ?? process.env,
+          encoding: 'utf8',
+          maxBuffer: 20 * 1024 * 1024,
+          windowsHide: true
+        });
+        const stdout = String(result.stdout ?? '');
+        const stderr = String(result.stderr ?? '');
+        if (stdout) {
+          process.stderr.write(secretMasker(stdout));
+        }
+        if (stderr) {
+          process.stderr.write(secretMasker(stderr));
+        }
+        return {
+          exitCode: 0,
+          stdout,
+          stderr
+        };
+      } catch (error) {
+        const execError = error as {
+          code?: number | string;
+          stdout?: string | Buffer;
+          stderr?: string | Buffer;
+          message?: string;
+        };
+        const stdout = String(execError.stdout ?? '');
+        const stderr = String(execError.stderr ?? '');
+        const fallbackMessage = execError.message ? `${execError.message}\n` : '';
+        if (stdout) {
+          process.stderr.write(secretMasker(stdout));
+        }
+        if (stderr) {
+          process.stderr.write(secretMasker(stderr));
+        } else if (fallbackMessage) {
+          process.stderr.write(secretMasker(fallbackMessage));
+        }
+        const exitCode =
+          typeof execError.code === 'number'
+            ? execError.code
+            : Number.parseInt(String(execError.code ?? '1'), 10) || 1;
+        if (!options?.ignoreReturnCode) {
+          throw new Error(`Command failed with exit code ${exitCode}: ${commandLabel}`);
+        }
+        return {
+          exitCode,
+          stdout,
+          stderr
+        };
+      }
+    }
+  };
+}
+
+export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliConfig {
+  const inputNames = [
+    'project-name',
+    'workspace-id',
+    'baseline-collection-id',
+    'smoke-collection-id',
+    'contract-collection-id',
+    'environments-json',
+    'repo-url',
+    'integration-backend',
+    'workspace-link-enabled',
+    'environment-sync-enabled',
+    'system-env-map-json',
+    'environment-uids-json',
+    'env-runtime-urls-json',
+    'artifact-dir',
+    'repo-write-mode',
+    'repository',
+    'current-ref',
+    'github-head-ref',
+    'github-ref-name',
+    'committer-name',
+    'committer-email',
+    'postman-api-key',
+    'postman-access-token',
+    'github-token',
+    'gh-fallback-token',
+    'github-auth-mode',
+    'ci-workflow-base64',
+    'generate-ci-workflow',
+    'monitor-type',
+    'ci-workflow-path',
+    'org-mode',
+    'monitor-id',
+    'mock-url',
+    'monitor-cron',
+    'ssl-client-cert',
+    'ssl-client-key',
+    'ssl-client-passphrase',
+    'ssl-extra-ca-certs',
+    'team-id'
+  ];
+
+  const inputEnv: NodeJS.ProcessEnv = { ...env };
+  for (const name of inputNames) {
+    const value = readFlag(argv, name);
+    if (value !== undefined) {
+      inputEnv[normalizeCliFlag(name)] = value;
+    }
+  }
+
+  return {
+    inputEnv,
+    resultJsonPath: readFlag(argv, 'result-json') ?? 'postman-repo-sync-result.json',
+    dotenvPath: readFlag(argv, 'dotenv-path')
+  };
+}
+
+export function toDotenv(outputs: object): string {
+  return Object.entries(outputs as Record<string, unknown>)
+    .map(([key, value]) => [
+      `POSTMAN_REPO_SYNC_${key.replace(/-/g, '_').toUpperCase()}`,
+      String(value ?? '')
+    ] as const)
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join('\n');
+}
+
+async function writeOptionalFile(filePath: string | undefined, content: string): Promise<void> {
+  if (!filePath) {
+    return;
+  }
+  const workspaceRoot = path.resolve(process.cwd());
+  const resolved = path.resolve(workspaceRoot, filePath);
+  const relative = path.relative(workspaceRoot, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Output path must stay within workspace: ${filePath}`);
+  }
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, content, 'utf8');
+}
+
+export function createCliDependencies(
+  inputs: ResolvedInputs,
+  resolved: { apiKey: string; teamId: string }
+): RepoSyncDependencies {
+  const secretMasker = createSecretMasker([
+    resolved.apiKey,
+    inputs.postmanAccessToken,
+    inputs.githubToken,
+    inputs.ghFallbackToken,
+    inputs.sslClientCert,
+    inputs.sslClientKey,
+    inputs.sslClientPassphrase,
+    inputs.sslExtraCaCerts
+  ]);
+  const cliExec = createCliExec(secretMasker);
+
+  return createRepoSyncDependencies(
+    inputs,
+    resolved,
+    {
+      core: new ConsoleReporter(),
+      exec: cliExec
+    },
+    {
+      secretMasker
+    }
+  );
+}
+
+export async function runCli(
+  argv: string[] = process.argv.slice(2),
+  runtime: CliRuntime = {}
+): Promise<void> {
+  const env = runtime.env ?? process.env;
+  const config = parseCliArgs(argv, env);
+  const inputs = resolveInputs(config.inputEnv);
+  const reporter = new ConsoleReporter();
+  const initialMasker = createSecretMasker([
+    inputs.postmanApiKey,
+    inputs.postmanAccessToken,
+    inputs.githubToken,
+    inputs.ghFallbackToken,
+    inputs.sslClientCert,
+    inputs.sslClientKey,
+    inputs.sslClientPassphrase,
+    inputs.sslExtraCaCerts
+  ]);
+  const resolvingExec = createCliExec(initialMasker);
+  const resolved = await resolvePostmanApiKeyAndTeamId(
+    inputs,
+    reporter,
+    resolvingExec,
+    initialMasker,
+    {
+      persistGeneratedApiKeySecret: false,
+      env
+    }
+  );
+
+  const dependencies = createCliDependencies(inputs, resolved);
+
+  if (!dependencies.github) {
+    dependencies.core.info('GitHub variable persistence disabled for this run');
+  }
+  if (inputs.environmentSyncEnabled && !dependencies.internalIntegration) {
+    dependencies.core.warning(
+      'Skipping system environment association because postman-access-token is not configured'
+    );
+  }
+  if (inputs.workspaceLinkEnabled && !dependencies.internalIntegration) {
+    dependencies.core.warning(
+      'Skipping workspace linking because postman-access-token is not configured'
+    );
+  }
+
+  const result = await (runtime.executeRepoSync ?? runRepoSync)(inputs, dependencies);
+
+  await writeOptionalFile(config.resultJsonPath, JSON.stringify(result, null, 2));
+  await writeOptionalFile(config.dotenvPath, toDotenv(result));
+
+  const writeStdout = runtime.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
+  writeStdout(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const currentModulePath = typeof __filename === 'string' ? __filename : '';
+const entrypoint = process.argv[1];
+
+if (entrypoint && currentModulePath === entrypoint) {
+  runCli().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { convertAndSplitCollection } from './postman-v3/converter.js';
 import { CI_WORKFLOW_TEMPLATE } from './lib/ci-workflow-template.js';
 import { GitHubApiClient } from './lib/github/github-api-client.js';
 import { RepoMutationService, resolveCurrentRef } from './lib/github/repo-mutation.js';
+import { detectRepoContext } from './lib/repo/context.js';
 import {
   createInternalIntegrationAdapter,
   type InternalIntegrationAdapter
@@ -45,6 +46,8 @@ export interface ResolvedInputs {
   artifactDir: string;
   repoWriteMode: 'none' | 'commit-only' | 'commit-and-push';
   currentRef: string;
+  githubHeadRef: string;
+  githubRefName: string;
   committerName: string;
   committerEmail: string;
   postmanApiKey: string;
@@ -64,6 +67,8 @@ export interface ResolvedInputs {
   sslClientKey: string;
   sslClientPassphrase: string;
   sslExtraCaCerts: string;
+  teamId: string;
+  repository: string;
 }
 
 interface RepoSyncOutputs {
@@ -87,7 +92,7 @@ interface CoreLike {
   warning(message: string): void;
 }
 
-interface ExecLike {
+export interface ExecLike {
   getExecOutput(
     commandLine: string,
     args?: string[],
@@ -95,7 +100,7 @@ interface ExecLike {
   ): ReturnType<typeof exec.getExecOutput>;
 }
 
-interface RepoSyncDependencies {
+export interface RepoSyncDependencies {
   core: Pick<CoreLike, 'info' | 'setOutput' | 'warning'>;
   postman: Pick<
     PostmanAssetsClient,
@@ -120,12 +125,29 @@ interface RepoSyncDependencies {
   repoMutation?: RepoMutationService;
 }
 
+export interface RepoSyncDependencyFactories {
+  core: Pick<CoreLike, 'info' | 'setOutput' | 'warning'>;
+  exec: ExecLike;
+}
+
 function parseBooleanInput(value: string, defaultValue: boolean): boolean {
   const normalized = String(value || '').trim().toLowerCase();
   if (!normalized) return defaultValue;
   if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
   if (['false', '0', 'no', 'off'].includes(normalized)) return false;
   return defaultValue;
+}
+
+function normalizeInputValue(value: string | undefined): string {
+  return String(value ?? '').trim();
+}
+
+export function getInput(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const envName = `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
+  return normalizeInputValue(env[envName]);
 }
 
 function parseJsonMap(raw: string): Record<string, string> {
@@ -179,15 +201,66 @@ function normalizeGithubAuthMode(
   return 'github_token_first';
 }
 
-function resolveRepoUrl(explicitRepoUrl: string): string {
-  if (explicitRepoUrl) return explicitRepoUrl;
-  // GitHub Actions
-  const repository = process.env.GITHUB_REPOSITORY || '';
-  if (repository) return `https://github.com/${repository}`;
-  // GitLab CI provides the full project URL directly
-  const gitlabProjectUrl = process.env.CI_PROJECT_URL || '';
-  if (gitlabProjectUrl) return gitlabProjectUrl;
-  return '';
+export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInputs {
+  const repoContext = detectRepoContext(
+    {
+      repoUrl: getInput('repo-url', env)
+    },
+    env
+  );
+
+  const environments = parseJsonArray(getInput('environments-json', env) || '["prod"]');
+  const systemEnvMap = parseJsonMap(getInput('system-env-map-json', env) || '{}');
+  const environmentUids = parseJsonMap(getInput('environment-uids-json', env) || '{}');
+  const envRuntimeUrls = parseJsonMap(getInput('env-runtime-urls-json', env) || '{}');
+
+  return {
+    projectName: getInput('project-name', env),
+    workspaceId: getInput('workspace-id', env),
+    baselineCollectionId: getInput('baseline-collection-id', env),
+    smokeCollectionId: getInput('smoke-collection-id', env),
+    contractCollectionId: getInput('contract-collection-id', env),
+    environments: environments.length > 0 ? environments : ['prod'],
+    repoUrl: repoContext.repoUrl || '',
+    integrationBackend: getInput('integration-backend', env) || 'bifrost',
+    workspaceLinkEnabled: parseBooleanInput(getInput('workspace-link-enabled', env), true),
+    environmentSyncEnabled: parseBooleanInput(getInput('environment-sync-enabled', env), true),
+    systemEnvMap,
+    environmentUids,
+    envRuntimeUrls,
+    artifactDir: getInput('artifact-dir', env) || 'postman',
+    repoWriteMode: normalizeRepoWriteMode(getInput('repo-write-mode', env) || 'commit-and-push'),
+    currentRef: getInput('current-ref', env) || normalizeInputValue(env.GITHUB_REF),
+    githubHeadRef: getInput('github-head-ref', env) || normalizeInputValue(env.GITHUB_HEAD_REF),
+    githubRefName:
+      getInput('github-ref-name', env) ||
+      normalizeInputValue(env.GITHUB_REF_NAME) ||
+      normalizeInputValue(repoContext.ref),
+    committerName: getInput('committer-name', env) || 'Postman CSE',
+    committerEmail: getInput('committer-email', env) || 'help@postman.com',
+    postmanApiKey: getInput('postman-api-key', env),
+    postmanAccessToken: getInput('postman-access-token', env),
+    githubToken: getInput('github-token', env),
+    ghFallbackToken: getInput('gh-fallback-token', env),
+    githubAuthMode: normalizeGithubAuthMode(getInput('github-auth-mode', env) || 'github_token_first'),
+    ciWorkflowBase64: getInput('ci-workflow-base64', env),
+    generateCiWorkflow: parseBooleanInput(getInput('generate-ci-workflow', env), true),
+    monitorType: getInput('monitor-type', env) || 'cloud',
+    ciWorkflowPath: getInput('ci-workflow-path', env) || '.github/workflows/ci.yml',
+    orgMode: parseBooleanInput(getInput('org-mode', env), false),
+    monitorId: getInput('monitor-id', env),
+    mockUrl: getInput('mock-url', env),
+    monitorCron: getInput('monitor-cron', env),
+    sslClientCert: getInput('ssl-client-cert', env),
+    sslClientKey: getInput('ssl-client-key', env),
+    sslClientPassphrase: getInput('ssl-client-passphrase', env),
+    sslExtraCaCerts: getInput('ssl-extra-ca-certs', env),
+    teamId: getInput('team-id', env) || normalizeInputValue(env.POSTMAN_TEAM_ID),
+    repository:
+      getInput('repository', env) ||
+      normalizeInputValue(env.GITHUB_REPOSITORY) ||
+      normalizeInputValue(repoContext.repoSlug)
+  };
 }
 
 function buildEnvironmentValues(envName: string, baseUrl: string): EnvironmentValues {
@@ -206,9 +279,9 @@ function createOutputs(inputs: ResolvedInputs): RepoSyncOutputs {
   return {
     'integration-backend': inputs.integrationBackend,
     'resolved-current-ref': resolveCurrentRef({
-      currentRef: inputs.currentRef || process.env.GITHUB_REF || '',
-      githubHeadRef: process.env.GITHUB_HEAD_REF || '',
-      githubRefName: process.env.GITHUB_REF_NAME || '',
+      currentRef: inputs.currentRef,
+      githubHeadRef: inputs.githubHeadRef,
+      githubRefName: inputs.githubRefName,
       repoWriteMode: inputs.repoWriteMode
     }),
     'workspace-link-status': 'skipped',
@@ -248,56 +321,73 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || undefined);
   }
 
-  const environments = parseJsonArray(readInput(actionCore, 'environments-json') || '["prod"]');
-  const systemEnvMap = parseJsonMap(readInput(actionCore, 'system-env-map-json') || '{}');
-  const environmentUids = parseJsonMap(readInput(actionCore, 'environment-uids-json') || '{}');
-  const envRuntimeUrls = parseJsonMap(readInput(actionCore, 'env-runtime-urls-json') || '{}');
+  return resolveInputs({
+    ...process.env,
+    INPUT_PROJECT_NAME: projectName,
+    INPUT_WORKSPACE_ID: readInput(actionCore, 'workspace-id'),
+    INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
+    INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
+    INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
+    INPUT_ENVIRONMENTS_JSON: readInput(actionCore, 'environments-json') || '["prod"]',
+    INPUT_REPO_URL: readInput(actionCore, 'repo-url'),
+    INPUT_INTEGRATION_BACKEND: readInput(actionCore, 'integration-backend') || 'bifrost',
+    INPUT_WORKSPACE_LINK_ENABLED: readInput(actionCore, 'workspace-link-enabled'),
+    INPUT_ENVIRONMENT_SYNC_ENABLED: readInput(actionCore, 'environment-sync-enabled'),
+    INPUT_SYSTEM_ENV_MAP_JSON: readInput(actionCore, 'system-env-map-json') || '{}',
+    INPUT_ENVIRONMENT_UIDS_JSON: readInput(actionCore, 'environment-uids-json') || '{}',
+    INPUT_ENV_RUNTIME_URLS_JSON: readInput(actionCore, 'env-runtime-urls-json') || '{}',
+    INPUT_ARTIFACT_DIR: readInput(actionCore, 'artifact-dir') || 'postman',
+    INPUT_REPO_WRITE_MODE: readInput(actionCore, 'repo-write-mode') || 'commit-and-push',
+    INPUT_CURRENT_REF: readInput(actionCore, 'current-ref'),
+    INPUT_GITHUB_HEAD_REF: readInput(actionCore, 'github-head-ref'),
+    INPUT_GITHUB_REF_NAME: readInput(actionCore, 'github-ref-name'),
+    INPUT_COMMITTER_NAME: readInput(actionCore, 'committer-name') || 'Postman CSE',
+    INPUT_COMMITTER_EMAIL: readInput(actionCore, 'committer-email') || 'help@postman.com',
+    INPUT_POSTMAN_API_KEY: postmanApiKey,
+    INPUT_POSTMAN_ACCESS_TOKEN: postmanAccessToken,
+    INPUT_GITHUB_TOKEN: githubToken,
+    INPUT_GH_FALLBACK_TOKEN: ghFallbackToken,
+    INPUT_GITHUB_AUTH_MODE: readInput(actionCore, 'github-auth-mode') || 'github_token_first',
+    INPUT_CI_WORKFLOW_BASE64: readInput(actionCore, 'ci-workflow-base64'),
+    INPUT_GENERATE_CI_WORKFLOW: readInput(actionCore, 'generate-ci-workflow'),
+    INPUT_MONITOR_TYPE: readInput(actionCore, 'monitor-type') || 'cloud',
+    INPUT_CI_WORKFLOW_PATH: readInput(actionCore, 'ci-workflow-path') || '.github/workflows/ci.yml',
+    INPUT_ORG_MODE: readInput(actionCore, 'org-mode'),
+    INPUT_MONITOR_ID: readInput(actionCore, 'monitor-id'),
+    INPUT_MOCK_URL: readInput(actionCore, 'mock-url'),
+    INPUT_MONITOR_CRON: readInput(actionCore, 'monitor-cron'),
+    INPUT_SSL_CLIENT_CERT: sslClientCert,
+    INPUT_SSL_CLIENT_KEY: sslClientKey,
+    INPUT_SSL_CLIENT_PASSPHRASE: sslClientPassphrase,
+    INPUT_SSL_EXTRA_CA_CERTS: sslExtraCaCerts,
+    INPUT_TEAM_ID: readInput(actionCore, 'team-id') || process.env.POSTMAN_TEAM_ID,
+    INPUT_REPOSITORY: readInput(actionCore, 'repository') || process.env.GITHUB_REPOSITORY,
+    GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
+    GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
+  });
+}
 
-  return {
-    projectName,
-    workspaceId: readInput(actionCore, 'workspace-id'),
-    baselineCollectionId: readInput(actionCore, 'baseline-collection-id'),
-    smokeCollectionId: readInput(actionCore, 'smoke-collection-id'),
-    contractCollectionId: readInput(actionCore, 'contract-collection-id'),
-    environments: environments.length > 0 ? environments : ['prod'],
-    repoUrl: resolveRepoUrl(readInput(actionCore, 'repo-url')),
-    integrationBackend: readInput(actionCore, 'integration-backend') || 'bifrost',
-    workspaceLinkEnabled: parseBooleanInput(
-      readInput(actionCore, 'workspace-link-enabled'),
-      true
-    ),
-    environmentSyncEnabled: parseBooleanInput(
-      readInput(actionCore, 'environment-sync-enabled'),
-      true
-    ),
-    systemEnvMap,
-    environmentUids,
-    envRuntimeUrls,
-    artifactDir: readInput(actionCore, 'artifact-dir') || 'postman',
-    repoWriteMode: normalizeRepoWriteMode(readInput(actionCore, 'repo-write-mode') || 'commit-and-push'),
-    currentRef: readInput(actionCore, 'current-ref'),
-    committerName: readInput(actionCore, 'committer-name') || 'Postman CSE',
-    committerEmail: readInput(actionCore, 'committer-email') || 'help@postman.com',
-    postmanApiKey,
-    postmanAccessToken,
-    githubToken,
-    ghFallbackToken,
-    githubAuthMode: normalizeGithubAuthMode(
-      readInput(actionCore, 'github-auth-mode') || 'github_token_first'
-    ),
-    ciWorkflowBase64: readInput(actionCore, 'ci-workflow-base64'),
-    generateCiWorkflow: parseBooleanInput(readInput(actionCore, 'generate-ci-workflow'), true),
-    monitorType: readInput(actionCore, 'monitor-type') || 'cloud',
-    ciWorkflowPath: readInput(actionCore, 'ci-workflow-path') || '.github/workflows/ci.yml',
-    orgMode: parseBooleanInput(readInput(actionCore, 'org-mode'), false),
-    monitorId: readInput(actionCore, 'monitor-id'),
-    mockUrl: readInput(actionCore, 'mock-url'),
-    monitorCron: readInput(actionCore, 'monitor-cron'),
-    sslClientCert,
-    sslClientKey,
-    sslClientPassphrase,
-    sslExtraCaCerts
-  };
+function buildGhCliEnv(env: NodeJS.ProcessEnv, token: string): Record<string, string> {
+  const allowList = [
+    'PATH',
+    'HOME',
+    'USERPROFILE',
+    'XDG_CONFIG_HOME',
+    'GH_CONFIG_DIR',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'RUNNER_TEMP',
+    'SYSTEMROOT'
+  ];
+  const filtered: Record<string, string> = { GH_TOKEN: token };
+  for (const key of allowList) {
+    const value = env[key];
+    if (value) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
 }
 
 async function persistSslSecrets(
@@ -305,7 +395,8 @@ async function persistSslSecrets(
   actionCore: Pick<CoreLike, 'info' | 'warning'>,
   actionExec: ExecLike,
   repository: string,
-  githubClient?: Pick<GitHubApiClient, 'setRepositoryVariable'>
+  githubClient?: Pick<GitHubApiClient, 'setRepositoryVariable'>,
+  env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
   if (!inputs.sslClientCert) {
     return;
@@ -344,7 +435,7 @@ async function persistSslSecrets(
         ['secret', 'set', name, '--repo', repository],
         {
           input: Buffer.from(value),
-          env: { ...process.env, GH_TOKEN: token },
+          env: buildGhCliEnv(env, token),
           ignoreReturnCode: true
         }
       );
@@ -647,9 +738,9 @@ async function commitAndPushGeneratedFiles(
 
   const result = await dependencies.repoMutation.commitAndPush({
     repoWriteMode: inputs.repoWriteMode,
-    currentRef: inputs.currentRef || process.env.GITHUB_REF || '',
-    githubHeadRef: process.env.GITHUB_HEAD_REF || '',
-    githubRefName: process.env.GITHUB_REF_NAME || '',
+    currentRef: inputs.currentRef,
+    githubHeadRef: inputs.githubHeadRef,
+    githubRefName: inputs.githubRefName,
     committerName: inputs.committerName,
     committerEmail: inputs.committerEmail,
     githubToken: inputs.githubToken,
@@ -854,14 +945,18 @@ export async function runRepoSync(
   return outputs;
 }
 
-async function resolvePostmanApiKeyAndTeamId(
+export async function resolvePostmanApiKeyAndTeamId(
   inputs: ResolvedInputs,
-  actionCore: CoreLike,
+  actionCore: Pick<CoreLike, 'info' | 'setSecret' | 'warning'>,
   actionExec: ExecLike,
-  masker: SecretMasker
+  masker: SecretMasker,
+  options: {
+    persistGeneratedApiKeySecret?: boolean;
+    env: NodeJS.ProcessEnv;
+  }
 ): Promise<{ apiKey: string; teamId: string }> {
   let apiKey = inputs.postmanApiKey;
-  let teamId = process.env.POSTMAN_TEAM_ID || '';
+  let teamId = inputs.teamId;
   let keyValid = false;
 
   if (apiKey) {
@@ -908,17 +1003,17 @@ async function resolvePostmanApiKeyAndTeamId(
        if (autoTeamId) teamId = autoTeamId;
     }
 
-    if (inputs.githubToken || inputs.ghFallbackToken) {
+    if ((options.persistGeneratedApiKeySecret ?? true) && (inputs.githubToken || inputs.ghFallbackToken)) {
       actionCore.info('Persisting new Postman API key to GitHub repository secrets...');
       const ghToken = inputs.ghFallbackToken || inputs.githubToken;
-      const repo = process.env.GITHUB_REPOSITORY;
+      const repo = inputs.repository;
       if (repo) {
         try {
           const ghCommand = await actionExec.getExecOutput('gh', [
             'secret', 'set', 'POSTMAN_API_KEY', '--repo', repo
           ], {
             input: Buffer.from(apiKey),
-            env: { ...process.env, GH_TOKEN: ghToken },
+            env: buildGhCliEnv(options.env, ghToken),
             ignoreReturnCode: true
           });
           if (ghCommand.exitCode !== 0) {
@@ -928,12 +1023,88 @@ async function resolvePostmanApiKeyAndTeamId(
           actionCore.warning(`Error saving POSTMAN_API_KEY secret: ${e.message}`);
         }
       }
-    } else {
+    } else if (options.persistGeneratedApiKeySecret ?? true) {
       actionCore.warning('No GitHub token provided; cannot save generated POSTMAN_API_KEY secret.');
+    } else {
+      actionCore.info('Skipping generated POSTMAN_API_KEY GitHub secret persistence for this run.');
     }
   }
 
   return { apiKey, teamId };
+}
+
+export function createRepoSyncDependencies(
+  inputs: ResolvedInputs,
+  resolved: { apiKey: string; teamId: string },
+  factories: RepoSyncDependencyFactories,
+  options: { repository?: string; secretMasker?: SecretMasker } = {}
+): RepoSyncDependencies {
+  const repository = options.repository ?? inputs.repository;
+  const masker =
+    options.secretMasker ??
+    createSecretMasker([
+      resolved.apiKey,
+      inputs.postmanAccessToken,
+      inputs.githubToken,
+      inputs.ghFallbackToken,
+      inputs.sslClientCert,
+      inputs.sslClientKey,
+      inputs.sslClientPassphrase,
+      inputs.sslExtraCaCerts
+    ]);
+
+  const postman = new PostmanAssetsClient({
+    apiKey: resolved.apiKey,
+    secretMasker: masker
+  });
+
+  const github =
+    repository && (inputs.githubToken || inputs.ghFallbackToken)
+      ? new GitHubApiClient({
+          repository,
+          token: inputs.githubToken || inputs.ghFallbackToken,
+          fallbackToken: inputs.ghFallbackToken,
+          authMode: inputs.githubAuthMode,
+          secretMasker: masker
+        })
+      : undefined;
+
+  const repoMutation =
+    repository &&
+    (inputs.repoWriteMode === 'commit-only' || inputs.repoWriteMode === 'commit-and-push')
+      ? new RepoMutationService({
+          repository,
+          secretMasker: masker,
+          execute: async (command, args) => {
+            const result = await factories.exec.getExecOutput(command, args, {
+              ignoreReturnCode: true
+            });
+            return {
+              exitCode: result.exitCode,
+              stdout: result.stdout,
+              stderr: result.stderr
+            };
+          }
+        })
+      : undefined;
+
+  const internalIntegration = inputs.postmanAccessToken
+    ? createInternalIntegrationAdapter({
+        accessToken: inputs.postmanAccessToken,
+        backend: inputs.integrationBackend,
+        orgMode: inputs.orgMode,
+        teamId: resolved.teamId,
+        secretMasker: masker
+      })
+    : undefined;
+
+  return {
+    core: factories.core,
+    postman,
+    github,
+    internalIntegration,
+    repoMutation
+  };
 }
 
 export async function runAction(
@@ -952,77 +1123,40 @@ export async function runAction(
     inputs.sslExtraCaCerts
   ]);
 
-  const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker);
-
-  const postman = new PostmanAssetsClient({
-    apiKey: resolved.apiKey,
-    secretMasker: masker
+  const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    env: process.env
   });
+  const repository = inputs.repository;
+  const dependencies = createRepoSyncDependencies(
+    inputs,
+    resolved,
+    {
+      core: actionCore,
+      exec: actionExec
+    },
+    {
+      repository,
+      secretMasker: masker
+    }
+  );
 
-  const repository = process.env.GITHUB_REPOSITORY || '';
-  const github =
-    repository && (inputs.githubToken || inputs.ghFallbackToken)
-      ? new GitHubApiClient({
-        repository,
-        token: inputs.githubToken || inputs.ghFallbackToken,
-        fallbackToken: inputs.ghFallbackToken,
-        authMode: inputs.githubAuthMode,
-        secretMasker: masker
-      })
-      : undefined;
-
-  const repoMutation =
-    repository && (inputs.repoWriteMode === 'commit-only' || inputs.repoWriteMode === 'commit-and-push')
-      ? new RepoMutationService({
-        repository,
-        secretMasker: masker,
-        execute: async (command, args) => {
-          const result = await actionExec.getExecOutput(command, args, {
-            ignoreReturnCode: true
-          });
-          return {
-            exitCode: result.exitCode,
-            stdout: result.stdout,
-            stderr: result.stderr
-          };
-        }
-      })
-      : undefined;
-
-  const internalIntegration =
-    inputs.postmanAccessToken
-      ? createInternalIntegrationAdapter({
-        accessToken: inputs.postmanAccessToken,
-        backend: inputs.integrationBackend,
-        orgMode: inputs.orgMode,
-        teamId: resolved.teamId,
-        secretMasker: masker
-      })
-      : undefined;
-
-  if (!github) {
+  if (!dependencies.github) {
     actionCore.info('GitHub variable persistence disabled for this run');
   }
-  if (inputs.environmentSyncEnabled && !internalIntegration) {
+  if (inputs.environmentSyncEnabled && !dependencies.internalIntegration) {
     actionCore.warning(
       'Skipping system environment association because postman-access-token is not configured'
     );
   }
-  if (inputs.workspaceLinkEnabled && !internalIntegration) {
+  if (inputs.workspaceLinkEnabled && !dependencies.internalIntegration) {
     actionCore.warning(
       'Skipping workspace linking because postman-access-token is not configured'
     );
   }
 
-  await persistSslSecrets(inputs, actionCore, actionExec, repository, github);
+  await persistSslSecrets(inputs, actionCore, actionExec, repository, dependencies.github);
 
-  return runRepoSync(inputs, {
-    core: actionCore,
-    postman,
-    github,
-    internalIntegration,
-    repoMutation
-  });
+  return runRepoSync(inputs, dependencies);
 }
 
 const entrypoint = process.argv[1];

--- a/src/lib/repo/context.ts
+++ b/src/lib/repo/context.ts
@@ -1,0 +1,128 @@
+export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'azure-devops' | 'unknown';
+
+export interface RepoContextInput {
+  repoUrl?: string;
+  repoSlug?: string;
+  gitProvider?: string;
+  ref?: string;
+  sha?: string;
+}
+
+export interface RepoContext {
+  provider: GitProvider;
+  repoUrl?: string;
+  repoSlug?: string;
+  ref?: string;
+  sha?: string;
+}
+
+function normalize(value?: string): string | undefined {
+  const trimmed = (value ?? '').trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeRepoUrl(url?: string): string | undefined {
+  const raw = normalize(url);
+  if (!raw) {
+    return undefined;
+  }
+
+  const sshMatch = raw.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    const host = sshMatch[1];
+    const path = sshMatch[2];
+    return `https://${host}/${path}`;
+  }
+
+  return raw.replace(/\.git$/, '');
+}
+
+function parseProvider(
+  explicitProvider: string | undefined,
+  repoUrl: string | undefined,
+  env: NodeJS.ProcessEnv
+): GitProvider {
+  const explicit = normalize(explicitProvider)?.toLowerCase();
+  if (
+    explicit === 'github' ||
+    explicit === 'gitlab' ||
+    explicit === 'bitbucket' ||
+    explicit === 'azure-devops'
+  ) {
+    return explicit;
+  }
+
+  const url = (repoUrl ?? '').toLowerCase();
+  if (url.includes('github')) {
+    return 'github';
+  }
+  if (url.includes('gitlab')) {
+    return 'gitlab';
+  }
+  if (url.includes('bitbucket')) {
+    return 'bitbucket';
+  }
+  if (url.includes('dev.azure.com') || url.includes('visualstudio.com')) {
+    return 'azure-devops';
+  }
+
+  if (normalize(env.GITHUB_REPOSITORY)) {
+    return 'github';
+  }
+  if (normalize(env.CI_PROJECT_PATH) || normalize(env.GITLAB_CI)) {
+    return 'gitlab';
+  }
+  if (normalize(env.BITBUCKET_REPO_SLUG)) {
+    return 'bitbucket';
+  }
+  if (normalize(env.BUILD_REPOSITORY_URI)) {
+    return 'azure-devops';
+  }
+
+  return 'unknown';
+}
+
+export function detectRepoContext(
+  input: RepoContextInput,
+  env: NodeJS.ProcessEnv = process.env
+): RepoContext {
+  const repoUrl =
+    normalizeRepoUrl(input.repoUrl) ??
+    normalizeRepoUrl(
+      env.GITHUB_SERVER_URL && env.GITHUB_REPOSITORY
+        ? `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}`
+        : undefined
+    ) ??
+    normalizeRepoUrl(env.CI_PROJECT_URL) ??
+    normalizeRepoUrl(env.BITBUCKET_GIT_HTTP_ORIGIN) ??
+    normalizeRepoUrl(env.BUILD_REPOSITORY_URI);
+  const repoSlug =
+    normalize(input.repoSlug) ??
+    normalize(env.GITHUB_REPOSITORY) ??
+    normalize(env.CI_PROJECT_PATH) ??
+    (env.BITBUCKET_WORKSPACE && env.BITBUCKET_REPO_SLUG
+      ? normalize(`${env.BITBUCKET_WORKSPACE}/${env.BITBUCKET_REPO_SLUG}`)
+      : undefined) ??
+    normalize(env.BUILD_REPOSITORY_NAME);
+  const ref =
+    normalize(input.ref) ??
+    normalize(env.GITHUB_REF_NAME) ??
+    normalize(env.CI_COMMIT_REF_NAME) ??
+    normalize(env.BITBUCKET_BRANCH) ??
+    normalize(env.BUILD_SOURCEBRANCHNAME);
+  const sha =
+    normalize(input.sha) ??
+    normalize(env.GITHUB_SHA) ??
+    normalize(env.CI_COMMIT_SHA) ??
+    normalize(env.BITBUCKET_COMMIT) ??
+    normalize(env.BUILD_SOURCEVERSION);
+  const provider = parseProvider(input.gitProvider, repoUrl, env);
+
+  return {
+    provider,
+    repoUrl,
+    repoSlug,
+    ref,
+    sha
+  };
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConsoleReporter, parseCliArgs, toDotenv } from '../src/cli.js';
+import { resolveInputs } from '../src/index.js';
+
+describe('cli', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps flags to INPUT_* env variables', () => {
+    const config = parseCliArgs(
+      [
+        '--project-name',
+        'core-payments',
+        '--workspace-id=ws-123',
+        '--repo-url',
+        'https://github.com/postman-cs/repo-sync-demo',
+        '--team-id',
+        'team-001',
+        '--result-json',
+        'outputs/result.json',
+        '--dotenv-path=.env.repo-sync'
+      ],
+      { EXISTING_ENV: 'keep-me' }
+    );
+
+    expect(config.inputEnv.EXISTING_ENV).toBe('keep-me');
+    expect(config.inputEnv.INPUT_PROJECT_NAME).toBe('core-payments');
+    expect(config.inputEnv.INPUT_WORKSPACE_ID).toBe('ws-123');
+    expect(config.inputEnv.INPUT_REPO_URL).toBe('https://github.com/postman-cs/repo-sync-demo');
+    expect(config.inputEnv.INPUT_TEAM_ID).toBe('team-001');
+    expect(config.resultJsonPath).toBe('outputs/result.json');
+    expect(config.dotenvPath).toBe('.env.repo-sync');
+  });
+
+  it('formats dotenv output with POSTMAN_REPO_SYNC_ prefix', () => {
+    const rendered = toDotenv({
+      'workspace-link-status': 'success',
+      'environment-uids-json': '{"prod":"env-prod"}'
+    });
+
+    expect(rendered).toContain('POSTMAN_REPO_SYNC_WORKSPACE_LINK_STATUS="success"');
+    expect(rendered).toContain(
+      'POSTMAN_REPO_SYNC_ENVIRONMENT_UIDS_JSON="{\\"prod\\":\\"env-prod\\"}"'
+    );
+  });
+
+  it('writes reporter logs to stderr', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const reporter = new ConsoleReporter();
+
+    reporter.info('info message');
+    reporter.warning('warn message');
+
+    expect(errorSpy).toHaveBeenCalledWith('info message');
+    expect(errorSpy).toHaveBeenCalledWith('warning: warn message');
+  });
+
+  it('resolves non-GitHub branch and repository from CI context', () => {
+    const config = parseCliArgs([], {
+      BITBUCKET_BRANCH: 'feature/non-github-ref',
+      BITBUCKET_WORKSPACE: 'acme',
+      BITBUCKET_REPO_SLUG: 'payments-api'
+    });
+
+    const inputs = resolveInputs(config.inputEnv);
+
+    expect(inputs.currentRef).toBe('');
+    expect(inputs.githubHeadRef).toBe('');
+    expect(inputs.githubRefName).toBe('feature/non-github-ref');
+    expect(inputs.repository).toBe('acme/payments-api');
+  });
+});

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -32,6 +32,8 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     artifactDir: 'postman',
     repoWriteMode: 'commit-and-push',
     currentRef: 'feature/repo-sync',
+    githubHeadRef: '',
+    githubRefName: 'feature/repo-sync',
     committerName: 'Postman CSE',
     committerEmail: 'help@postman.com',
     postmanApiKey: 'pmak-test',
@@ -51,6 +53,8 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     sslClientKey: '',
     sslClientPassphrase: '',
     sslExtraCaCerts: '',
+    teamId: '',
+    repository: 'postman-cs/repo-sync-demo',
     ...overrides
   };
 }


### PR DESCRIPTION
## Summary

- Add CLI entry point (`dist/cli.cjs`) enabling repo-sync on GitLab CI, Bitbucket Pipelines, Azure DevOps, and any CI
- Eliminate ambient `process.env` reads from core functions
- Extract `createRepoSyncDependencies()` shared between both entry points
- Non-GitHub ref resolution via `repoContext.ref` fallback
- 53 tests passing, typecheck clean

## Changes

- `src/index.ts`: Refactored -- ambient env reads moved to `resolveInputs()`, shared dep factory, `resolvePostmanApiKeyAndTeamId` requires explicit env
- `src/cli.ts`: New CLI adapter with stderr-only logging, JSON stdout, secret-masked exec wrapper
- `src/lib/repo/context.ts`: New multi-provider auto-detection
- `tests/cli.test.ts`: New CLI tests including non-GitHub ref detection
- `package.json`: Dual build targets, bin field