### PR TITLE
Codex/spec id debug

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -25599,7 +25599,7 @@ function readActionInputs(actionCore) {
     }
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || void 0);
   }
-  const resolved = resolveInputs({
+  return resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, "workspace-id"),
@@ -25647,13 +25647,6 @@ function readActionInputs(actionCore) {
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
-  actionCore.info(
-    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, "spec-id")}", spec-path="${readInput(actionCore, "spec-path")}"`
-  );
-  actionCore.info(
-    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
-  );
-  return resolved;
 }
 function buildGhCliEnv(env, token) {
   const allowList = [
@@ -25880,25 +25873,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
   const manifestCollections = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
-  dependencies.core.info(
-    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
-      discoveredSpecs.map((spec) => ({
-        repoRelativePath: spec.repoRelativePath,
-        configRelativePath: spec.configRelativePath
-      }))
-    )}`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
-      mappedSpec ? {
-        repoRelativePath: mappedSpec.repoRelativePath,
-        configRelativePath: mappedSpec.configRelativePath
-      } : null
-    )}`
-  );
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
       await dependencies.postman.getCollection(inputs.baselineCollectionId)
@@ -25939,10 +25913,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     mappedSpec?.configRelativePath,
     inputs.specId || void 0
   ));
-  dependencies.core.info(
-    `[debug] exportArtifacts: resources.yaml after write
-${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
-  );
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     (0, import_node_fs.writeFileSync)(
       ".postman/workflows.yaml",
@@ -25950,10 +25920,6 @@ ${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
-    );
-    dependencies.core.info(
-      `[debug] exportArtifacts: workflows.yaml after write
-${(0, import_node_fs.readFileSync)(".postman/workflows.yaml", "utf8")}`
     );
   }
 }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -25599,7 +25599,7 @@ function readActionInputs(actionCore) {
     }
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || void 0);
   }
-  return resolveInputs({
+  const resolved = resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, "workspace-id"),
@@ -25645,6 +25645,13 @@ function readActionInputs(actionCore) {
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
+  actionCore.info(
+    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, "spec-id")}", spec-path="${readInput(actionCore, "spec-path")}"`
+  );
+  actionCore.info(
+    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
+  );
+  return resolved;
 }
 function buildGhCliEnv(env, token) {
   const allowList = [
@@ -25871,6 +25878,25 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
   const manifestCollections = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
+  dependencies.core.info(
+    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
+      discoveredSpecs.map((spec) => ({
+        repoRelativePath: spec.repoRelativePath,
+        configRelativePath: spec.configRelativePath
+      }))
+    )}`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
+      mappedSpec ? {
+        repoRelativePath: mappedSpec.repoRelativePath,
+        configRelativePath: mappedSpec.configRelativePath
+      } : null
+    )}`
+  );
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
       await dependencies.postman.getCollection(inputs.baselineCollectionId)
@@ -25911,6 +25937,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     mappedSpec?.configRelativePath,
     inputs.specId || void 0
   ));
+  dependencies.core.info(
+    `[debug] exportArtifacts: resources.yaml after write
+${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
+  );
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     (0, import_node_fs.writeFileSync)(
       ".postman/workflows.yaml",
@@ -25918,6 +25948,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
+    );
+    dependencies.core.info(
+      `[debug] exportArtifacts: workflows.yaml after write
+${(0, import_node_fs.readFileSync)(".postman/workflows.yaml", "utf8")}`
     );
   }
 }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -25606,6 +25606,8 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
+    INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, "collection-sync-mode") || "refresh",
     INPUT_SPEC_SYNC_MODE: readInput(actionCore, "spec-sync-mode") || "update",
     INPUT_RELEASE_LABEL: readInput(actionCore, "release-label"),

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25601,6 +25601,8 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
+    INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, "collection-sync-mode") || "refresh",
     INPUT_SPEC_SYNC_MODE: readInput(actionCore, "spec-sync-mode") || "update",
     INPUT_RELEASE_LABEL: readInput(actionCore, "release-label"),

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25594,7 +25594,7 @@ function readActionInputs(actionCore) {
     }
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || void 0);
   }
-  return resolveInputs({
+  const resolved = resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, "workspace-id"),
@@ -25640,6 +25640,13 @@ function readActionInputs(actionCore) {
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
+  actionCore.info(
+    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, "spec-id")}", spec-path="${readInput(actionCore, "spec-path")}"`
+  );
+  actionCore.info(
+    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
+  );
+  return resolved;
 }
 function buildGhCliEnv(env, token) {
   const allowList = [
@@ -25866,6 +25873,25 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
   const manifestCollections = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
+  dependencies.core.info(
+    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
+      discoveredSpecs.map((spec) => ({
+        repoRelativePath: spec.repoRelativePath,
+        configRelativePath: spec.configRelativePath
+      }))
+    )}`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
+      mappedSpec ? {
+        repoRelativePath: mappedSpec.repoRelativePath,
+        configRelativePath: mappedSpec.configRelativePath
+      } : null
+    )}`
+  );
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
       await dependencies.postman.getCollection(inputs.baselineCollectionId)
