### PR TITLE
fix: prevent shell injection via postman-cli-install-url in emitted CI workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# postman-repo-sync-action
+
+Syncs Postman artifacts into a git repository: exports collections as Collection v3 multi-file YAML, creates/updates environments with runtime URLs, creates mock servers and smoke monitors, links workspace to repo via Bifrost, generates CI workflow, and commits/pushes results. Dual entry: GitHub Action and CLI.
+
+## Structure
+
+```
+src/
+  index.ts                  # Main orchestration: envs -> mocks -> monitors -> export -> CI -> commit
+  cli.ts                    # CLI adapter for non-GitHub CI
+  lib/
+    postman/
+      postman-assets-client.ts     # Postman API client (envs, mocks, monitors, collection export)
+      internal-integration-adapter.ts  # Bifrost adapter (workspace linking, system env association)
+    github/
+      github-api-client.ts         # Repo variable persistence
+      repo-mutation.ts             # Git commit/push logic, ref resolution
+    repo/
+      context.ts                   # CI provider auto-detection (GitHub, GitLab, Bitbucket, Azure)
+    ci-workflow-template.ts        # Template for generated .github/workflows/ci.yml
+    ssl-validation.ts              # mTLS cert material validation
+    retry.ts, secrets.ts, http-error.ts  # Shared utilities (duplicated from bootstrap)
+  postman-v3/
+    converter.ts                   # Converts Postman Collection JSON -> v3 multi-file YAML directory
+    convert.js, split.js           # Supporting conversion utilities
+tests/
+```
+
+## Commands
+
+```bash
+npm ci && npm test && npm run typecheck && npm run build
+npm run check:dist   # build + git diff --exit-code
+```
+
+## Key Behaviors
+
+- **Collection v3 export**: `converter.ts` transforms single-JSON Postman collections into a directory tree: `postman/collections/[Type] name/collection.yaml` with nested folder/request YAML files.
+- **Environment management**: Creates Postman environments per slug in `environments-json`, injects runtime URLs from `env-runtime-urls-json`, associates with system environments via Bifrost.
+- **Mock/Monitor creation**: Creates mock server from baseline collection, smoke monitor from smoke collection. Supports reuse via `mock-url` and `monitor-id` inputs. Monitor scheduling via `monitor-cron`.
+- **CI workflow generation**: Writes a Postman CLI-based smoke/contract test workflow. Controlled by `generate-ci-workflow` flag and `ci-workflow-path`.
+- **Repo mutation**: Commits exported artifacts under `postman/` and `.postman/` (resources.yaml, releases.yaml). Modes: `none`, `commit-only`, `commit-and-push`. Identity: `Postman CSE <help@postman.com>`.
+- **mTLS support**: Passes SSL cert/key material through to generated CI workflow for APIs requiring client certificates.
+- **Git provider support**: Auto-detects GitHub/GitLab/Bitbucket/Azure DevOps from env vars. Explicit `repo-url` also supported.
+
+## Artifact Layout (written to target repo)
+
+```
+postman/
+  collections/
+    [Baseline] name/collection.yaml
+    [Smoke] name/collection.yaml
+    [Contract] name/collection.yaml
+  environments/
+    prod.postman_environment.json
+  mocks/
+.postman/
+  resources.yaml  # PostmanResourcesConfig: workspace, localResources, cloudResources
+  releases.yaml   # (versioned runs only) release manifest with spec/collection UIDs per tag
+```
+
+## Gotchas
+
+- `repo-sync` build script runs `typecheck` before esbuild (unlike other actions)
+- Collection v3 format uses `$schema: https://schema.postman.com/json/draft-2020-12/collection/v3.0.0/` -- not the standard v2.1 JSON format
+- `commit-and-push` mode requires write permissions on the checked-out ref
+- `repo-mutation.ts` handles detached HEAD via `current-ref` input

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -24499,8 +24499,18 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 
 // src/lib/ci-workflow-template.ts
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
+function validateHttpsInstallUrl(url) {
+  const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
+  if (!safeUrlPattern.test(url)) {
+    throw new Error(
+      `postman-cli-install-url must be an https URL with safe characters; got: ${url}`
+    );
+  }
+  return url;
+}
 function renderCiWorkflowTemplate(options = {}) {
-  const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  const rawUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  const installUrl = validateHttpsInstallUrl(rawUrl);
   return buildCiWorkflowLines(installUrl).join("\n");
 }
 function buildCiWorkflowLines(installUrl) {
@@ -24519,7 +24529,9 @@ function buildCiWorkflowLines(installUrl) {
     "    steps:",
     "      - uses: actions/checkout@v4",
     "      - name: Install Postman CLI",
-    `        run: curl -o- "${installUrl}" | sh`,
+    "        env:",
+    `          POSTMAN_CLI_INSTALL_URL: ${installUrl}`,
+    '        run: curl -fsSL "$POSTMAN_CLI_INSTALL_URL" | sh',
     "      - name: Login to Postman CLI",
     "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
     "      - name: Resolve Postman Resource IDs",

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24494,8 +24494,18 @@ async function convertAndSplitCollection(v2Collection, outputDir) {
 
 // src/lib/ci-workflow-template.ts
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = "https://dl-cli.pstmn.io/install/unix.sh";
+function validateHttpsInstallUrl(url) {
+  const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
+  if (!safeUrlPattern.test(url)) {
+    throw new Error(
+      `postman-cli-install-url must be an https URL with safe characters; got: ${url}`
+    );
+  }
+  return url;
+}
 function renderCiWorkflowTemplate(options = {}) {
-  const installUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  const rawUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  const installUrl = validateHttpsInstallUrl(rawUrl);
   return buildCiWorkflowLines(installUrl).join("\n");
 }
 function buildCiWorkflowLines(installUrl) {
@@ -24514,7 +24524,9 @@ function buildCiWorkflowLines(installUrl) {
     "    steps:",
     "      - uses: actions/checkout@v4",
     "      - name: Install Postman CLI",
-    `        run: curl -o- "${installUrl}" | sh`,
+    "        env:",
+    `          POSTMAN_CLI_INSTALL_URL: ${installUrl}`,
+    '        run: curl -fsSL "$POSTMAN_CLI_INSTALL_URL" | sh',
     "      - name: Login to Postman CLI",
     "        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}",
     "      - name: Resolve Postman Resource IDs",

--- a/src/lib/ci-workflow-template.ts
+++ b/src/lib/ci-workflow-template.ts
@@ -1,10 +1,21 @@
 export const DEFAULT_POSTMAN_CLI_INSTALL_URL = 'https://dl-cli.pstmn.io/install/unix.sh';
 
+function validateHttpsInstallUrl(url: string): string {
+  const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
+  if (!safeUrlPattern.test(url)) {
+    throw new Error(
+      `postman-cli-install-url must be an https URL with safe characters; got: ${url}`
+    );
+  }
+  return url;
+}
+
 export function renderCiWorkflowTemplate(
   options: { postmanCliInstallUrl?: string } = {}
 ): string {
-  const installUrl =
+  const rawUrl =
     String(options.postmanCliInstallUrl || '').trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
+  const installUrl = validateHttpsInstallUrl(rawUrl);
   return buildCiWorkflowLines(installUrl).join('\n');
 }
 
@@ -24,7 +35,9 @@ function buildCiWorkflowLines(installUrl: string): string[] {
   '    steps:',
   '      - uses: actions/checkout@v4',
   '      - name: Install Postman CLI',
-  `        run: curl -o- "${installUrl}" | sh`,
+  '        env:',
+  `          POSTMAN_CLI_INSTALL_URL: ${installUrl}`,
+  '        run: curl -fsSL "$POSTMAN_CLI_INSTALL_URL" | sh',
   '      - name: Login to Postman CLI',
   '        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}',
   '      - name: Resolve Postman Resource IDs',

--- a/tests/ci-workflow-template.test.ts
+++ b/tests/ci-workflow-template.test.ts
@@ -79,4 +79,90 @@ describe('renderCiWorkflowTemplate', () => {
     expect(stepNames).toContain('Run Smoke Tests');
     expect(stepNames).toContain('Run Contract Tests');
   });
+
+  it('routes install URL via env var, not shell interpolation', () => {
+    const ciWorkflow = renderCiWorkflowTemplate();
+    const parsed = parse(ciWorkflow);
+
+    const installStep = parsed.jobs.test.steps.find(
+      (step: { name?: string }) => step.name === 'Install Postman CLI'
+    );
+
+    expect(installStep).toBeDefined();
+    expect(installStep.env).toHaveProperty('POSTMAN_CLI_INSTALL_URL');
+    expect(installStep.run).toContain('$POSTMAN_CLI_INSTALL_URL');
+    expect(installStep.run).not.toContain('${');
+    expect(installStep.run).not.toContain('curl -o-');
+    expect(installStep.run).toContain('curl -fsSL');
+  });
+
+  it('rejects javascript: pseudo-protocol', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'javascript:alert(1)'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects http:// (non-https)', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'http://dl-cli.pstmn.io/install/unix.sh'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects URLs with shell metacharacters: semicolon', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'https://example.com/install.sh; rm -rf /'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects URLs with shell metacharacters: double quotes', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'https://example.com/install.sh" && rm -rf /'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects URLs with shell metacharacters: backticks', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'https://example.com/install.sh` echo pwned`'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects URLs with command substitution: $()', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'https://example.com/install.sh$(whoami)'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('rejects URLs with pipe characters', () => {
+    expect(() =>
+      renderCiWorkflowTemplate({
+        postmanCliInstallUrl: 'https://example.com/install.sh | cat'
+      })
+    ).toThrow(/must be an https URL with safe characters/);
+  });
+
+  it('accepts valid https URLs with query parameters', () => {
+    const url = 'https://cdn.example.com/path/install.sh?version=1.0&platform=linux';
+    const ciWorkflow = renderCiWorkflowTemplate({
+      postmanCliInstallUrl: url
+    });
+
+    const parsed = parse(ciWorkflow);
+    const installStep = parsed.jobs.test.steps.find(
+      (step: { name?: string }) => step.name === 'Install Postman CLI'
+    );
+
+    expect(installStep.env.POSTMAN_CLI_INSTALL_URL).toBe(url);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes HIGH security finding from [critic-sweep.md](../../pmak-service-account-beta/.omc/critic-sweep.md).

`src/lib/ci-workflow-template.ts` shell-interpolated the install URL into the emitted customer-facing `.github/workflows/ci.yml`. **More durable than the sibling bug in bootstrap** because the injected line persists on the customer's default branch after the action commits it.

### Fix
- New `validateHttpsInstallUrl()` rejects non-https and shell metacharacters at template-generation time (fails fast before writing to the customer repo)
- The emitted workflow now sets `POSTMAN_CLI_INSTALL_URL` as a step-level env var and references `"$POSTMAN_CLI_INSTALL_URL"` in `run:`

Companion PRs: postman-cs/postman-bootstrap-action#<TBD>, postman-cs/postman-api-onboarding-action#<TBD>.

## Test plan
- [x] 9 new tests for env-var routing and validation
- [x] Emitted YAML parses cleanly with yaml.load
- [x] typecheck, lint, test, build, check:dist all clean
