### PR TITLE
fix: CI workflow template writes real newlines (not literal \n)

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -24501,7 +24501,7 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
 function renderCiWorkflowTemplate(options = {}) {
   const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
-  return buildCiWorkflowLines(installUrl).join("\\n");
+  return buildCiWorkflowLines(installUrl).join("\n");
 }
 function buildCiWorkflowLines(installUrl) {
   return [

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24496,7 +24496,7 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
 function renderCiWorkflowTemplate(options = {}) {
   const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
-  return buildCiWorkflowLines(installUrl).join("\\n");
+  return buildCiWorkflowLines(installUrl).join("\n");
 }
 function buildCiWorkflowLines(installUrl) {
   return [

--- a/src/lib/ci-workflow-template.ts
+++ b/src/lib/ci-workflow-template.ts
@@ -5,7 +5,7 @@ export function renderCiWorkflowTemplate(
 ): string {
   const installUrl =
     String(options.postmanCliInstallUrl || '').trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
-  return buildCiWorkflowLines(installUrl).join('\\n');
+  return buildCiWorkflowLines(installUrl).join('\n');
 }
 
 function buildCiWorkflowLines(installUrl: string): string[] {

--- a/tests/ci-workflow-template.test.ts
+++ b/tests/ci-workflow-template.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { renderCiWorkflowTemplate } from '../src/lib/ci-workflow-template.js';
+
+describe('renderCiWorkflowTemplate', () => {
+  it('produces multi-line YAML output with real newlines', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+
+    // Assert it's not a single-line blob
+    const lines = ciWorkflow.split('\n');
+    expect(lines.length).toBeGreaterThan(10);
+  });
+
+  it('does not contain literal backslash-n escape sequences', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+
+    // The bug was .join('\\n') which produces the two-character sequence \n
+    expect(ciWorkflow).not.toContain('\\n');
+  });
+
+  it('produces valid YAML that parses correctly', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+
+    // This is the real customer-facing correctness assertion
+    const parsed = parse(ciWorkflow);
+
+    expect(parsed).toBeTypeOf('object');
+    expect(parsed).toHaveProperty('name');
+    expect(parsed).toHaveProperty('on');
+    expect(parsed).toHaveProperty('jobs');
+    expect(parsed.jobs).toHaveProperty('test');
+  });
+
+  it('includes all required workflow structure', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+    const parsed = parse(ciWorkflow);
+
+    expect(parsed.name).toBe('CI/CD Pipeline');
+    expect(parsed.on).toHaveProperty('push');
+    expect(parsed.on).toHaveProperty('pull_request');
+    expect(parsed.on).toHaveProperty('schedule');
+    expect(parsed.jobs.test).toHaveProperty('runs-on');
+    expect(parsed.jobs.test).toHaveProperty('steps');
+    expect(parsed.jobs.test.steps.length).toBeGreaterThan(5);
+  });
+
+  it('accepts custom postmanCliInstallUrl', () => {
+    const customUrl = 'https://example.com/custom-install.sh';
+    const ciWorkflow = renderCiWorkflowTemplate({
+      postmanCliInstallUrl: customUrl
+    });
+
+    expect(ciWorkflow).toContain(customUrl);
+
+    // Verify it still produces valid YAML
+    const parsed = parse(ciWorkflow);
+    expect(parsed).toHaveProperty('jobs');
+  });
+
+  it('uses default install URL when none provided', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+
+    expect(ciWorkflow).toContain('https://dl-cli.pstmn.io/install/unix.sh');
+  });
+
+  it('contains expected CI steps in order', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+    const parsed = parse(ciWorkflow);
+
+    const stepNames = parsed.jobs.test.steps
+      .filter((step: { name?: string }) => step.name)
+      .map((step: { name: string }) => step.name);
+
+    expect(stepNames).toContain('Install Postman CLI');
+    expect(stepNames).toContain('Login to Postman CLI');
+    expect(stepNames).toContain('Resolve Postman Resource IDs');
+    expect(stepNames).toContain('Decode SSL certificates');
+    expect(stepNames).toContain('Run Smoke Tests');
+    expect(stepNames).toContain('Run Contract Tests');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HIGH-severity regression from commit 7c041ac where `renderCiWorkflowTemplate()` produced single-line YAML with literal `\n` escape sequences instead of real newlines.

## Customer Impact

Every repo using this action with `generate-ci-workflow` enabled (the default) had a broken `.github/workflows/ci.yml` committed on their behalf. The YAML parser cannot read the single-line blob, causing all CI workflows to fail.

## Root Cause

`.join('\\n')` in `src/lib/ci-workflow-template.ts:8` produces the two-character sequence `\n` (backslash followed by n), not a newline character.

Existing tests passed via substring matching (`toContain('name: ...')`), which succeeds even on malformed single-line output. The tests never validated the YAML structure.

## Fix

- Changed `.join('\\n')` to `.join('\n')` in `src/lib/ci-workflow-template.ts:8`
- Added comprehensive regression tests in `tests/ci-workflow-template.test.ts` that:
  - Assert multi-line output (>10 lines)
  - Assert no literal `\n` sequences remain
  - Parse output with `yaml.load()` and validate structure (the real customer-facing correctness check)
  - Verify all expected CI steps are present

## Source

Discovered by critic sweep in `pmak-service-account-beta/.omc/critic-sweep.md`

## Verification

- ✅ Tests: 86 passed (7 new CI template tests)
- ✅ Typecheck: clean
- ✅ Lint: clean
- ✅ Build: clean
- ✅ check:dist: clean

## Files Changed

- `src/lib/ci-workflow-template.ts`: Fixed `.join()` call
- `tests/ci-workflow-template.test.ts`: Added comprehensive regression tests
- `dist/index.cjs`, `dist/cli.cjs`: Rebuilt with fix