### PR TITLE
docs: revamp marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,13 @@
-# postman-repo-sync-action
+# Postman Repo Sync
 
 [![CI](https://github.com/postman-cs/postman-repo-sync-action/actions/workflows/ci.yml/badge.svg)](https://github.com/postman-cs/postman-repo-sync-action/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/postman-cs/postman-repo-sync-action?sort=semver)](https://github.com/postman-cs/postman-repo-sync-action/releases)
 [![npm](https://img.shields.io/npm/v/%40postman-cse%2Fonboarding-repo-sync)](https://www.npmjs.com/package/@postman-cse/onboarding-repo-sync)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Sync Postman workspace assets into a repository and optionally connect the workspace back to that repository.
+Exports Postman collections and environments into your repository and wires CI, mocks, and monitors around them.
 
-Use this action when a repo should contain the Postman artifacts needed for CI, reviews, and repeatable API test runs:
-
-- Postman Collection v3 multi-file YAML exports under `postman/collections/`.
-- Postman environment exports under `postman/environments/`.
-- `.postman/resources.yaml` with local-to-cloud resource mappings.
-- Optional `.postman/workflows.yaml` spec-to-collection metadata.
-- Optional generated GitHub Actions workflow for Postman CLI smoke and contract runs.
-- Optional mock server, cloud monitor, workspace repository link, and system environment associations.
-
-## Quick Start
+## Usage
 
 ```yaml
 jobs:
@@ -31,16 +22,34 @@ jobs:
       - uses: postman-cs/postman-repo-sync-action@v1
         with:
           project-name: core-payments
-          workspace-id: ws-123
-          baseline-collection-id: col-baseline
-          smoke-collection-id: col-smoke
-          contract-collection-id: col-contract
-          environments-json: '["prod","stage"]'
-          env-runtime-urls-json: '{"prod":"https://api.example.com","stage":"https://stage-api.example.com"}'
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
-          postman-access-token: ${{ secrets.POSTMAN_ACCESS_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+`actions/checkout` must run before this action. `project-name` is the only required input; workspace and collection IDs are resolved from `.postman/resources.yaml` when the repo already carries one.
+
+## Examples
+
+### Full sync with workspace assets
+
+```yaml
+- uses: postman-cs/postman-repo-sync-action@v1
+  with:
+    project-name: core-payments
+    workspace-id: ws-123
+    baseline-collection-id: col-baseline
+    smoke-collection-id: col-smoke
+    contract-collection-id: col-contract
+    environments-json: '["prod","stage"]'
+    env-runtime-urls-json: '{"prod":"https://api.example.com","stage":"https://stage-api.example.com"}'
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-access-token: ${{ secrets.POSTMAN_ACCESS_TOKEN }}
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`postman-access-token` is required for workspace-to-repository linking, system environment association, and API key generation. If it is omitted, those integration steps are skipped and the remaining artifact sync can still run with `postman-api-key`. See [docs/credentials.md](docs/credentials.md).
+
+### Disable CI workflow generation
 
 For existing repositories that already own their CI workflow, disable workflow generation:
 
@@ -49,201 +58,163 @@ with:
   generate-ci-workflow: false
 ```
 
-Or write the generated workflow somewhere other than `.github/workflows/ci.yml`:
+### Custom CI workflow path
+
+Write the generated workflow somewhere other than `.github/workflows/ci.yml`:
 
 ```yaml
 with:
   ci-workflow-path: .github/workflows/postman-sync.yml
 ```
 
-## Requirements
+### Commit-only mode for protected branches
 
-- `actions/checkout` must run before this action.
-- `project-name` is required.
-- Provide a valid `postman-api-key`, or provide `postman-access-token` so the action can generate one.
-- `contents: write` is required when `repo-write-mode` commits files.
-- `actions: write` is required when the action writes workflow files.
-- `gh-fallback-token` is recommended when the default `GITHUB_TOKEN` cannot update workflow files or repository secrets.
+If branch protection requires pull requests, run on a temporary branch with commit-only writes, then create the PR in a later workflow step. Use this for customer-managed PR workflows.
 
-`postman-access-token` is required for workspace-to-repository linking, system environment association, and API key generation. If it is omitted, those integration steps are skipped and the remaining artifact sync can still run with `postman-api-key`.
+```yaml
+with:
+  repo-write-mode: commit-only
+```
 
-## What Gets Written
+`repo-write-mode` options:
 
-The default artifact root is `postman/`. The action ensures these directories exist:
+| Mode | Behavior |
+| --- | --- |
+| `commit-and-push` | Commit generated files and push them back to the current checked out ref. |
+| `commit-only` | Commit generated files without pushing. |
+| `none` | Write files in the workspace only. |
 
-- `postman/collections`
-- `postman/environments`
-- `postman/flows`
-- `postman/globals`
-- `postman/mocks`
-- `postman/specs`
+### Reuse an existing mock server and monitor
 
-Collections are exported as Collection v3 multi-file YAML directories, for example:
+Pass `mock-url` or `monitor-id` to validate and reuse existing assets instead of creating new ones:
+
+```yaml
+with:
+  mock-url: https://abc123.mock.pstmn.io
+  monitor-id: 1e2f3a4b-monitor-id
+```
+
+### mTLS certificates for Postman CLI runs
+
+The generated CI workflow can run Postman CLI with client certificates. Pass the cert material as inputs; when a GitHub token and repository context are available, the action persists them as repository secrets (`POSTMAN_SSL_CLIENT_CERT_B64`, `POSTMAN_SSL_CLIENT_KEY_B64`, `POSTMAN_SSL_CLIENT_PASSPHRASE`, `POSTMAN_SSL_EXTRA_CA_CERTS_B64`) for the generated workflow:
+
+```yaml
+with:
+  ssl-client-cert: ${{ secrets.POSTMAN_SSL_CLIENT_CERT_B64 }}
+  ssl-client-key: ${{ secrets.POSTMAN_SSL_CLIENT_KEY_B64 }}
+  ssl-client-passphrase: ${{ secrets.POSTMAN_SSL_CLIENT_PASSPHRASE }}
+```
+
+## Inputs
+
+<!-- inputs-table:start -->
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `generate-ci-workflow` | Whether to generate the CI workflow file | no | `true` |
+| `ci-workflow-path` | Path to write the generated CI workflow file | no | `.github/workflows/ci.yml` |
+| `project-name` | Service project name used for environment, mock, and monitor naming. | yes |  |
+| `workspace-id` | Postman workspace ID used for workspace-link and export metadata. | no |  |
+| `baseline-collection-id` | Baseline collection ID used for exported artifacts and mock server creation. | no |  |
+| `monitor-type` | Type of monitor to create ("cloud" or "cli"). "cli" will skip cloud monitor creation and rely on the CI workflow. | no | `cloud` |
+| `smoke-collection-id` | Smoke collection ID used for monitor creation. | no |  |
+| `contract-collection-id` | Contract collection ID used for exported artifacts. | no |  |
+| `collection-sync-mode` | Collection sync lifecycle mode (refresh or version). | no | `refresh` |
+| `spec-sync-mode` | Spec sync lifecycle mode (update or version). | no | `update` |
+| `release-label` | Optional release label used for versioned naming. | no |  |
+| `monitor-id` | Existing smoke monitor ID. When set, the action validates and reuses this monitor instead of creating a new one. | no |  |
+| `mock-url` | Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one. | no |  |
+| `monitor-cron` | Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run). | no | `""` |
+| `environments-json` | JSON array of environment slugs to create or update. | no | `["prod"]` |
+| `repo-url` | Explicit repository URL (GitHub or GitLab). Defaults to https://github.com/$GITHUB_REPOSITORY on GitHub Actions, or $CI_PROJECT_URL on GitLab CI, when omitted. | no |  |
+| `integration-backend` | Integration backend for workspace linking and environment sync. | no | `bifrost` |
+| `workspace-link-enabled` | Enable workspace linking. | no | `true` |
+| `environment-sync-enabled` | Enable association of Postman environments to system environments. | no | `true` |
+| `system-env-map-json` | JSON map of environment slug to system environment id. | no | `{}` |
+| `environment-uids-json` | JSON map of environment slug to Postman environment uid. | no | `{}` |
+| `env-runtime-urls-json` | JSON map of environment slug to runtime base URL. | no | `{}` |
+| `artifact-dir` | Root directory for exported Postman artifacts. | no | `postman` |
+| `repo-write-mode` | Repo mutation mode for generated artifacts and workflow files. | no | `commit-and-push` |
+| `current-ref` | Explicit ref override for push-changes when the checkout is detached. | no |  |
+| `committer-name` | Git committer name for sync commits. | no | `Postman CSE` |
+| `committer-email` | Git committer email for sync commits. | no | `help@postman.com` |
+| `postman-api-key` | Postman API key used for environment, mock, and monitor operations. | no |  |
+| `postman-access-token` | Postman access token used for Bifrost and system environment association. | no |  |
+| `credential-preflight` | Credential identity preflight policy. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created; off skips the identity probes entirely (the reactive error guidance still applies). Promotion of the default to enforce is planned once the live e2e legs prove both directions. | no | `warn` |
+| `github-token` | GitHub token used for repo variable persistence and commits. | no |  |
+| `gh-fallback-token` | Fallback token for repository variable APIs and workflow-file pushes. | no |  |
+| `org-mode` | Whether the Postman team uses org-mode. When true, x-entity-team-id header is included in Bifrost proxy calls. Non-org teams must omit this header. | no | `false` |
+| `ci-workflow-base64` | Optional base64-encoded ci.yml content. Defaults to the built-in template. | no |  |
+| `ssl-client-cert` | Base64-encoded PEM client certificate for Postman CLI mTLS runs. | no |  |
+| `ssl-client-key` | Base64-encoded PEM client private key for Postman CLI mTLS runs. | no |  |
+| `ssl-client-passphrase` | Optional passphrase for encrypted ssl-client-key. | no |  |
+| `ssl-extra-ca-certs` | Optional base64-encoded PEM CA certificate bundle for custom trust. | no |  |
+| `spec-id` | Spec UID from bootstrap, persisted into .postman/resources.yaml cloudResources. | no |  |
+| `spec-path` | Optional repo-root-relative path to the local spec file for resources/workflows metadata. | no |  |
+| `postman-stack` | Postman stack profile. | no | `prod` |
+<!-- inputs-table:end -->
+
+## Outputs
+
+<!-- outputs-table:start -->
+| Name | Description |
+| --- | --- |
+| `integration-backend` | Resolved integration backend for the customer preview run. |
+| `resolved-current-ref` | Resolved push target based on current-ref semantics. |
+| `workspace-link-status` | Whether workspace linking succeeded, was skipped, or failed. |
+| `environment-sync-status` | Whether environment sync succeeded, was skipped, or failed. |
+| `environment-uids-json` | JSON map of environment slug to Postman environment uid. |
+| `mock-url` | Created or reused mock server URL. |
+| `monitor-id` | Created or reused smoke monitor ID. |
+| `repo-sync-summary-json` | JSON summary of repo materialization and workspace sync outputs. |
+| `commit-sha` | Commit SHA produced by repo-write-mode, if any. |
+<!-- outputs-table:end -->
+
+## How it works
+
+The action syncs a Postman workspace into the checked-out repository and can connect the workspace back to that repository:
+
+- Postman Collection v3 multi-file YAML exports under `postman/collections/`.
+- Postman environment exports under `postman/environments/`.
+- `.postman/resources.yaml` with local-to-cloud resource mappings.
+- Optional `.postman/workflows.yaml` spec-to-collection metadata.
+- Optional generated GitHub Actions workflow for Postman CLI smoke and contract runs.
+- Optional mock server, cloud monitor, workspace repository link, and system environment associations.
+
+A typical export looks like:
 
 ```text
 postman/collections/[Smoke] core-payments/
   collection.yaml
   <folder>.yaml
   <request>.yaml
+postman/environments/
+  prod.postman_environment.json
+.postman/
+  resources.yaml
 ```
 
-The action also writes `.postman/resources.yaml`. The generated CI workflow reads that file to resolve smoke collection, contract collection, and environment IDs for Postman CLI runs.
+For `commit-and-push`, the push target is resolved from `current-ref`, then `GITHUB_HEAD_REF`, then `GITHUB_REF_NAME`. Pull request merge refs are normalized to the PR head branch.
 
-Long Postman folder and request names are truncated to 120 characters per path segment when files are written.
+Mocks and monitors: when `baseline-collection-id`, `workspace-id`, and at least one environment are available, the action creates or reuses a mock server. When `smoke-collection-id` is also available, it creates or reuses a cloud smoke monitor unless `monitor-type: cli` is set. With an empty `monitor-cron`, a new cloud monitor is created disabled and triggered once per workflow invocation.
 
-When a local OpenAPI spec is found, `.postman/resources.yaml` records it under `localResources.specs`. If `spec-id` and an unambiguous local spec are available, the action also maps the spec under `cloudResources.specs`. When a mapped spec and exported collections are both present, `.postman/workflows.yaml` is written with `syncSpecToCollection` metadata.
+Deeper reference:
 
-## Repository Writes
+- [Artifact layout and Collection v3 format](docs/artifact-layout.md), including sync modes and versioned releases.
+- [Credentials](docs/credentials.md): `postman-api-key`, `postman-access-token`, credential preflight, GitHub tokens.
+- [CLI usage](docs/cli.md): the `postman-repo-sync` binary for GitLab CI, Bitbucket Pipelines, and Azure DevOps.
 
-`repo-write-mode` controls repository mutation:
+## Resources
 
-| Mode | Behavior |
-| --- | --- |
-| `commit-and-push` | Commit generated files and push them back to the current checked out ref. |
-| `commit-only` | Commit generated files without pushing. Use this for customer-managed PR workflows. |
-| `none` | Write files in the workspace only. |
+- [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action): mints a service-account access token and team ID.
+- [postman-api-onboarding-action](https://github.com/postman-cs/postman-api-onboarding-action): composite action that orchestrates the onboarding pipeline.
+- [postman-bootstrap-action](https://github.com/postman-cs/postman-bootstrap-action): workspace provisioning, spec upload, and collection generation.
+- [postman-smoke-flow-action](https://github.com/postman-cs/postman-smoke-flow-action): applies a curated flow.yaml to the Smoke collection.
+- [postman-insights-onboarding-action](https://github.com/postman-cs/postman-insights-onboarding-action): links Postman Insights to a workspace.
+- [postman-aws-spec-discovery-action](https://github.com/postman-cs/postman-aws-spec-discovery-action): discovers API specs in AWS accounts.
+- npm package: [@postman-cse/onboarding-repo-sync](https://www.npmjs.com/package/@postman-cse/onboarding-repo-sync)
+- [Postman API documentation](https://learning.postman.com/docs/developer/postman-api/intro-api/)
+- [Postman CLI](https://learning.postman.com/docs/postman-cli/postman-cli-overview/)
 
-For `commit-and-push`, the push target is resolved from `current-ref`, then `GITHUB_HEAD_REF`, then `GITHUB_REF_NAME`. Pull request merge refs are normalized to the PR head branch. Pushes use `HEAD:refs/heads/<resolved-branch>`.
+## License
 
-If branch protection requires pull requests, run on a temporary branch with `repo-write-mode: commit-only`, then create the PR in a later workflow step.
-
-## Sync Modes
-
-`collection-sync-mode` controls collection lifecycle:
-
-| Mode | Behavior |
-| --- | --- |
-| `refresh` | Refresh exports and rewrite resource mappings for the current ref. |
-| `reuse` | Reuse explicit IDs or IDs already present in `.postman/resources.yaml`. |
-| `version` | Require a release label and suffix exported collection directories, mock names, and monitor names with that label. |
-
-`spec-sync-mode` supports:
-
-| Mode | Behavior |
-| --- | --- |
-| `update` | Keep the current spec mapping updated. |
-| `version` | Require a release label and use versioned metadata. |
-
-If either mode is `version`, provide `release-label` or run on a ref name that can be used as the release label.
-
-## Monitoring And Mocks
-
-When `baseline-collection-id`, `workspace-id`, and at least one environment are available, the action creates or reuses a mock server.
-
-When `smoke-collection-id`, `workspace-id`, and at least one environment are available, the action creates or reuses a cloud smoke monitor unless `monitor-type: cli` is set. If `monitor-cron` is empty, a new cloud monitor is created disabled.
-
-Use `mock-url` or `monitor-id` to force reuse of existing assets.
-
-## mTLS
-
-The generated CI workflow can run Postman CLI with client certificates. Set these GitHub repository secrets:
-
-- `POSTMAN_SSL_CLIENT_CERT_B64`
-- `POSTMAN_SSL_CLIENT_KEY_B64`
-- `POSTMAN_SSL_CLIENT_PASSPHRASE` (optional)
-- `POSTMAN_SSL_EXTRA_CA_CERTS_B64` (optional)
-
-You can also pass the matching action inputs. When `ssl-client-cert` is provided and a GitHub token/repository context is available, the action attempts to persist those values as repository secrets for the generated workflow.
-
-## CLI
-
-The package also ships a `postman-repo-sync` binary for GitLab CI, Bitbucket Pipelines, Azure DevOps, and other CI systems.
-
-```bash
-npm install -g @postman-cse/onboarding-repo-sync
-
-postman-repo-sync \
-  --project-name core-payments \
-  --workspace-id ws-123 \
-  --baseline-collection-id col-baseline \
-  --smoke-collection-id col-smoke \
-  --contract-collection-id col-contract \
-  --postman-api-key "$POSTMAN_API_KEY" \
-  --result-json postman-repo-sync-result.json \
-  --dotenv-path postman-repo-sync.env \
-  --repo-write-mode commit-only
-```
-
-The CLI auto-detects repository URL, branch, and SHA from common CI environment variables. It writes JSON to stdout, writes the same JSON to `--result-json`, and optionally writes shell-sourceable `POSTMAN_REPO_SYNC_*` values to `--dotenv-path`. Logs go to stderr.
-
-## Inputs
-
-| Input | Default | Notes |
-| --- | --- | --- |
-| `project-name` | | Required. Service name used for environments, mock servers, and monitors. |
-| `workspace-id` | | Postman workspace ID. Can be resolved from `.postman/resources.yaml` when available. |
-| `baseline-collection-id` | | Baseline collection exported into the repo and used for mock server creation. |
-| `smoke-collection-id` | | Smoke collection used for monitor creation and generated CI. |
-| `contract-collection-id` | | Contract collection exported into the repo and used for generated CI. |
-| `environments-json` | `["prod"]` | JSON array of environment slugs to create or update. |
-| `env-runtime-urls-json` | `{}` | JSON map of environment slug to runtime base URL. |
-| `environment-uids-json` | `{}` | JSON map of environment slug to existing Postman environment UID. |
-| `system-env-map-json` | `{}` | JSON map of environment slug to system environment ID. |
-| `repo-url` | Auto-detected | Explicit repository URL for workspace linking. Auto-detected from common GitHub, GitLab, Bitbucket, and Azure DevOps CI variables when available. |
-| `artifact-dir` | `postman` | Root directory for exported artifacts. |
-| `repo-write-mode` | `commit-and-push` | `commit-and-push`, `commit-only`, or `none`. |
-| `current-ref` | | Explicit branch/ref override for push target resolution. |
-| `generate-ci-workflow` | `true` | Whether to write the generated CI workflow. |
-| `ci-workflow-path` | `.github/workflows/ci.yml` | Path for the generated CI workflow. |
-| `ci-workflow-base64` | | Base64-encoded workflow content that replaces the built-in template. |
-| `collection-sync-mode` | `refresh` | `refresh`, `reuse`, or `version`. |
-| `spec-sync-mode` | `update` | `update` or `version`. |
-| `release-label` | | Label used for versioned collection/spec sync. |
-| `spec-id` | | Cloud spec UID to persist in `.postman/resources.yaml`. |
-| `spec-path` | | Repo-root-relative local spec path to use for metadata. |
-| `monitor-type` | `cloud` | `cloud` creates/reuses a cloud monitor; `cli` skips cloud monitor creation. |
-| `monitor-id` | | Existing smoke monitor ID to validate and reuse. |
-| `mock-url` | | Existing mock server URL to reuse. |
-| `monitor-cron` | | Cron expression for cloud monitor scheduling. Empty creates a disabled monitor. |
-| `workspace-link-enabled` | `true` | Enable workspace-to-repository linking. Requires `postman-access-token`. |
-| `environment-sync-enabled` | `true` | Enable system environment association. Requires `postman-access-token`. |
-| `integration-backend` | `bifrost` | Backend used for workspace linking and environment association. |
-| `org-mode` | `false` | Include `x-entity-team-id` for org-mode Bifrost calls. |
-| `postman-api-key` | | Postman API key for standard Postman API operations. |
-| `postman-access-token` | | Postman session access token for integration operations and API key generation. |
-| `github-token` | | Token for commits, pushes, workflow updates, and secret persistence. |
-| `gh-fallback-token` | | Preferred fallback token for workflow-file pushes and secret persistence. |
-| `committer-name` | `Postman CSE` | Git committer name for sync commits. |
-| `committer-email` | `help@postman.com` | Git committer email for sync commits. |
-| `ssl-client-cert` | | Base64-encoded PEM client certificate. |
-| `ssl-client-key` | | Base64-encoded PEM private key. Required with `ssl-client-cert`. |
-| `ssl-client-passphrase` | | Optional private-key passphrase. |
-| `ssl-extra-ca-certs` | | Optional base64-encoded PEM CA bundle. |
-
-## Outputs
-
-| Output | Meaning |
-| --- | --- |
-| `integration-backend` | Resolved integration backend. |
-| `resolved-current-ref` | Branch used as the push target for `commit-and-push`. |
-| `workspace-link-status` | `success`, `skipped`, or `failed`. |
-| `environment-sync-status` | `success`, `skipped`, or `failed`. |
-| `environment-uids-json` | JSON map of environment slug to Postman environment UID. |
-| `mock-url` | Created or reused mock server URL. |
-| `monitor-id` | Created or reused smoke monitor ID. |
-| `repo-sync-summary-json` | JSON summary of commit, environment, mock, monitor, push, and integration state. |
-| `commit-sha` | Commit SHA produced by `repo-write-mode`, when a commit is created. |
-
-## Credentials
-
-Create a Postman API key in Postman under **Settings -> Account Settings -> API Keys**, then store it as `POSTMAN_API_KEY`.
-
-The `postman-access-token` value is a session token used for integration APIs that are not covered by PMAK. To obtain it:
-
-```bash
-postman login
-cat ~/.postman/postmanrc | jq -r '.login._profiles[].accessToken'
-```
-
-Store that value as `POSTMAN_ACCESS_TOKEN`. It expires with the Postman session and must be refreshed when integration steps start skipping or failing because of authentication.
-
-## Local Development
-
-```bash
-npm install
-npm test
-npm run typecheck
-npm run build
-```
-
-`npm run build` produces the committed `dist/index.cjs` action bundle used by `action.yml` and `dist/cli.cjs` for the CLI.
+[MIT](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: postman-repo-sync-action
-description: Sync exported Postman artifacts into a repository and expose workspace-link and environment-sync outputs.
+name: Postman Repo Sync
+description: Export Postman collections and environments into your repo and wire CI, mocks, and monitors around them.
 author: Postman
 branding:
   icon: refresh-cw

--- a/docs/artifact-layout.md
+++ b/docs/artifact-layout.md
@@ -1,0 +1,59 @@
+# Artifact Layout and Collection v3 Format
+
+This page covers the full detail of what `postman-cs/postman-repo-sync-action` writes into a repository. The short operational version lives in the [README](../README.md).
+
+## Directory structure
+
+The default artifact root is `postman/`. The action ensures these directories exist:
+
+- `postman/collections`
+- `postman/environments`
+- `postman/flows`
+- `postman/globals`
+- `postman/mocks`
+- `postman/specs`
+
+It also writes `.postman/resources.yaml`, the reusable state file. The generated CI workflow reads that file to resolve smoke collection, contract collection, and environment IDs for Postman CLI runs.
+
+## Collection v3 multi-file YAML
+
+Collections are exported in the Postman Collection v3 format (`$schema: https://schema.postman.com/json/draft-2020-12/collection/v3.0.0/`) as a directory tree rather than a single JSON file. Each collection becomes a directory containing a `collection.yaml` plus one YAML file per folder and per request:
+
+```text
+postman/collections/[Smoke] core-payments/
+  collection.yaml
+  <folder>.yaml
+  <request>.yaml
+```
+
+This layout keeps diffs reviewable: a change to one request shows up as a change to one file. Long Postman folder and request names are truncated to 120 characters per path segment when files are written.
+
+Note that v3 collections are run with `postman collection run` (Postman CLI). Newman cannot execute the v3 format.
+
+## Spec and workflow metadata
+
+When a local OpenAPI spec is found, `.postman/resources.yaml` records it under `localResources.specs`. If `spec-id` and an unambiguous local spec are available, the action also maps the spec under `cloudResources.specs`. When a mapped spec and exported collections are both present, `.postman/workflows.yaml` is written with `syncSpecToCollection` metadata that ties the spec to its generated collections.
+
+## Versioned runs
+
+When `collection-sync-mode` or `spec-sync-mode` is `version`, the action requires a release label (`release-label` input, or a usable ref name) and:
+
+- suffixes exported collection directories, mock names, and monitor names with the label
+- writes `.postman/releases.yaml`, a release manifest with spec and collection UIDs per tag
+
+## Sync mode reference
+
+`collection-sync-mode` controls collection lifecycle:
+
+| Mode | Behavior |
+| --- | --- |
+| `refresh` | Refresh exports and rewrite resource mappings for the current ref. |
+| `reuse` | Reuse explicit IDs or IDs already present in `.postman/resources.yaml`. |
+| `version` | Require a release label and suffix exported collection directories, mock names, and monitor names with that label. |
+
+`spec-sync-mode` supports:
+
+| Mode | Behavior |
+| --- | --- |
+| `update` | Keep the current spec mapping updated. |
+| `version` | Require a release label and use versioned metadata. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,22 @@
+# CLI Usage
+
+The npm package ships a `postman-repo-sync` binary for GitLab CI, Bitbucket Pipelines, Azure DevOps, and other CI systems.
+
+```bash
+npm install -g @postman-cse/onboarding-repo-sync
+
+postman-repo-sync \
+  --project-name core-payments \
+  --workspace-id ws-123 \
+  --baseline-collection-id col-baseline \
+  --smoke-collection-id col-smoke \
+  --contract-collection-id col-contract \
+  --postman-api-key "$POSTMAN_API_KEY" \
+  --result-json postman-repo-sync-result.json \
+  --dotenv-path postman-repo-sync.env \
+  --repo-write-mode commit-only
+```
+
+The CLI auto-detects repository URL, branch, and SHA from common CI environment variables (GitHub, GitLab, Bitbucket, Azure DevOps). It writes JSON to stdout, writes the same JSON to `--result-json`, and optionally writes shell-sourceable `POSTMAN_REPO_SYNC_*` values to `--dotenv-path`. Logs go to stderr.
+
+CLI flags mirror the action inputs (kebab-case, prefixed with `--`). See the Inputs table in the [README](../README.md) for the full list.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,31 @@
+# Credentials
+
+## `postman-api-key`
+
+Create a Postman API key in Postman under **Settings -> Account Settings -> API Keys**, then store it as the `POSTMAN_API_KEY` repository secret. The API key covers standard Postman API operations: environments, mock servers, monitors, and collection export.
+
+## `postman-access-token`
+
+The `postman-access-token` value is a session token used for integration APIs that are not covered by the API key: workspace-to-repository linking, system environment association, and API key generation. To obtain it:
+
+```bash
+postman login
+cat ~/.postman/postmanrc | jq -r '.login._profiles[].accessToken'
+```
+
+Store that value as `POSTMAN_ACCESS_TOKEN`. It expires with the Postman session and must be refreshed when integration steps start skipping or failing because of authentication.
+
+If `postman-access-token` is omitted, the integration steps are skipped and the remaining artifact sync still runs with `postman-api-key` alone. Provide a valid `postman-api-key`, or provide `postman-access-token` so the action can generate one.
+
+## Credential preflight
+
+The `credential-preflight` input controls what happens when `postman-api-key` and `postman-access-token` resolve to different parent organizations:
+
+- `warn` (default) logs a note and continues
+- `enforce` fails the run before any workspace is touched
+- `off` skips the identity probes entirely
+
+## GitHub tokens
+
+- `github-token` handles commits, pushes, workflow updates, and secret persistence. `contents: write` is required when `repo-write-mode` commits files; `actions: write` is required when the action writes workflow files.
+- `gh-fallback-token` is recommended when the default `GITHUB_TOKEN` cannot update workflow files or repository secrets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-repo-sync",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Public customer preview Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/main.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/action.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/cli.cjs",
     "check:dist": "npm run build && git diff --exit-code -- dist",
+    "docs:tables": "node scripts/render-action-tables.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",

--- a/scripts/render-action-tables.mjs
+++ b/scripts/render-action-tables.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Renders the Inputs and Outputs tables in README.md from action.yml.
+// Usage: node scripts/render-action-tables.mjs [--check]
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { argv, exit } from 'node:process';
+import { error as logError } from 'node:console';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const actionPath = resolve(repoRoot, 'action.yml');
+const readmePath = resolve(repoRoot, 'README.md');
+
+const action = parse(readFileSync(actionPath, 'utf8'));
+
+function cell(value) {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+  return String(value).replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim();
+}
+
+function renderInputs(inputs) {
+  const lines = [
+    '| Name | Description | Required | Default |',
+    '| --- | --- | --- | --- |'
+  ];
+  for (const [name, def] of Object.entries(inputs)) {
+    const required = def.required === true ? 'yes' : 'no';
+    const fallback = def.default === undefined ? '' : `\`${cell(def.default) === '' ? '""' : cell(def.default)}\``;
+    lines.push(`| \`${name}\` | ${cell(def.description)} | ${required} | ${fallback} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderOutputs(outputs) {
+  const lines = ['| Name | Description |', '| --- | --- |'];
+  for (const [name, def] of Object.entries(outputs)) {
+    lines.push(`| \`${name}\` | ${cell(def.description)} |`);
+  }
+  return lines.join('\n');
+}
+
+function replaceBlock(content, marker, table) {
+  const start = `<!-- ${marker}:start -->`;
+  const end = `<!-- ${marker}:end -->`;
+  const startIdx = content.indexOf(start);
+  const endIdx = content.indexOf(end);
+  if (startIdx === -1 || endIdx === -1) {
+    throw new Error(`README.md is missing ${start} / ${end} markers`);
+  }
+  return (
+    content.slice(0, startIdx + start.length) +
+    '\n' +
+    table +
+    '\n' +
+    content.slice(endIdx)
+  );
+}
+
+const current = readFileSync(readmePath, 'utf8');
+let next = replaceBlock(current, 'inputs-table', renderInputs(action.inputs ?? {}));
+next = replaceBlock(next, 'outputs-table', renderOutputs(action.outputs ?? {}));
+
+if (argv.includes('--check')) {
+  if (next !== current) {
+    logError('README tables are out of date. Run: npm run docs:tables');
+    exit(1);
+  }
+  logError('README tables are up to date.');
+} else if (next !== current) {
+  writeFileSync(readmePath, next);
+  logError('README tables updated.');
+} else {
+  logError('README tables already up to date.');
+}

--- a/tests/readme-tables.test.ts
+++ b/tests/readme-tables.test.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+describe('README action tables', () => {
+  it('match action.yml (run npm run docs:tables after editing action.yml)', () => {
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [resolve(repoRoot, 'scripts/render-action-tables.mjs'), '--check'],
+        { cwd: repoRoot, stdio: 'pipe' }
+      )
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Revamps the GitHub Marketplace presentation of this action.

- README rebuilt to the marketplace skeleton: tagline, minimal Usage, six Examples, generated Inputs/Outputs tables, How it works, Resources, License.
- Long-form Collection v3 / artifact narrative, credentials guidance, and CLI usage moved to docs/ (linked from README).
- action.yml metadata: name "Postman Repo Sync", benefit-led description.
- scripts/render-action-tables.mjs renders Inputs/Outputs tables from action.yml between README markers; npm run docs:tables regenerates; tests/readme-tables.test.ts gates drift.
- Version bumped to 1.0.1 (no tag).

Validation: npm test (152 passed), typecheck, lint, build, check:dist all green.