@@ -25906,6 +25932,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     mappedSpec?.configRelativePath,
     inputs.specId || void 0
   ));
+  dependencies.core.info(
+    `[debug] exportArtifacts: resources.yaml after write
+${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
+  );
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     (0, import_node_fs.writeFileSync)(
       ".postman/workflows.yaml",
@@ -25913,6 +25943,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
+    );
+    dependencies.core.info(
+      `[debug] exportArtifacts: workflows.yaml after write
+${(0, import_node_fs.readFileSync)(".postman/workflows.yaml", "utf8")}`
     );
   }
 }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25594,7 +25594,7 @@ function readActionInputs(actionCore) {
     }
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || void 0);
   }
-  const resolved = resolveInputs({
+  return resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, "workspace-id"),
@@ -25642,13 +25642,6 @@ function readActionInputs(actionCore) {
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
-  actionCore.info(
-    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, "spec-id")}", spec-path="${readInput(actionCore, "spec-path")}"`
-  );
-  actionCore.info(
-    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
-  );
-  return resolved;
 }
 function buildGhCliEnv(env, token) {
   const allowList = [
@@ -25875,25 +25868,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
   const manifestCollections = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
-  dependencies.core.info(
-    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
-      discoveredSpecs.map((spec) => ({
-        repoRelativePath: spec.repoRelativePath,
-        configRelativePath: spec.configRelativePath
-      }))
-    )}`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
-      mappedSpec ? {
-        repoRelativePath: mappedSpec.repoRelativePath,
-        configRelativePath: mappedSpec.configRelativePath
-      } : null
-    )}`
-  );
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
       await dependencies.postman.getCollection(inputs.baselineCollectionId)
@@ -25934,10 +25908,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     mappedSpec?.configRelativePath,
     inputs.specId || void 0
   ));
-  dependencies.core.info(
-    `[debug] exportArtifacts: resources.yaml after write
-${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
-  );
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     (0, import_node_fs.writeFileSync)(
       ".postman/workflows.yaml",
@@ -25945,10 +25915,6 @@ ${(0, import_node_fs.readFileSync)(".postman/resources.yaml", "utf8")}`
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
-    );
-    dependencies.core.info(
-      `[debug] exportArtifacts: workflows.yaml after write
-${(0, import_node_fs.readFileSync)(".postman/workflows.yaml", "utf8")}`
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,6 +528,8 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
+    INPUT_SPEC_ID: readInput(actionCore, 'spec-id'),
+    INPUT_SPEC_PATH: readInput(actionCore, 'spec-path'),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, 'collection-sync-mode') || 'refresh',
     INPUT_SPEC_SYNC_MODE: readInput(actionCore, 'spec-sync-mode') || 'update',
     INPUT_RELEASE_LABEL: readInput(actionCore, 'release-label'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,7 +494,7 @@ function createOutputs(inputs: ResolvedInputs): RepoSyncOutputs {
   };
 }
 
-export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSecret' | 'info'>): ResolvedInputs {
+export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSecret'>): ResolvedInputs {
   const projectName = readInput(actionCore, 'project-name', true);
   const postmanApiKey = readInput(actionCore, 'postman-api-key', true);
   const postmanAccessToken = readInput(actionCore, 'postman-access-token');
@@ -521,7 +521,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || undefined);
   }
 
-  const resolved = resolveInputs({
+  return resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, 'workspace-id'),
@@ -569,15 +569,6 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
-
-  actionCore.info(
-    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, 'spec-id')}", spec-path="${readInput(actionCore, 'spec-path')}"`
-  );
-  actionCore.info(
-    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
-  );
-
-  return resolved;
 }
 
 function buildGhCliEnv(env: NodeJS.ProcessEnv, token: string): Record<string, string> {
@@ -870,27 +861,6 @@ async function exportArtifacts(
   const manifestCollections: Record<string, string> = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
-  dependencies.core.info(
-    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
-      discoveredSpecs.map((spec) => ({
-        repoRelativePath: spec.repoRelativePath,
-        configRelativePath: spec.configRelativePath
-      }))
-    )}`
-  );
-  dependencies.core.info(
-    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
-      mappedSpec
-        ? {
-            repoRelativePath: mappedSpec.repoRelativePath,
-            configRelativePath: mappedSpec.configRelativePath
-          }
-        : null
-    )}`
-  );
 
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
@@ -937,9 +907,6 @@ async function exportArtifacts(
     mappedSpec?.configRelativePath,
     inputs.specId || undefined
   ));
