### PR TITLE
feat(monitor): run monitor once when monitor-cron is empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     description: Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one.
     required: false
   monitor-cron:
-    description: Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created in a disabled state.
+    description: Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run).
     required: false
     default: ""
   environments-json:

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -25238,6 +25238,9 @@ var PostmanAssetsClient = class {
       return false;
     }
   }
+  async runMonitor(uid) {
+    await this.request(`/monitors/${uid}/run`, { method: "POST" });
+  }
   async mockExists(uid) {
     try {
       await this.request(`/mocks/${uid}`);
@@ -26093,9 +26096,19 @@ async function runRepoSync(inputs, dependencies) {
           monitorEnvUid,
           effectiveCron || void 0
         );
-        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? "" : " (disabled \u2014 no cron configured)"}`);
+        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? "" : " (disabled \u2014 no cron configured; will trigger a one-time run)"}`);
       }
       outputs["monitor-id"] = resolvedMonitorId;
+      if (!effectiveCron && resolvedMonitorId) {
+        try {
+          await dependencies.postman.runMonitor(resolvedMonitorId);
+          dependencies.core.info(`Triggered one-time run for monitor: ${resolvedMonitorId}`);
+        } catch (error) {
+          dependencies.core.warning(
+            `Failed to trigger one-time run for monitor ${resolvedMonitorId}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
     }
   }
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25233,6 +25233,9 @@ var PostmanAssetsClient = class {
       return false;
     }
   }
+  async runMonitor(uid) {
+    await this.request(`/monitors/${uid}/run`, { method: "POST" });
+  }
   async mockExists(uid) {
     try {
       await this.request(`/mocks/${uid}`);
@@ -26088,9 +26091,19 @@ async function runRepoSync(inputs, dependencies) {
           monitorEnvUid,
           effectiveCron || void 0
         );
-        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? "" : " (disabled \u2014 no cron configured)"}`);
+        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? "" : " (disabled \u2014 no cron configured; will trigger a one-time run)"}`);
       }
       outputs["monitor-id"] = resolvedMonitorId;
+      if (!effectiveCron && resolvedMonitorId) {
+        try {
+          await dependencies.postman.runMonitor(resolvedMonitorId);
+          dependencies.core.info(`Triggered one-time run for monitor: ${resolvedMonitorId}`);
+        } catch (error) {
+          dependencies.core.warning(
+            `Failed to trigger one-time run for monitor ${resolvedMonitorId}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
     }
   }
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration) {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -122,7 +122,7 @@ export const postmanRepoSyncActionContract: {
       required: false
     },
     'monitor-cron': {
-      description: "Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created in a disabled state.",
+      description: "Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run).",
       required: false,
       default: ''
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export interface RepoSyncDependencies {
     | 'mockExists'
     | 'findMonitorByCollection'
     | 'findMockByCollection'
+    | 'runMonitor'
   >;
   github?: {
     getRepositoryVariable(name: string): Promise<string>;
@@ -1137,10 +1138,21 @@ export async function runRepoSync(
           monitorEnvUid,
           effectiveCron || undefined
         );
-        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? '' : ' (disabled — no cron configured)'}`);
+        dependencies.core.info(`Created new monitor: ${resolvedMonitorId}${effectiveCron ? '' : ' (disabled — no cron configured; will trigger a one-time run)'}`);
       }
 
       outputs['monitor-id'] = resolvedMonitorId;
+
+      if (!effectiveCron && resolvedMonitorId) {
+        try {
+          await dependencies.postman.runMonitor(resolvedMonitorId);
+          dependencies.core.info(`Triggered one-time run for monitor: ${resolvedMonitorId}`);
+        } catch (error) {
+          dependencies.core.warning(
+            `Failed to trigger one-time run for monitor ${resolvedMonitorId}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
     }
   }
 

--- a/src/lib/postman/postman-assets-client.ts
+++ b/src/lib/postman/postman-assets-client.ts
@@ -278,6 +278,10 @@ export class PostmanAssetsClient {
     }
   }
 
