### PR TITLE
feat: make Postman API/Bifrost/CLI base URLs configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,18 @@ inputs:
   spec-path:
     description: Optional repo-root-relative path to the local spec file for resources/workflows metadata.
     required: false
+  postman-api-base:
+    description: Base URL for the public Postman API (override for beta/staging stacks).
+    required: false
+    default: https://api.getpostman.com
+  postman-bifrost-base:
+    description: Base URL for the Bifrost gateway used by internal integration calls (override for beta/staging stacks).
+    required: false
+    default: https://bifrost-premium-https-v4.gw.postman.com
+  postman-cli-install-url:
+    description: Installer URL for the Postman CLI written into the generated CI workflow (override for beta/staging stacks).
+    required: false
+    default: https://dl-cli.pstmn.io/install/unix.sh
 outputs:
   integration-backend:
     description: Resolved integration backend for the open-alpha run.

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -24498,99 +24498,107 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 }
 
 // src/lib/ci-workflow-template.ts
-var CI_WORKFLOW_TEMPLATE = [
-  "name: CI/CD Pipeline",
-  "on:",
-  "  push:",
-  "    branches: [main]",
-  "  pull_request:",
-  "    branches: [main]",
-  "  schedule:",
-  '    - cron: "0 */6 * * *"',
-  "jobs:",
-  "  test:",
-  "    runs-on: ubuntu-latest",
-  "    steps:",
-  "      - uses: actions/checkout@v4",
-  "      - name: Install Postman CLI",
-  '        run: curl -o- "https://dl-cli.pstmn.io/install/unix.sh" | sh',
-  "      - name: Login to Postman CLI",
-  "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
-  "      - name: Resolve Postman Resource IDs",
-  "        run: |",
-  "          ruby <<'RUBY'",
-  "          require 'yaml'",
-  "          config = YAML.load_file('.postman/resources.yaml') || {}",
-  "          cloud = config.fetch('cloudResources', {})",
-  "          collections = cloud.fetch('collections', {})",
-  "          environments = cloud.fetch('environments', {})",
-  "          smoke = collections.find { |path, _| path.include?('[Smoke]') }&.last",
-  "          contract = collections.find { |path, _| path.include?('[Contract]') }&.last",
-  "          environment = environments.find { |path, _| path.end_with?('/prod.postman_environment.json') }&.last || environments.values.first",
-  "          missing = []",
-  "          missing << 'smoke collection' unless smoke",
-  "          missing << 'contract collection' unless contract",
-  "          missing << 'environment' unless environment",
-  `          abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?`,
-  "          File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|",
-  '            file.puts("POSTMAN_SMOKE_COLLECTION_UID=#{smoke}")',
-  '            file.puts("POSTMAN_CONTRACT_COLLECTION_UID=#{contract}")',
-  '            file.puts("POSTMAN_ENVIRONMENT_UID=#{environment}")',
-  "          end",
-  "          RUBY",
-  "      - name: Decode SSL certificates",
-  "        if: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 != '' }}",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_CERT_B64: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 }}",
-  "          POSTMAN_SSL_CLIENT_KEY_B64: ${{ secrets.POSTMAN_SSL_CLIENT_KEY_B64 }}",
-  "          POSTMAN_SSL_EXTRA_CA_CERTS_B64: ${{ secrets.POSTMAN_SSL_EXTRA_CA_CERTS_B64 }}",
-  "        run: |",
-  '          mkdir -p "$RUNNER_TEMP/postman-ssl"',
-  '          printf %s "$POSTMAN_SSL_CLIENT_CERT_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '          printf %s "$POSTMAN_SSL_CLIENT_KEY_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.key"',
-  '          if [ -n "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" ]; then',
-  '            printf %s "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/ca.crt"',
-  "          fi",
-  "      - name: Run Smoke Tests",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
-  "        run: |",
-  '          CMD=(postman collection run "$POSTMAN_SMOKE_COLLECTION_UID"',
-  '            -e "$POSTMAN_ENVIRONMENT_UID"',
-  "            --report-events",
-  `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
-  '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
-  '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
-  '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
-  '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
-  "            fi",
-  '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
-  '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
-  "            fi",
-  "          fi",
-  '          "${CMD[@]}"',
-  "      - name: Run Contract Tests",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
-  "        run: |",
-  '          CMD=(postman collection run "$POSTMAN_CONTRACT_COLLECTION_UID"',
-  '            -e "$POSTMAN_ENVIRONMENT_UID"',
-  "            --report-events",
-  `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
-  '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
-  '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
-  '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
-  '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
-  "            fi",
-  '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
-  '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
-  "            fi",
-  "          fi",
-  '          "${CMD[@]}"',
-  ""
-].join("\\n");
+var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
+function renderCiWorkflowTemplate(options = {}) {
+  const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  return buildCiWorkflowLines(installUrl).join("\\n");
+}
+function buildCiWorkflowLines(installUrl) {
+  return [
+    "name: CI/CD Pipeline",
+    "on:",
+    "  push:",
+    "    branches: [main]",
+    "  pull_request:",
+    "    branches: [main]",
+    "  schedule:",
+    '    - cron: "0 */6 * * *"',
+    "jobs:",
+    "  test:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - name: Install Postman CLI",
+    `        run: curl -o- "${installUrl}" | sh`,
+    "      - name: Login to Postman CLI",
+    "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
+    "      - name: Resolve Postman Resource IDs",
+    "        run: |",
+    "          ruby <<'RUBY'",
+    "          require 'yaml'",
+    "          config = YAML.load_file('.postman/resources.yaml') || {}",
+    "          cloud = config.fetch('cloudResources', {})",
+    "          collections = cloud.fetch('collections', {})",
+    "          environments = cloud.fetch('environments', {})",
+    "          smoke = collections.find { |path, _| path.include?('[Smoke]') }&.last",
+    "          contract = collections.find { |path, _| path.include?('[Contract]') }&.last",
+    "          environment = environments.find { |path, _| path.end_with?('/prod.postman_environment.json') }&.last || environments.values.first",
+    "          missing = []",
+    "          missing << 'smoke collection' unless smoke",
+    "          missing << 'contract collection' unless contract",
+    "          missing << 'environment' unless environment",
+    `          abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?`,
+    "          File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|",
+    '            file.puts("POSTMAN_SMOKE_COLLECTION_UID=#{smoke}")',
+    '            file.puts("POSTMAN_CONTRACT_COLLECTION_UID=#{contract}")',
+    '            file.puts("POSTMAN_ENVIRONMENT_UID=#{environment}")',
+    "          end",
+    "          RUBY",
+    "      - name: Decode SSL certificates",
+    "        if: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 != '' }}",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_CERT_B64: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 }}",
+    "          POSTMAN_SSL_CLIENT_KEY_B64: ${{ secrets.POSTMAN_SSL_CLIENT_KEY_B64 }}",
+    "          POSTMAN_SSL_EXTRA_CA_CERTS_B64: ${{ secrets.POSTMAN_SSL_EXTRA_CA_CERTS_B64 }}",
+    "        run: |",
+    '          mkdir -p "$RUNNER_TEMP/postman-ssl"',
+    '          printf %s "$POSTMAN_SSL_CLIENT_CERT_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '          printf %s "$POSTMAN_SSL_CLIENT_KEY_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.key"',
+    '          if [ -n "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" ]; then',
+    '            printf %s "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/ca.crt"',
+    "          fi",
+    "      - name: Run Smoke Tests",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
+    "        run: |",
+    '          CMD=(postman collection run "$POSTMAN_SMOKE_COLLECTION_UID"',
+    '            -e "$POSTMAN_ENVIRONMENT_UID"',
+    "            --report-events",
+    `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
+    '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
+    '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
+    '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
+    "            fi",
+    '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
+    '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
+    "            fi",
+    "          fi",
+    '          "${CMD[@]}"',
+    "      - name: Run Contract Tests",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
+    "        run: |",
+    '          CMD=(postman collection run "$POSTMAN_CONTRACT_COLLECTION_UID"',
+    '            -e "$POSTMAN_ENVIRONMENT_UID"',
+    "            --report-events",
+    `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
+    '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
+    '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
+    '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
+    "            fi",
+    '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
+    '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
+    "            fi",
+    "          fi",
+    '          "${CMD[@]}"',
+    ""
+  ];
+}
+var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
 // src/lib/secrets.ts
 var REDACTED = "[REDACTED]";
