### PR TITLE
Refresh behavior fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ When a local spec file and exported collections are both available, repo-sync wr
 | `monitor-type` | `cloud` | Type of monitor to create (`cloud` or `cli`). `cli` uses GitHub Actions cron. |
 | `smoke-collection-id` | | Smoke collection used for monitor creation. |
 | `contract-collection-id` | | Contract collection exported into the repo. |
-| `collection-sync-mode` | `refresh` | Collection lifecycle mode: `refresh`, `reuse`, or `version`. |
+| `collection-sync-mode` | `refresh` | Collection lifecycle mode: `refresh` or `version`. |
 | `spec-sync-mode` | `update` | Spec lifecycle mode: `update` or `version`. |
 | `release-label` | | Optional release label for versioned naming. Falls back to `github-ref-name` when omitted. |
 | `spec-path` | | Optional repo-root-relative path to the local spec file for `resources.yaml` and `workflows.yaml` metadata. |

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: Contract collection ID used for exported artifacts.
     required: false
   collection-sync-mode:
-    description: Collection sync lifecycle mode (refresh, reuse, or version).
+    description: Collection sync lifecycle mode (refresh or version).
     required: false
     default: refresh
   spec-sync-mode:

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -25356,7 +25356,7 @@ function normalizeRepoWriteMode(value) {
   return "commit-and-push";
 }
 function normalizeCollectionSyncMode(value) {
-  if (value === "reuse" || value === "refresh" || value === "version") {
+  if (value === "refresh" || value === "version") {
     return value;
   }
   return "refresh";

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25351,7 +25351,7 @@ function normalizeRepoWriteMode(value) {
   return "commit-and-push";
 }
 function normalizeCollectionSyncMode(value) {
-  if (value === "reuse" || value === "refresh" || value === "version") {
+  if (value === "refresh" || value === "version") {
     return value;
   }
   return "refresh";

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -100,7 +100,7 @@ export const postmanRepoSyncActionContract: {
       required: false
     },
     'collection-sync-mode': {
-      description: 'Collection sync lifecycle mode (refresh, reuse, or version).',
+      description: 'Collection sync lifecycle mode (refresh or version).',
       required: false,
       default: 'refresh'
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export interface ResolvedInputs {
   baselineCollectionId: string;
   smokeCollectionId: string;
   contractCollectionId: string;
-  collectionSyncMode: 'reuse' | 'refresh' | 'version';
+  collectionSyncMode: 'refresh' | 'version';
   specSyncMode: 'update' | 'version';
   releaseLabel?: string;
   environments: string[];
@@ -198,8 +198,8 @@ function normalizeRepoWriteMode(value: string): 'none' | 'commit-only' | 'commit
   return 'commit-and-push';
 }
 
-function normalizeCollectionSyncMode(value: string): 'reuse' | 'refresh' | 'version' {
-  if (value === 'reuse' || value === 'refresh' || value === 'version') {
+function normalizeCollectionSyncMode(value: string): 'refresh' | 'version' {
+  if (value === 'refresh' || value === 'version') {
     return value;
   }
   return 'refresh';

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -427,6 +427,68 @@ describe('repo sync action', () => {
     expect(postman.updateEnvironment).toHaveBeenCalledTimes(2);
   });
 
+  it('refresh reruns keep the same tracked collection ids in .postman/resources.yaml', async () => {
+    const postman = {
+      createEnvironment: vi.fn().mockResolvedValue('env-prod'),
+      updateEnvironment: vi.fn().mockResolvedValue(undefined),
+      createMock: vi.fn().mockResolvedValue({ uid: 'mock-1', url: 'https://mock.pstmn.io' }),
+      createMonitor: vi.fn().mockResolvedValue('mon-1'),
+      getCollection: vi
+        .fn()
+        .mockResolvedValueOnce(createCollectionFixture('[Baseline] core-payments'))
+        .mockResolvedValueOnce(createCollectionFixture('[Smoke] core-payments'))
+        .mockResolvedValueOnce(createCollectionFixture('[Contract] core-payments')),
+      getEnvironment: vi.fn().mockResolvedValue({ values: [] }),
+      listMonitors: vi.fn().mockResolvedValue([]),
+      listMocks: vi.fn().mockResolvedValue([]),
+      monitorExists: vi.fn().mockResolvedValue(false),
+      mockExists: vi.fn().mockResolvedValue(false),
+      findMonitorByCollection: vi.fn().mockResolvedValue(null),
+      findMockByCollection: vi.fn().mockResolvedValue(null)
+    };
+
+    await runRepoSync(
+      createInputs({
+        environments: ['prod'],
+        generateCiWorkflow: false,
+        collectionSyncMode: 'refresh',
+        baselineCollectionId: 'col-baseline-existing',
+        smokeCollectionId: 'col-smoke-existing',
+        contractCollectionId: 'col-contract-existing'
+      }),
+      {
+        core: createCoreStub().core,
+        postman,
+        github: {
+          getRepositoryVariable: vi.fn().mockResolvedValue(''),
+          setRepositoryVariable: vi.fn().mockResolvedValue(undefined)
+        },
+        internalIntegration: {
+          associateSystemEnvironments: vi.fn().mockResolvedValue(undefined),
+          connectWorkspaceToRepository: vi.fn().mockResolvedValue(undefined)
+        },
+        repoMutation: {
+          commitAndPush: vi.fn().mockResolvedValue({
+            commitSha: '',
+            pushed: false,
+            resolvedCurrentRef: 'feature/repo-sync'
+          })
+        } as unknown as Parameters<typeof runRepoSync>[1]['repoMutation']
+      }
+    );
+
+    const resourcesYaml = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as Record<
+      string,
+      any
+    >;
+
+    expect(resourcesYaml.cloudResources.collections).toEqual({
+      '../postman/collections/[Baseline] core-payments': 'col-baseline-existing',
+      '../postman/collections/[Smoke] core-payments': 'col-smoke-existing',
+      '../postman/collections/[Contract] core-payments': 'col-contract-existing'
+    });
+  });
+
   it('skips writing a CI workflow when generation is disabled', async () => {
     const postman = {
       createEnvironment: vi.fn().mockResolvedValue('env-prod'),

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -22,6 +22,12 @@ import {
   type ResolvedInputs
 } from '../src/index.js';
 
+type ResourcesYamlShape = {
+  cloudResources?: {
+    collections?: Record<string, string>;
+  };
+};
+
 function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
   return {
     projectName: 'core-payments',
@@ -477,12 +483,11 @@ describe('repo sync action', () => {
       }
     );
 
-    const resourcesYaml = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as Record<
-      string,
-      any
-    >;
+    const resourcesYaml = loadYaml(
+      readFileSync('.postman/resources.yaml', 'utf8')
+    ) as ResourcesYamlShape;
 
-    expect(resourcesYaml.cloudResources.collections).toEqual({
+    expect(resourcesYaml.cloudResources?.collections).toEqual({
       '../postman/collections/[Baseline] core-payments': 'col-baseline-existing',
       '../postman/collections/[Smoke] core-payments': 'col-smoke-existing',
       '../postman/collections/[Contract] core-payments': 'col-contract-existing'


### PR DESCRIPTION
## Summary

This PR aligns repo-sync with the new collection lifecycle model where `collection-sync-mode` supports only:
- `refresh`
- `version`

`reuse` is removed as a collection-sync mode value.

Repo-sync itself already writes whatever collection IDs bootstrap outputs declare as authoritative, so the main changes here are:
- contract/runtime normalization updates
- test coverage confirming refresh reruns keep the same tracked collection IDs in `.postman/resources.yaml`
- doc updates to match the new lifecycle model

## Behavior changes

### `refresh`
- continues to write the current tracked baseline/smoke/contract IDs into `.postman/resources.yaml`
- now assumes bootstrap may preserve those IDs across reruns via in-place refresh

### `version`
- unchanged in principle

### `reuse`
- removed as a valid `collection-sync-mode` value

## Why this change

Bootstrap now treats refresh as “refresh tracked collections in place.”
Repo-sync should reflect that model instead of documenting or accepting a separate `reuse` collection mode.