+  async runMonitor(uid: string): Promise<void> {
+    await this.request(`/monitors/${uid}/run`, { method: 'POST' });
+  }
+
   async mockExists(uid: string): Promise<boolean> {
     try {
       await this.request(`/mocks/${uid}`);

--- a/tests/postman-assets-client.test.ts
+++ b/tests/postman-assets-client.test.ts
@@ -189,6 +189,16 @@ describe('discovery and validation methods', () => {
     expect(uid).toBe('mon-cron');
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  it('runMonitor triggers a one-time run via POST /monitors/:uid/run', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ monitor: { uid: 'mon-1' } }));
+    const client = new PostmanAssetsClient({ apiKey: 'pmak-test', fetchImpl });
+    await client.runMonitor('mon-1');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0];
+    expect(call?.[0]).toContain('/monitors/mon-1/run');
+    expect(call?.[1]?.method).toBe('POST');
+  });
 });
 
 describe('getTeams', () => {

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -245,7 +245,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
     const github = {
       getRepositoryVariable: vi.fn().mockResolvedValue(''),
@@ -398,7 +399,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
     const github = {
       getRepositoryVariable: vi
@@ -450,7 +452,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
 
     await runRepoSync(
@@ -507,7 +510,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
     const repoMutation = {
       commitAndPush: vi.fn().mockResolvedValue({
@@ -564,7 +568,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
 
     await runRepoSync(
@@ -616,7 +621,8 @@ describe('repo sync action', () => {
       monitorExists: vi.fn().mockResolvedValue(false),
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
-      findMockByCollection: vi.fn().mockResolvedValue(null)
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
     };
 
     await runRepoSync(
@@ -675,6 +681,7 @@ describe('monitor resolution paths', () => {
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
       findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined),
       ...overrides
     };
   }
@@ -745,6 +752,54 @@ describe('monitor resolution paths', () => {
       undefined
     );
   });
+
+  it('triggers a one-time monitor run when monitor-cron is empty', async () => {
+    const postman = makePostman();
+    const github = makeGithub();
+    await runRepoSync(
+      createInputs({ environments: ['prod'], generateCiWorkflow: false, monitorCron: '' }),
+      makeDeps(postman, github)
+    );
+
+    expect(postman.runMonitor).toHaveBeenCalledTimes(1);
+    expect(postman.runMonitor).toHaveBeenCalledWith('mon-new');
+  });
+
+  it('does not trigger a one-time monitor run when monitor-cron is provided', async () => {
+    const postman = makePostman();
+    const github = makeGithub();
+    await runRepoSync(
+      createInputs({ environments: ['prod'], generateCiWorkflow: false, monitorCron: '0 */6 * * *' }),
+      makeDeps(postman, github)
+    );
+
+    expect(postman.runMonitor).not.toHaveBeenCalled();
+  });
+
+  it('triggers a one-time run on a reused explicit monitor when cron is empty', async () => {
+    const postman = makePostman({ monitorExists: vi.fn().mockResolvedValue(true) });
+    const github = makeGithub();
+    await runRepoSync(
+      createInputs({ environments: ['prod'], generateCiWorkflow: false, monitorId: 'explicit-mon', monitorCron: '' }),
+      makeDeps(postman, github)
+    );
+
+    expect(postman.createMonitor).not.toHaveBeenCalled();
+    expect(postman.runMonitor).toHaveBeenCalledWith('explicit-mon');
+  });
+
+  it('swallows runMonitor failures with a warning', async () => {
+    const postman = makePostman({
+      runMonitor: vi.fn().mockRejectedValue(new Error('boom'))
+    });
+    const github = makeGithub();
+    await expect(
+      runRepoSync(
+        createInputs({ environments: ['prod'], generateCiWorkflow: false, monitorCron: '' }),
+        makeDeps(postman, github)
+      )
+    ).resolves.toBeDefined();
+  });
 });
 
 describe('mock resolution paths', () => {
@@ -762,6 +817,7 @@ describe('mock resolution paths', () => {
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
       findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined),
       ...overrides
     };
   }
@@ -1064,6 +1120,7 @@ describe('repo-variable fallback resolution', () => {
       mockExists: vi.fn().mockResolvedValue(false),
       findMonitorByCollection: vi.fn().mockResolvedValue(null),
       findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined),
       ...overrides
     };
   }


### PR DESCRIPTION
When monitor-cron is empty, the monitor is still created in a disabled state, but the action now also triggers a one-time run via POST /monitors/:uid/run on every invocation. This applies to newly created monitors, monitors reused via explicit monitor-id, and monitors discovered by smoke collection.

- Add PostmanAssetsClient.runMonitor()
- Trigger one-time run in repo-sync when effectiveCron is empty
- Wrap run in try/catch and emit a warning on failure (non-fatal)
- Update action.yml / contracts description
- Add tests for runMonitor, run-once paths, reuse path, and failure tolerance

## Description

<!-- What changed and why -->

## Related Issue

<!-- Fixes #123 or "N/A" -->

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` run and `dist/` updated (skip for composite action)
- [x] No secrets or credentials in diff
- [x] Breaking changes documented (if any)