@@ -24918,12 +24926,16 @@ var HttpError = class _HttpError extends Error {
 // src/lib/postman/internal-integration-adapter.ts
 var BifrostInternalIntegrationAdapter = class {
   accessToken;
+  bifrostBaseUrl;
   fetchImpl;
   orgMode;
   teamId;
   workerBaseUrl;
   constructor(options) {
     this.accessToken = String(options.accessToken || "").trim();
+    this.bifrostBaseUrl = String(
+      options.bifrostBaseUrl || "https://bifrost-premium-https-v4.gw.postman.com"
+    ).replace(/\/+$/, "");
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.orgMode = options.orgMode ?? false;
     this.teamId = String(options.teamId || "").trim();
@@ -24977,7 +24989,7 @@ var BifrostInternalIntegrationAdapter = class {
     }
   }
   async connectWorkspaceToRepository(workspaceId, repoUrl) {
-    const url = "https://bifrost-premium-https-v4.gw.postman.com/ws/proxy";
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const payload = {
       service: "workspaces",
       method: "POST",
@@ -25011,7 +25023,7 @@ var BifrostInternalIntegrationAdapter = class {
     }
   }
   async createApiKey(name) {
-    const url = "https://bifrost-premium-https-v4.gw.postman.com/ws/proxy";
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const headers = this.bifrostHeaders();
     const payload = {
       service: "identity",
@@ -25062,6 +25074,9 @@ var PostmanAssetsClient = class {
     );
     this.fetchImpl = options.fetchImpl ?? fetch;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
+  }
+  getBaseUrl() {
+    return this.baseUrl;
   }
   async request(path4, init = {}) {
     const url = path4.startsWith("http") ? path4 : `${this.baseUrl}${path4}`;
@@ -25441,7 +25456,10 @@ function resolveInputs(env = process.env) {
     sslClientPassphrase: getInput("ssl-client-passphrase", env),
     sslExtraCaCerts: getInput("ssl-extra-ca-certs", env),
     teamId: getInput("team-id", env) || normalizeInputValue(env.POSTMAN_TEAM_ID),
-    repository: getInput("repository", env) || normalizeInputValue(env.GITHUB_REPOSITORY) || normalizeInputValue(repoContext.repoSlug)
+    repository: getInput("repository", env) || normalizeInputValue(env.GITHUB_REPOSITORY) || normalizeInputValue(repoContext.repoSlug),
+    postmanApiBase: getInput("postman-api-base", env) || "https://api.getpostman.com",
+    postmanBifrostBase: getInput("postman-bifrost-base", env) || "https://bifrost-premium-https-v4.gw.postman.com",
+    postmanCliInstallUrl: getInput("postman-cli-install-url", env) || "https://dl-cli.pstmn.io/install/unix.sh"
   };
 }
 function buildEnvironmentValues(envName, baseUrl) {
@@ -25647,6 +25665,9 @@ function readActionInputs(actionCore) {
     INPUT_SSL_EXTRA_CA_CERTS: sslExtraCaCerts,
     INPUT_TEAM_ID: readInput(actionCore, "team-id") || process.env.POSTMAN_TEAM_ID,
     INPUT_REPOSITORY: readInput(actionCore, "repository") || process.env.GITHUB_REPOSITORY,
+    INPUT_POSTMAN_API_BASE: readInput(actionCore, "postman-api-base") || "https://api.getpostman.com",
+    INPUT_POSTMAN_BIFROST_BASE: readInput(actionCore, "postman-bifrost-base") || "https://bifrost-premium-https-v4.gw.postman.com",
+    INPUT_POSTMAN_CLI_INSTALL_URL: readInput(actionCore, "postman-cli-install-url") || "https://dl-cli.pstmn.io/install/unix.sh",
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
@@ -25930,7 +25951,9 @@ function renderCiWorkflow(inputs) {
   if (inputs.ciWorkflowBase64) {
     return Buffer.from(inputs.ciWorkflowBase64, "base64").toString("utf8");
   }
-  return CI_WORKFLOW_TEMPLATE;
+  return renderCiWorkflowTemplate({
+    postmanCliInstallUrl: inputs.postmanCliInstallUrl
+  });
 }
 function createRepoSummary(outputs, envUids, pushed) {
   return JSON.stringify({
@@ -26144,7 +26167,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   let teamId = inputs.teamId;
   let keyValid = false;
   if (apiKey) {
-    const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+    const tempClient = new PostmanAssetsClient({
+      apiKey,
+      baseUrl: inputs.postmanApiBase,
+      secretMasker: masker
+    });
     try {
       const me = await tempClient.getMe();
       if (me && me.user) {
@@ -26169,6 +26196,7 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
     const internalIntegration = createInternalIntegrationAdapter({
       accessToken: inputs.postmanAccessToken,
       backend: inputs.integrationBackend,
+      bifrostBaseUrl: inputs.postmanBifrostBase,
       orgMode: inputs.orgMode,
       teamId,
       secretMasker: masker
@@ -26177,7 +26205,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
     apiKey = await internalIntegration.createApiKey(keyName);
     actionCore.setSecret(apiKey);
     if (!teamId) {
-      const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+      const tempClient = new PostmanAssetsClient({
+        apiKey,
+        baseUrl: inputs.postmanApiBase,
+        secretMasker: masker
+      });
       const autoTeamId = await tempClient.getAutoDerivedTeamId();
       if (autoTeamId) teamId = autoTeamId;
     }
@@ -26215,7 +26247,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   }
   if (!inputs.orgMode && teamId) {
     try {
-      const client = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+      const client = new PostmanAssetsClient({
+        apiKey,
+        baseUrl: inputs.postmanApiBase,
+        secretMasker: masker
+      });
       const teams = await client.getTeams();
       if (teams.length > 1 && teams.every((t) => t.organizationId == null)) {
         actionCore.warning(
@@ -26247,6 +26283,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
   ]);
   const postman = new PostmanAssetsClient({
     apiKey: resolved.apiKey,
+    baseUrl: inputs.postmanApiBase,
     secretMasker: masker
   });
   const repoMutation = repository && (inputs.repoWriteMode === "commit-only" || inputs.repoWriteMode === "commit-and-push") ? new RepoMutationService({
@@ -26266,6 +26303,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
   const internalIntegration = inputs.postmanAccessToken ? createInternalIntegrationAdapter({
     accessToken: inputs.postmanAccessToken,
     backend: inputs.integrationBackend,
+    bifrostBaseUrl: inputs.postmanBifrostBase,
     orgMode: inputs.orgMode,
     teamId: resolved.teamId,
     secretMasker: masker
@@ -26463,7 +26501,10 @@ function parseCliArgs(argv, env = process.env) {
     "ssl-extra-ca-certs",
     "spec-id",
     "spec-path",
-    "team-id"
+    "team-id",
+    "postman-api-base",
+    "postman-bifrost-base",
+    "postman-cli-install-url"
   ];
   const inputEnv = { ...env };
   for (const name of inputNames) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24493,99 +24493,107 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 }
 
 // src/lib/ci-workflow-template.ts
-var CI_WORKFLOW_TEMPLATE = [
-  "name: CI/CD Pipeline",
-  "on:",
-  "  push:",
-  "    branches: [main]",
-  "  pull_request:",
-  "    branches: [main]",
-  "  schedule:",
-  '    - cron: "0 */6 * * *"',
-  "jobs:",
-  "  test:",
-  "    runs-on: ubuntu-latest",
-  "    steps:",
-  "      - uses: actions/checkout@v4",
-  "      - name: Install Postman CLI",
-  '        run: curl -o- "https://dl-cli.pstmn.io/install/unix.sh" | sh',
-  "      - name: Login to Postman CLI",
-  "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
-  "      - name: Resolve Postman Resource IDs",
-  "        run: |",
-  "          ruby <<'RUBY'",
-  "          require 'yaml'",
-  "          config = YAML.load_file('.postman/resources.yaml') || {}",
-  "          cloud = config.fetch('cloudResources', {})",
-  "          collections = cloud.fetch('collections', {})",
-  "          environments = cloud.fetch('environments', {})",
-  "          smoke = collections.find { |path, _| path.include?('[Smoke]') }&.last",
-  "          contract = collections.find { |path, _| path.include?('[Contract]') }&.last",
-  "          environment = environments.find { |path, _| path.end_with?('/prod.postman_environment.json') }&.last || environments.values.first",
-  "          missing = []",
-  "          missing << 'smoke collection' unless smoke",
-  "          missing << 'contract collection' unless contract",
-  "          missing << 'environment' unless environment",
-  `          abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?`,
-  "          File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|",
-  '            file.puts("POSTMAN_SMOKE_COLLECTION_UID=#{smoke}")',
-  '            file.puts("POSTMAN_CONTRACT_COLLECTION_UID=#{contract}")',
-  '            file.puts("POSTMAN_ENVIRONMENT_UID=#{environment}")',
-  "          end",
-  "          RUBY",
-  "      - name: Decode SSL certificates",
-  "        if: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 != '' }}",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_CERT_B64: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 }}",
-  "          POSTMAN_SSL_CLIENT_KEY_B64: ${{ secrets.POSTMAN_SSL_CLIENT_KEY_B64 }}",
-  "          POSTMAN_SSL_EXTRA_CA_CERTS_B64: ${{ secrets.POSTMAN_SSL_EXTRA_CA_CERTS_B64 }}",
-  "        run: |",
-  '          mkdir -p "$RUNNER_TEMP/postman-ssl"',
-  '          printf %s "$POSTMAN_SSL_CLIENT_CERT_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '          printf %s "$POSTMAN_SSL_CLIENT_KEY_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.key"',
-  '          if [ -n "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" ]; then',
-  '            printf %s "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/ca.crt"',
-  "          fi",
-  "      - name: Run Smoke Tests",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
-  "        run: |",
-  '          CMD=(postman collection run "$POSTMAN_SMOKE_COLLECTION_UID"',
-  '            -e "$POSTMAN_ENVIRONMENT_UID"',
-  "            --report-events",
-  `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
-  '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
-  '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
-  '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
-  '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
-  "            fi",
-  '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
-  '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
-  "            fi",
-  "          fi",
-  '          "${CMD[@]}"',
-  "      - name: Run Contract Tests",
-  "        env:",
-  "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
-  "        run: |",
-  '          CMD=(postman collection run "$POSTMAN_CONTRACT_COLLECTION_UID"',
-  '            -e "$POSTMAN_ENVIRONMENT_UID"',
-  "            --report-events",
-  `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
-  '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
-  '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
-  '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
-  '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
-  '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
-  "            fi",
-  '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
-  '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
-  "            fi",
-  "          fi",
-  '          "${CMD[@]}"',
-  ""
-].join("\\n");
+var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
+function renderCiWorkflowTemplate(options = {}) {
+  const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  return buildCiWorkflowLines(installUrl).join("\\n");
+}
+function buildCiWorkflowLines(installUrl) {
+  return [
+    "name: CI/CD Pipeline",
+    "on:",
+    "  push:",
+    "    branches: [main]",
+    "  pull_request:",
+    "    branches: [main]",
+    "  schedule:",
+    '    - cron: "0 */6 * * *"',
+    "jobs:",
+    "  test:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - name: Install Postman CLI",
+    `        run: curl -o- "${installUrl}" | sh`,
+    "      - name: Login to Postman CLI",
+    "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
+    "      - name: Resolve Postman Resource IDs",
+    "        run: |",
+    "          ruby <<'RUBY'",
+    "          require 'yaml'",
+    "          config = YAML.load_file('.postman/resources.yaml') || {}",
+    "          cloud = config.fetch('cloudResources', {})",
+    "          collections = cloud.fetch('collections', {})",
+    "          environments = cloud.fetch('environments', {})",
+    "          smoke = collections.find { |path, _| path.include?('[Smoke]') }&.last",
+    "          contract = collections.find { |path, _| path.include?('[Contract]') }&.last",
+    "          environment = environments.find { |path, _| path.end_with?('/prod.postman_environment.json') }&.last || environments.values.first",
+    "          missing = []",
+    "          missing << 'smoke collection' unless smoke",
+    "          missing << 'contract collection' unless contract",
+    "          missing << 'environment' unless environment",
+    `          abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?`,
+    "          File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|",
+    '            file.puts("POSTMAN_SMOKE_COLLECTION_UID=#{smoke}")',
+    '            file.puts("POSTMAN_CONTRACT_COLLECTION_UID=#{contract}")',
+    '            file.puts("POSTMAN_ENVIRONMENT_UID=#{environment}")',
+    "          end",
+    "          RUBY",
+    "      - name: Decode SSL certificates",
+    "        if: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 != '' }}",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_CERT_B64: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 }}",
+    "          POSTMAN_SSL_CLIENT_KEY_B64: ${{ secrets.POSTMAN_SSL_CLIENT_KEY_B64 }}",
+    "          POSTMAN_SSL_EXTRA_CA_CERTS_B64: ${{ secrets.POSTMAN_SSL_EXTRA_CA_CERTS_B64 }}",
+    "        run: |",
+    '          mkdir -p "$RUNNER_TEMP/postman-ssl"',
+    '          printf %s "$POSTMAN_SSL_CLIENT_CERT_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '          printf %s "$POSTMAN_SSL_CLIENT_KEY_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/client.key"',
+    '          if [ -n "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" ]; then',
+    '            printf %s "$POSTMAN_SSL_EXTRA_CA_CERTS_B64" | base64 -d > "$RUNNER_TEMP/postman-ssl/ca.crt"',
+    "          fi",
+    "      - name: Run Smoke Tests",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
+    "        run: |",
+    '          CMD=(postman collection run "$POSTMAN_SMOKE_COLLECTION_UID"',
+    '            -e "$POSTMAN_ENVIRONMENT_UID"',
+    "            --report-events",
+    `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
+    '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
+    '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
+    '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
+    "            fi",
+    '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
+    '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
+    "            fi",
+    "          fi",
+    '          "${CMD[@]}"',
+    "      - name: Run Contract Tests",
+    "        env:",
+    "          POSTMAN_SSL_CLIENT_PASSPHRASE: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}",
+    "        run: |",
+    '          CMD=(postman collection run "$POSTMAN_CONTRACT_COLLECTION_UID"',
+    '            -e "$POSTMAN_ENVIRONMENT_UID"',
+    "            --report-events",
+    `            --env-var "\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
+    '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
+    '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
+    '            if [ -n "$POSTMAN_SSL_CLIENT_PASSPHRASE" ]; then',
+    '              CMD+=(--ssl-client-passphrase "$POSTMAN_SSL_CLIENT_PASSPHRASE")',
+    "            fi",
+    '            if [ -f "$RUNNER_TEMP/postman-ssl/ca.crt" ]; then',
+    '              CMD+=(--ssl-extra-ca-certs "$RUNNER_TEMP/postman-ssl/ca.crt")',
+    "            fi",
+    "          fi",
+    '          "${CMD[@]}"',
+    ""
+  ];
+}
+var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
 // src/lib/secrets.ts
 var REDACTED = "[REDACTED]";
@@ -24913,12 +24921,16 @@ var HttpError = class _HttpError extends Error {
 // src/lib/postman/internal-integration-adapter.ts
 var BifrostInternalIntegrationAdapter = class {
   accessToken;
+  bifrostBaseUrl;
   fetchImpl;
   orgMode;
   teamId;
   workerBaseUrl;
   constructor(options) {
     this.accessToken = String(options.accessToken || "").trim();
+    this.bifrostBaseUrl = String(
+      options.bifrostBaseUrl || "https://bifrost-premium-https-v4.gw.postman.com"
+    ).replace(/\/+$/, "");
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.orgMode = options.orgMode ?? false;
     this.teamId = String(options.teamId || "").trim();
@@ -24972,7 +24984,7 @@ var BifrostInternalIntegrationAdapter = class {
     }
   }
   async connectWorkspaceToRepository(workspaceId, repoUrl) {
-    const url = "https://bifrost-premium-https-v4.gw.postman.com/ws/proxy";
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const payload = {
       service: "workspaces",
       method: "POST",
@@ -25006,7 +25018,7 @@ var BifrostInternalIntegrationAdapter = class {
     }
   }
   async createApiKey(name) {
-    const url = "https://bifrost-premium-https-v4.gw.postman.com/ws/proxy";
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const headers = this.bifrostHeaders();
     const payload = {
       service: "identity",
@@ -25057,6 +25069,9 @@ var PostmanAssetsClient = class {
     );
     this.fetchImpl = options.fetchImpl ?? fetch;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
+  }
+  getBaseUrl() {
+    return this.baseUrl;
   }
   async request(path3, init = {}) {
     const url = path3.startsWith("http") ? path3 : `${this.baseUrl}${path3}`;
@@ -25436,7 +25451,10 @@ function resolveInputs(env = process.env) {
     sslClientPassphrase: getInput("ssl-client-passphrase", env),
     sslExtraCaCerts: getInput("ssl-extra-ca-certs", env),
     teamId: getInput("team-id", env) || normalizeInputValue(env.POSTMAN_TEAM_ID),
-    repository: getInput("repository", env) || normalizeInputValue(env.GITHUB_REPOSITORY) || normalizeInputValue(repoContext.repoSlug)
+    repository: getInput("repository", env) || normalizeInputValue(env.GITHUB_REPOSITORY) || normalizeInputValue(repoContext.repoSlug),
+    postmanApiBase: getInput("postman-api-base", env) || "https://api.getpostman.com",
+    postmanBifrostBase: getInput("postman-bifrost-base", env) || "https://bifrost-premium-https-v4.gw.postman.com",
+    postmanCliInstallUrl: getInput("postman-cli-install-url", env) || "https://dl-cli.pstmn.io/install/unix.sh"
   };
 }
 function buildEnvironmentValues(envName, baseUrl) {
@@ -25642,6 +25660,9 @@ function readActionInputs(actionCore) {
     INPUT_SSL_EXTRA_CA_CERTS: sslExtraCaCerts,
     INPUT_TEAM_ID: readInput(actionCore, "team-id") || process.env.POSTMAN_TEAM_ID,
     INPUT_REPOSITORY: readInput(actionCore, "repository") || process.env.GITHUB_REPOSITORY,
+    INPUT_POSTMAN_API_BASE: readInput(actionCore, "postman-api-base") || "https://api.getpostman.com",
+    INPUT_POSTMAN_BIFROST_BASE: readInput(actionCore, "postman-bifrost-base") || "https://bifrost-premium-https-v4.gw.postman.com",
+    INPUT_POSTMAN_CLI_INSTALL_URL: readInput(actionCore, "postman-cli-install-url") || "https://dl-cli.pstmn.io/install/unix.sh",
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
@@ -25925,7 +25946,9 @@ function renderCiWorkflow(inputs) {
   if (inputs.ciWorkflowBase64) {
     return Buffer.from(inputs.ciWorkflowBase64, "base64").toString("utf8");
   }
-  return CI_WORKFLOW_TEMPLATE;
+  return renderCiWorkflowTemplate({
+    postmanCliInstallUrl: inputs.postmanCliInstallUrl
+  });
 }
 function createRepoSummary(outputs, envUids, pushed) {
   return JSON.stringify({
@@ -26139,7 +26162,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   let teamId = inputs.teamId;
   let keyValid = false;
   if (apiKey) {
-    const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+    const tempClient = new PostmanAssetsClient({
+      apiKey,
+      baseUrl: inputs.postmanApiBase,
+      secretMasker: masker
+    });
     try {
       const me = await tempClient.getMe();
       if (me && me.user) {
@@ -26164,6 +26191,7 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
     const internalIntegration = createInternalIntegrationAdapter({
       accessToken: inputs.postmanAccessToken,
       backend: inputs.integrationBackend,
+      bifrostBaseUrl: inputs.postmanBifrostBase,
       orgMode: inputs.orgMode,
       teamId,
       secretMasker: masker
@@ -26172,7 +26200,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
     apiKey = await internalIntegration.createApiKey(keyName);
     actionCore.setSecret(apiKey);
     if (!teamId) {
-      const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+      const tempClient = new PostmanAssetsClient({
+        apiKey,
+        baseUrl: inputs.postmanApiBase,
+        secretMasker: masker
+      });
       const autoTeamId = await tempClient.getAutoDerivedTeamId();
       if (autoTeamId) teamId = autoTeamId;
     }
@@ -26210,7 +26242,11 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   }
   if (!inputs.orgMode && teamId) {
     try {
-      const client = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+      const client = new PostmanAssetsClient({
+        apiKey,
+        baseUrl: inputs.postmanApiBase,
+        secretMasker: masker
+      });
       const teams = await client.getTeams();
       if (teams.length > 1 && teams.every((t) => t.organizationId == null)) {
         actionCore.warning(
@@ -26242,6 +26278,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
   ]);
   const postman = new PostmanAssetsClient({
     apiKey: resolved.apiKey,
+    baseUrl: inputs.postmanApiBase,
     secretMasker: masker
   });
   const repoMutation = repository && (inputs.repoWriteMode === "commit-only" || inputs.repoWriteMode === "commit-and-push") ? new RepoMutationService({
@@ -26261,6 +26298,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
   const internalIntegration = inputs.postmanAccessToken ? createInternalIntegrationAdapter({
     accessToken: inputs.postmanAccessToken,
     backend: inputs.integrationBackend,
+    bifrostBaseUrl: inputs.postmanBifrostBase,
     orgMode: inputs.orgMode,
     teamId: resolved.teamId,
     secretMasker: masker

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,7 +180,10 @@ export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.en
     'ssl-extra-ca-certs',
     'spec-id',
     'spec-path',
-    'team-id'
+    'team-id',
+    'postman-api-base',
+    'postman-bifrost-base',
+    'postman-cli-install-url'
   ];
 
   const inputEnv: NodeJS.ProcessEnv = { ...env };

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -237,6 +237,21 @@ export const postmanRepoSyncActionContract: {
     'spec-path': {
       description: 'Optional repo-root-relative path to the local spec file for resources/workflows metadata.',
       required: false
+    },
+    'postman-api-base': {
+      description: 'Base URL for the public Postman API (override for beta/staging stacks).',
+      required: false,
+      default: 'https://api.getpostman.com'
+    },
+    'postman-bifrost-base': {
+      description: 'Base URL for the Bifrost gateway used by internal integration calls (override for beta/staging stacks).',
+      required: false,
+      default: 'https://bifrost-premium-https-v4.gw.postman.com'
+    },
+    'postman-cli-install-url': {
+      description: 'Installer URL for the Postman CLI written into the generated CI workflow (override for beta/staging stacks).',
+      required: false,
+      default: 'https://dl-cli.pstmn.io/install/unix.sh'
     }
   },
   outputs: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 
 import { convertAndSplitCollection } from './postman-v3/converter.js';
-import { CI_WORKFLOW_TEMPLATE } from './lib/ci-workflow-template.js';
+import { renderCiWorkflowTemplate } from './lib/ci-workflow-template.js';
 import { RepoMutationService, resolveCurrentRef } from './lib/github/repo-mutation.js';
 import { detectRepoContext } from './lib/repo/context.js';
 import {
@@ -76,6 +76,9 @@ export interface ResolvedInputs {
   specPath: string;
   teamId: string;
   repository: string;
+  postmanApiBase: string;
+  postmanBifrostBase: string;
+  postmanCliInstallUrl: string;
 }
 
 interface RepoSyncOutputs {
@@ -304,7 +307,15 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     repository:
       getInput('repository', env) ||
       normalizeInputValue(env.GITHUB_REPOSITORY) ||
-      normalizeInputValue(repoContext.repoSlug)
+      normalizeInputValue(repoContext.repoSlug),
+    postmanApiBase:
+      getInput('postman-api-base', env) || 'https://api.getpostman.com',
+    postmanBifrostBase:
+      getInput('postman-bifrost-base', env) ||
+      'https://bifrost-premium-https-v4.gw.postman.com',
+    postmanCliInstallUrl:
+      getInput('postman-cli-install-url', env) ||
+      'https://dl-cli.pstmn.io/install/unix.sh'
   };
 }
 
@@ -567,6 +578,14 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_SSL_EXTRA_CA_CERTS: sslExtraCaCerts,
     INPUT_TEAM_ID: readInput(actionCore, 'team-id') || process.env.POSTMAN_TEAM_ID,
     INPUT_REPOSITORY: readInput(actionCore, 'repository') || process.env.GITHUB_REPOSITORY,
+    INPUT_POSTMAN_API_BASE:
+      readInput(actionCore, 'postman-api-base') || 'https://api.getpostman.com',
+    INPUT_POSTMAN_BIFROST_BASE:
+      readInput(actionCore, 'postman-bifrost-base') ||
+      'https://bifrost-premium-https-v4.gw.postman.com',
+    INPUT_POSTMAN_CLI_INSTALL_URL:
+      readInput(actionCore, 'postman-cli-install-url') ||
+      'https://dl-cli.pstmn.io/install/unix.sh',
     GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF,
     GITHUB_REF_NAME: process.env.GITHUB_REF_NAME
   });
@@ -924,7 +943,9 @@ function renderCiWorkflow(inputs: ResolvedInputs): string {
   if (inputs.ciWorkflowBase64) {
     return Buffer.from(inputs.ciWorkflowBase64, 'base64').toString('utf8');
   }
-  return CI_WORKFLOW_TEMPLATE;
+  return renderCiWorkflowTemplate({
+    postmanCliInstallUrl: inputs.postmanCliInstallUrl
+  });
 }
 
 function createRepoSummary(
@@ -1208,7 +1229,11 @@ export async function resolvePostmanApiKeyAndTeamId(
   let keyValid = false;
 
   if (apiKey) {
-    const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+    const tempClient = new PostmanAssetsClient({
+      apiKey,
+      baseUrl: inputs.postmanApiBase,
+      secretMasker: masker
+    });
     try {
       const me = await tempClient.getMe();
       if (me && me.user) {
@@ -1241,6 +1266,7 @@ export async function resolvePostmanApiKeyAndTeamId(
     const internalIntegration = createInternalIntegrationAdapter({
       accessToken: inputs.postmanAccessToken,
       backend: inputs.integrationBackend,
+      bifrostBaseUrl: inputs.postmanBifrostBase,
       orgMode: inputs.orgMode,
       teamId,
       secretMasker: masker
@@ -1251,7 +1277,11 @@ export async function resolvePostmanApiKeyAndTeamId(
     actionCore.setSecret(apiKey);
 
     if (!teamId) {
-       const tempClient = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+       const tempClient = new PostmanAssetsClient({
+         apiKey,
+         baseUrl: inputs.postmanApiBase,
+         secretMasker: masker
+       });
        const autoTeamId = await tempClient.getAutoDerivedTeamId();
        if (autoTeamId) teamId = autoTeamId;
     }
@@ -1289,7 +1319,11 @@ export async function resolvePostmanApiKeyAndTeamId(
   // Auto-detect org-mode when not explicitly set
   if (!inputs.orgMode && teamId) {
     try {
-      const client = new PostmanAssetsClient({ apiKey, secretMasker: masker });
+      const client = new PostmanAssetsClient({
+        apiKey,
+        baseUrl: inputs.postmanApiBase,
+        secretMasker: masker
+      });
       const teams = await client.getTeams();
       if (teams.length > 1 && teams.every(t => t.organizationId == null)) {
         actionCore.warning(
@@ -1334,6 +1368,7 @@ export function createRepoSyncDependencies(
 
   const postman = new PostmanAssetsClient({
     apiKey: resolved.apiKey,
+    baseUrl: inputs.postmanApiBase,
     secretMasker: masker
   });
 
@@ -1360,6 +1395,7 @@ export function createRepoSyncDependencies(
     ? createInternalIntegrationAdapter({
         accessToken: inputs.postmanAccessToken,
         backend: inputs.integrationBackend,
+        bifrostBaseUrl: inputs.postmanBifrostBase,
         orgMode: inputs.orgMode,
         teamId: resolved.teamId,
         secretMasker: masker

--- a/src/lib/ci-workflow-template.ts
+++ b/src/lib/ci-workflow-template.ts
@@ -1,4 +1,15 @@
-export const CI_WORKFLOW_TEMPLATE = [
+export const DEFAULT_POSTMAN_CLI_INSTALL_URL = 'https://dl-cli.pstmn.io/install/unix.sh';
+
+export function renderCiWorkflowTemplate(
+  options: { postmanCliInstallUrl?: string } = {}
+): string {
+  const installUrl =
+    String(options.postmanCliInstallUrl || '').trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  return buildCiWorkflowLines(installUrl).join('\\n');
+}
+
+function buildCiWorkflowLines(installUrl: string): string[] {
+  return [
   'name: CI/CD Pipeline',
   'on:',
   '  push:',
@@ -13,7 +24,7 @@ export const CI_WORKFLOW_TEMPLATE = [
   '    steps:',
   '      - uses: actions/checkout@v4',
   '      - name: Install Postman CLI',
-  '        run: curl -o- "https://dl-cli.pstmn.io/install/unix.sh" | sh',
+  `        run: curl -o- "${installUrl}" | sh`,
   '      - name: Login to Postman CLI',
   '        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}',
   '      - name: Resolve Postman Resource IDs',
@@ -90,4 +101,7 @@ export const CI_WORKFLOW_TEMPLATE = [
   '          fi',
   '          "${CMD[@]}"',
   ''
-].join('\\n');
+  ];
+}
+
+export const CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();

--- a/src/lib/postman/internal-integration-adapter.ts
+++ b/src/lib/postman/internal-integration-adapter.ts
@@ -9,6 +9,7 @@ export interface GovernanceAssociation {
 export interface InternalIntegrationAdapterOptions {
   accessToken: string;
   backend: string;
+  bifrostBaseUrl?: string;
   fetchImpl?: typeof fetch;
   orgMode?: boolean;
   secretMasker?: SecretMasker;
@@ -32,6 +33,7 @@ export interface InternalIntegrationAdapter {
 
 class BifrostInternalIntegrationAdapter implements InternalIntegrationAdapter {
   private readonly accessToken: string;
+  private readonly bifrostBaseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly orgMode: boolean;
   private readonly teamId: string;
@@ -39,6 +41,9 @@ class BifrostInternalIntegrationAdapter implements InternalIntegrationAdapter {
 
   constructor(options: InternalIntegrationAdapterOptions) {
     this.accessToken = String(options.accessToken || '').trim();
+    this.bifrostBaseUrl = String(
+      options.bifrostBaseUrl || 'https://bifrost-premium-https-v4.gw.postman.com'
+    ).replace(/\/+$/, '');
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.orgMode = options.orgMode ?? false;
     this.teamId = String(options.teamId || '').trim();
@@ -104,7 +109,7 @@ class BifrostInternalIntegrationAdapter implements InternalIntegrationAdapter {
     workspaceId: string,
     repoUrl: string
   ): Promise<void> {
-    const url = 'https://bifrost-premium-https-v4.gw.postman.com/ws/proxy';
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const payload = {
       service: 'workspaces',
       method: 'POST',
@@ -148,7 +153,7 @@ class BifrostInternalIntegrationAdapter implements InternalIntegrationAdapter {
   }
 
   async createApiKey(name: string): Promise<string> {
-    const url = 'https://bifrost-premium-https-v4.gw.postman.com/ws/proxy';
+    const url = `${this.bifrostBaseUrl}/ws/proxy`;
     const headers = this.bifrostHeaders();
 
     const payload = {

--- a/src/lib/postman/postman-assets-client.ts
+++ b/src/lib/postman/postman-assets-client.ts
@@ -37,6 +37,10 @@ export class PostmanAssetsClient {
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
 
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
   private async request(
     path: string,
     init: RequestInit = {}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -54,7 +54,10 @@ describe('postman-repo-sync-action contract', () => {
       'ssl-client-passphrase',
       'ssl-extra-ca-certs',
       'spec-id',
-      'spec-path'
+      'spec-path',
+      'postman-api-base',
+      'postman-bifrost-base',
+      'postman-cli-install-url'
     ]);
 
     expect(Object.keys(postmanRepoSyncActionContract.outputs)).toEqual([

--- a/tests/internal-integration-adapter.test.ts
+++ b/tests/internal-integration-adapter.test.ts
@@ -38,6 +38,38 @@ describe('internal integration adapter', () => {
     );
   });
 
+  it('honors custom bifrostBaseUrl override for beta stacks', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+      .mockResolvedValueOnce(jsonResponse({ apikey: { key: 'pmak-beta-generated' } }));
+
+    const adapter = createInternalIntegrationAdapter({
+      backend: 'bifrost',
+      accessToken: 'token-beta',
+      teamId: '99999999',
+      bifrostBaseUrl: 'https://bifrost-premium-https-v4.gw.postman-beta.com/',
+      fetchImpl
+    });
+
+    await adapter.connectWorkspaceToRepository(
+      'ws-beta',
+      'https://github.com/postman-cs/repo-sync-demo'
+    );
+    await adapter.createApiKey('beta-key');
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://bifrost-premium-https-v4.gw.postman-beta.com/ws/proxy',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://bifrost-premium-https-v4.gw.postman-beta.com/ws/proxy',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
   it('sanitizes token content in internal failures', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('token-123 worker failure', {

--- a/tests/postman-assets-client.test.ts
+++ b/tests/postman-assets-client.test.ts
@@ -12,6 +12,38 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 }
 
 describe('PostmanAssetsClient', () => {
+  it('defaults baseUrl to the Postman prod API and routes requests through it', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ environment: { uid: 'env-prod' } })
+    );
+    const client = new PostmanAssetsClient({ apiKey: 'pmak-test', fetchImpl });
+
+    expect(client.getBaseUrl()).toBe('https://api.getpostman.com');
+    await client.createEnvironment('ws-1', 'n', []);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.getpostman.com/environments?workspace=ws-1',
+      expect.any(Object)
+    );
+  });
+
+  it('honors custom baseUrl override for beta stacks', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ environment: { uid: 'env-beta' } })
+    );
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-beta',
+      baseUrl: 'https://api.getpostman-beta.com/',
+      fetchImpl
+    });
+
+    expect(client.getBaseUrl()).toBe('https://api.getpostman-beta.com');
+    await client.createEnvironment('ws-beta', 'n', []);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.getpostman-beta.com/environments?workspace=ws-beta',
+      expect.any(Object)
+    );
+  });
+
   it('creates environments', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -76,6 +76,9 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     specPath: '',
     teamId: '',
     repository: 'postman-cs/repo-sync-demo',
+    postmanApiBase: 'https://api.getpostman.com',
+    postmanBifrostBase: 'https://bifrost-premium-https-v4.gw.postman.com',
+    postmanCliInstallUrl: 'https://dl-cli.pstmn.io/install/unix.sh',
     ...overrides
   };
 }


### PR DESCRIPTION
## Summary

Adds three optional action inputs so the whole repo-sync chain can be pointed at a non-prod Postman stack (e.g. `api.getpostman-beta.com`) while keeping every default identical to prior behavior. Fully backward compatible — callers that don't set these inputs get byte-identical behavior to the current release.

This unblocks the beta service-account PMAK E2E reproducer work being done from `postman-cs/postman-service-account-onboarding-sample`, where a beta-minted PMAK previously 401'd against the hard-coded prod endpoints. Sister change to the matching PR in `postman-bootstrap-action`.

## New inputs (all optional, prod defaults)

| Input | Default |
|---|---|
| `postman-api-base` | `https://api.getpostman.com` |
| `postman-bifrost-base` | `https://bifrost-premium-https-v4.gw.postman.com` |
| `postman-cli-install-url` | `https://dl-cli.pstmn.io/install/unix.sh` |

No `postman-gateway-base` is added here because `gateway.postman.com` is not used by `repo-sync-action` (governance-group assignment lives on the bootstrap side). The `workerBaseUrl` for the catalog-admin Cloudflare Worker was already configurable via the adapter option and stays as-is.

## Implementation notes

- `ResolvedInputs` gains `postmanApiBase`, `postmanBifrostBase`, `postmanCliInstallUrl`. Threaded through `resolveInputs`, `readActionInputs`, `createRepoSyncDependencies`, and every `PostmanAssetsClient` / `createInternalIntegrationAdapter` instantiation in `resolvePostmanApiKeyAndTeamId`.
- `PostmanAssetsClient` already accepted `baseUrl`; adds a `getBaseUrl()` accessor for parity with bootstrap and to simplify assertions.
- `InternalIntegrationAdapter` gains `bifrostBaseUrl?` option; `connectWorkspaceToRepository` and `createApiKey` now route through it instead of the hard-coded `bifrost-premium-https-v4.gw.postman.com` literal.
- `ci-workflow-template.ts` switches from a static `CI_WORKFLOW_TEMPLATE` const to a `renderCiWorkflowTemplate({ postmanCliInstallUrl })` function. The old `CI_WORKFLOW_TEMPLATE` export is retained as the default render so nothing that imported it breaks.
- `src/cli.ts` registers the three new `--postman-api-base`, `--postman-bifrost-base`, `--postman-cli-install-url` flags so the bundled CLI can also be retargeted.
- No existing exports, types, or defaults are reshaped; new fields on `ResolvedInputs` and adapter options are additive.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 78 passed (was 75; added 3 beta-override tests in `postman-assets-client.test.ts`, `internal-integration-adapter.test.ts`, plus contract-test entries for the three new input keys)
- [x] `npm run build` — regenerated `dist/index.cjs` and `dist/cli.cjs` committed so `check:dist` stays green
- [ ] End-to-end verification against beta stack via `postman-cs/postman-service-account-onboarding-sample` reproducer (Hammad's scenario)