-  dependencies.core.info(
-    `[debug] exportArtifacts: resources.yaml after write\n${readFileSync('.postman/resources.yaml', 'utf8')}`
-  );
 
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     writeFileSync(
@@ -948,9 +915,6 @@ async function exportArtifacts(
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
-    );
-    dependencies.core.info(
-      `[debug] exportArtifacts: workflows.yaml after write\n${readFileSync('.postman/workflows.yaml', 'utf8')}`
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,7 +494,7 @@ function createOutputs(inputs: ResolvedInputs): RepoSyncOutputs {
   };
 }
 
-export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSecret'>): ResolvedInputs {
+export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSecret' | 'info'>): ResolvedInputs {
   const projectName = readInput(actionCore, 'project-name', true);
   const postmanApiKey = readInput(actionCore, 'postman-api-key', true);
   const postmanAccessToken = readInput(actionCore, 'postman-access-token');
@@ -521,7 +521,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     validateCertMaterial(sslClientCert, sslClientKey, sslClientPassphrase || undefined);
   }
 
-  return resolveInputs({
+  const resolved = resolveInputs({
     ...process.env,
     INPUT_PROJECT_NAME: projectName,
     INPUT_WORKSPACE_ID: readInput(actionCore, 'workspace-id'),
@@ -567,6 +567,15 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
+
+  actionCore.info(
+    `[debug] readActionInputs: workflow-provided spec-id="${readInput(actionCore, 'spec-id')}", spec-path="${readInput(actionCore, 'spec-path')}"`
+  );
+  actionCore.info(
+    `[debug] readActionInputs: resolved specId="${resolved.specId}", resolved specPath="${resolved.specPath}"`
+  );
+
+  return resolved;
 }
 
 function buildGhCliEnv(env: NodeJS.ProcessEnv, token: string): Record<string, string> {
@@ -859,6 +868,27 @@ async function exportArtifacts(
   const manifestCollections: Record<string, string> = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
+  dependencies.core.info(
+    `[debug] exportArtifacts: inputs.specId="${inputs.specId}", inputs.specPath="${inputs.specPath}"`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: discoveredSpecs=${JSON.stringify(
+      discoveredSpecs.map((spec) => ({
+        repoRelativePath: spec.repoRelativePath,
+        configRelativePath: spec.configRelativePath
+      }))
+    )}`
+  );
+  dependencies.core.info(
+    `[debug] exportArtifacts: mappedSpec=${JSON.stringify(
+      mappedSpec
+        ? {
+            repoRelativePath: mappedSpec.repoRelativePath,
+            configRelativePath: mappedSpec.configRelativePath
+          }
+        : null
+    )}`
+  );
 
   if (inputs.baselineCollectionId) {
     const col = stripVolatileFields(
@@ -905,6 +935,9 @@ async function exportArtifacts(
     mappedSpec?.configRelativePath,
     inputs.specId || undefined
   ));
+  dependencies.core.info(
+    `[debug] exportArtifacts: resources.yaml after write\n${readFileSync('.postman/resources.yaml', 'utf8')}`
+  );
 
   if (mappedSpec && Object.keys(manifestCollections).length > 0) {
     writeFileSync(
@@ -913,6 +946,9 @@ async function exportArtifacts(
         mappedSpec.configRelativePath,
         Object.keys(manifestCollections)
       )
+    );
+    dependencies.core.info(
+      `[debug] exportArtifacts: workflows.yaml after write\n${readFileSync('.postman/workflows.yaml', 'utf8')}`
     );
   }
 }


### PR DESCRIPTION
Repo sync was accepting spec-id and spec-path, but readActionInputs() was not forwarding them into resolveInputs(). As a result, cloudResources.specs was never written to .postman/resources.yaml, so spec reuse could not work correctly.

This is easy to miss in repos that already had a tracked spec ID, but for a new or reset repo the spec ID would never be persisted, causing onboarding to create a new spec on every run. This change forwards spec-id and spec-path correctly so repo sync can persist the spec mapping and enable reuse on subsequent runs.
