### PR TITLE
fix: retry monitor and mock creation while a new collection becomes visible

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -9182,14 +9182,14 @@ var require_retry_agent = __commonJS({
         this.#options = options;
       }
       dispatch(opts, handler) {
-        const retry = new RetryHandler({
+        const retry2 = new RetryHandler({
           ...opts,
           retryOptions: this.#options
         }, {
           dispatch: this.#agent.dispatch.bind(this.#agent),
           handler
         });
-        return this.#agent.dispatch(opts, retry);
+        return this.#agent.dispatch(opts, retry2);
       }
       close() {
         return this.#agent.close();
@@ -25282,12 +25282,60 @@ var postmanRepoSyncActionContract = {
   }
 };
 
+// src/lib/retry.ts
+function sleep(delayMs) {
+  return new Promise((resolve3) => {
+    setTimeout(resolve3, delayMs);
+  });
+}
+function normalizeRetryOptions(options) {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2e3),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs: options.maxDelayMs === void 0 ? Number.POSITIVE_INFINITY : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => void 0),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep
+  };
+}
+async function retry(operation, options = {}) {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error2) {
+      const shouldRetry = attempt < normalized.maxAttempts && normalized.shouldRetry(error2, {
+        attempt,
+        maxAttempts: normalized.maxAttempts
+      });
+      if (!shouldRetry) {
+        throw error2;
+      }
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error: error2
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+  throw new Error("Retry exhausted without returning or throwing");
+}
+
 // src/lib/postman/postman-assets-client.ts
 var PostmanAssetsClient = class {
   apiKey;
   baseUrl;
   bifrostBaseUrl;
   fetchImpl;
+  retrySleep;
   constructor(options) {
     this.apiKey = String(options.apiKey || "").trim();
     this.baseUrl = String(options.baseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl).replace(
@@ -25298,6 +25346,7 @@ var PostmanAssetsClient = class {
       options.bifrostBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.bifrostBaseUrl
     ).replace(/\/+$/, "");
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.retrySleep = options.retrySleep;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
   getBaseUrl() {
@@ -25361,9 +25410,34 @@ var PostmanAssetsClient = class {
       })
     });
   }
+  /**
+   * Monitor and mock creation reference a collection that may have been
+   * created moments earlier; the Postman backend is eventually consistent
+   * and can reject the reference with a 400 "Unable to load collection"
+   * until the collection becomes visible. Retry that specific 400 plus
+   * generic transient statuses with backoff.
+   */
+  async requestWithCollectionRetry(path8, init) {
+    return retry(() => this.request(path8, init), {
+      maxAttempts: 5,
+      delayMs: 2e3,
+      backoffMultiplier: 2,
+      maxDelayMs: 15e3,
+      ...this.retrySleep ? { sleep: this.retrySleep } : {},
+      shouldRetry: (error2) => {
+        if (!(error2 instanceof HttpError)) {
+          return false;
+        }
+        if (error2.status >= 500 || error2.status === 429) {
+          return true;
+        }
+        return error2.status === 400 && /unable to load collection/i.test(error2.responseBody);
+      }
+    });
+  }
   async createMonitor(workspaceId, name, collectionUid, environmentUid, cronSchedule) {
     const effectiveCron = cronSchedule && cronSchedule.trim() ? cronSchedule.trim() : "0 0 * * 0";
-    const response = await this.request(`/monitors?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/monitors?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         monitor: {
@@ -25393,7 +25467,7 @@ var PostmanAssetsClient = class {
     return uid;
   }
   async createMock(workspaceId, name, collectionUid, environmentUid) {
-    const response = await this.request(`/mocks?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/mocks?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         mock: {

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -9183,14 +9183,14 @@ var require_retry_agent = __commonJS({
         this.#options = options;
       }
       dispatch(opts, handler) {
-        const retry = new RetryHandler({
+        const retry2 = new RetryHandler({
           ...opts,
           retryOptions: this.#options
         }, {
           dispatch: this.#agent.dispatch.bind(this.#agent),
           handler
         });
-        return this.#agent.dispatch(opts, retry);
+        return this.#agent.dispatch(opts, retry2);
       }
       close() {
         return this.#agent.close();
@@ -23385,12 +23385,60 @@ var postmanRepoSyncActionContract = {
   }
 };
 
+// src/lib/retry.ts
+function sleep(delayMs) {
+  return new Promise((resolve2) => {
+    setTimeout(resolve2, delayMs);
+  });
+}
+function normalizeRetryOptions(options) {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2e3),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs: options.maxDelayMs === void 0 ? Number.POSITIVE_INFINITY : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => void 0),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep
+  };
+}
+async function retry(operation, options = {}) {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const shouldRetry = attempt < normalized.maxAttempts && normalized.shouldRetry(error, {
+        attempt,
+        maxAttempts: normalized.maxAttempts
+      });
+      if (!shouldRetry) {
+        throw error;
+      }
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+  throw new Error("Retry exhausted without returning or throwing");
+}
+
 // src/lib/postman/postman-assets-client.ts
 var PostmanAssetsClient = class {
   apiKey;
   baseUrl;
   bifrostBaseUrl;
   fetchImpl;
+  retrySleep;
   constructor(options) {
     this.apiKey = String(options.apiKey || "").trim();
     this.baseUrl = String(options.baseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl).replace(
@@ -23401,6 +23449,7 @@ var PostmanAssetsClient = class {
       options.bifrostBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.bifrostBaseUrl
     ).replace(/\/+$/, "");
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.retrySleep = options.retrySleep;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
   getBaseUrl() {
@@ -23464,9 +23513,34 @@ var PostmanAssetsClient = class {
       })
     });
   }
+  /**
+   * Monitor and mock creation reference a collection that may have been
+   * created moments earlier; the Postman backend is eventually consistent
+   * and can reject the reference with a 400 "Unable to load collection"
+   * until the collection becomes visible. Retry that specific 400 plus
+   * generic transient statuses with backoff.
+   */
+  async requestWithCollectionRetry(path4, init) {
+    return retry(() => this.request(path4, init), {
+      maxAttempts: 5,
+      delayMs: 2e3,
+      backoffMultiplier: 2,
+      maxDelayMs: 15e3,
+      ...this.retrySleep ? { sleep: this.retrySleep } : {},
+      shouldRetry: (error) => {
+        if (!(error instanceof HttpError)) {
+          return false;
+        }
+        if (error.status >= 500 || error.status === 429) {
+          return true;
+        }
+        return error.status === 400 && /unable to load collection/i.test(error.responseBody);
+      }
+    });
+  }
   async createMonitor(workspaceId, name, collectionUid, environmentUid, cronSchedule) {
     const effectiveCron = cronSchedule && cronSchedule.trim() ? cronSchedule.trim() : "0 0 * * 0";
-    const response = await this.request(`/monitors?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/monitors?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         monitor: {
@@ -23496,7 +23570,7 @@ var PostmanAssetsClient = class {
     return uid;
   }
   async createMock(workspaceId, name, collectionUid, environmentUid) {
-    const response = await this.request(`/mocks?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/mocks?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         mock: {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -9183,14 +9183,14 @@ var require_retry_agent = __commonJS({
         this.#options = options;
       }
       dispatch(opts, handler) {
-        const retry = new RetryHandler({
+        const retry2 = new RetryHandler({
           ...opts,
           retryOptions: this.#options
         }, {
           dispatch: this.#agent.dispatch.bind(this.#agent),
           handler
         });
-        return this.#agent.dispatch(opts, retry);
+        return this.#agent.dispatch(opts, retry2);
       }
       close() {
         return this.#agent.close();
@@ -25297,12 +25297,60 @@ var postmanRepoSyncActionContract = {
   }
 };
 
+// src/lib/retry.ts
+function sleep(delayMs) {
+  return new Promise((resolve3) => {
+    setTimeout(resolve3, delayMs);
+  });
+}
+function normalizeRetryOptions(options) {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2e3),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs: options.maxDelayMs === void 0 ? Number.POSITIVE_INFINITY : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => void 0),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep
+  };
+}
+async function retry(operation, options = {}) {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error2) {
+      const shouldRetry = attempt < normalized.maxAttempts && normalized.shouldRetry(error2, {
+        attempt,
+        maxAttempts: normalized.maxAttempts
+      });
+      if (!shouldRetry) {
+        throw error2;
+      }
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error: error2
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+  throw new Error("Retry exhausted without returning or throwing");
+}
+
 // src/lib/postman/postman-assets-client.ts
 var PostmanAssetsClient = class {
   apiKey;
   baseUrl;
   bifrostBaseUrl;
   fetchImpl;
+  retrySleep;
   constructor(options) {
     this.apiKey = String(options.apiKey || "").trim();
     this.baseUrl = String(options.baseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl).replace(
@@ -25313,6 +25361,7 @@ var PostmanAssetsClient = class {
       options.bifrostBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.bifrostBaseUrl
     ).replace(/\/+$/, "");
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.retrySleep = options.retrySleep;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
   getBaseUrl() {
@@ -25376,9 +25425,34 @@ var PostmanAssetsClient = class {
       })
     });
   }
+  /**
+   * Monitor and mock creation reference a collection that may have been
+   * created moments earlier; the Postman backend is eventually consistent
+   * and can reject the reference with a 400 "Unable to load collection"
+   * until the collection becomes visible. Retry that specific 400 plus
+   * generic transient statuses with backoff.
+   */
+  async requestWithCollectionRetry(path8, init) {
+    return retry(() => this.request(path8, init), {
+      maxAttempts: 5,
+      delayMs: 2e3,
+      backoffMultiplier: 2,
+      maxDelayMs: 15e3,
+      ...this.retrySleep ? { sleep: this.retrySleep } : {},
+      shouldRetry: (error2) => {
+        if (!(error2 instanceof HttpError)) {
+          return false;
+        }
+        if (error2.status >= 500 || error2.status === 429) {
+          return true;
+        }
+        return error2.status === 400 && /unable to load collection/i.test(error2.responseBody);
+      }
+    });
+  }
   async createMonitor(workspaceId, name, collectionUid, environmentUid, cronSchedule) {
     const effectiveCron = cronSchedule && cronSchedule.trim() ? cronSchedule.trim() : "0 0 * * 0";
-    const response = await this.request(`/monitors?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/monitors?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         monitor: {
@@ -25408,7 +25482,7 @@ var PostmanAssetsClient = class {
     return uid;
   }
   async createMock(workspaceId, name, collectionUid, environmentUid) {
-    const response = await this.request(`/mocks?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/mocks?workspace=${workspaceId}`, {
       method: "POST",
       body: JSON.stringify({
         mock: {

--- a/src/lib/postman/postman-assets-client.ts
+++ b/src/lib/postman/postman-assets-client.ts
@@ -1,4 +1,5 @@
 import { HttpError } from '../http-error.js';
+import { retry } from '../retry.js';
 import { createSecretMasker, type SecretMasker } from '../secrets.js';
 import { POSTMAN_ENDPOINT_PROFILES } from './base-urls.js';
 
@@ -21,6 +22,7 @@ export interface PostmanAssetsClientOptions {
   baseUrl?: string;
   bifrostBaseUrl?: string;
   fetchImpl?: typeof fetch;
+  retrySleep?: (delayMs: number) => Promise<void>;
   secretMasker?: SecretMasker;
 }
 
@@ -29,6 +31,7 @@ export class PostmanAssetsClient {
   private readonly baseUrl: string;
   private readonly bifrostBaseUrl: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly retrySleep: ((delayMs: number) => Promise<void>) | undefined;
 
   constructor(options: PostmanAssetsClientOptions) {
     this.apiKey = String(options.apiKey || '').trim();
@@ -40,6 +43,7 @@ export class PostmanAssetsClient {
       options.bifrostBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.bifrostBaseUrl
     ).replace(/\/+$/, '');
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.retrySleep = options.retrySleep;
     void (options.secretMasker ?? createSecretMasker([this.apiKey]));
   }
 
@@ -123,6 +127,38 @@ export class PostmanAssetsClient {
     });
   }
 
+
+  /**
+   * Monitor and mock creation reference a collection that may have been
+   * created moments earlier; the Postman backend is eventually consistent
+   * and can reject the reference with a 400 "Unable to load collection"
+   * until the collection becomes visible. Retry that specific 400 plus
+   * generic transient statuses with backoff.
+   */
+  private async requestWithCollectionRetry(
+    path: string,
+    init: RequestInit
+  ): Promise<FetchResult> {
+    return retry(() => this.request(path, init), {
+      maxAttempts: 5,
+      delayMs: 2000,
+      backoffMultiplier: 2,
+      maxDelayMs: 15000,
+      ...(this.retrySleep ? { sleep: this.retrySleep } : {}),
+      shouldRetry: (error) => {
+        if (!(error instanceof HttpError)) {
+          return false;
+        }
+        if (error.status >= 500 || error.status === 429) {
+          return true;
+        }
+        return (
+          error.status === 400 && /unable to load collection/i.test(error.responseBody)
+        );
+      }
+    });
+  }
+
   async createMonitor(
     workspaceId: string,
     name: string,
@@ -131,7 +167,7 @@ export class PostmanAssetsClient {
     cronSchedule?: string
   ): Promise<string> {
     const effectiveCron = cronSchedule && cronSchedule.trim() ? cronSchedule.trim() : '0 0 * * 0';
-    const response = await this.request(`/monitors?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/monitors?workspace=${workspaceId}`, {
       method: 'POST',
       body: JSON.stringify({
         monitor: {
@@ -171,7 +207,7 @@ export class PostmanAssetsClient {
     collectionUid: string,
     environmentUid: string
   ): Promise<{ uid: string; url: string }> {
-    const response = await this.request(`/mocks?workspace=${workspaceId}`, {
+    const response = await this.requestWithCollectionRetry(`/mocks?workspace=${workspaceId}`, {
       method: 'POST',
       body: JSON.stringify({
         mock: {

--- a/tests/postman-assets-client.test.ts
+++ b/tests/postman-assets-client.test.ts
@@ -315,3 +315,79 @@ describe('getMe', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('collection visibility retry', () => {
+  const unableBody = JSON.stringify({
+    error: { name: 'serverError', message: 'Unable to load collection 55002873-b50e3ab4' }
+  });
+
+  it('retries monitor creation when the collection is not yet visible', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(async () => new Response(unableBody, { status: 400, statusText: 'Bad Request' }))
+      .mockImplementationOnce(async () => new Response(unableBody, { status: 400, statusText: 'Bad Request' }))
+      .mockImplementation(async () => jsonResponse({ monitor: { uid: 'mon-1' } }));
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-test',
+      fetchImpl,
+      retrySleep: async () => undefined
+    });
+
+    const uid = await client.createMonitor('ws-1', 'Smoke', 'col-1', 'env-1', '0 0 * * 0');
+    expect(uid).toBe('mon-1');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries mock creation on transient 5xx responses', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('oops', { status: 500, statusText: 'Internal Server Error' }))
+      .mockResolvedValue(jsonResponse({ mock: { uid: 'mock-1', mockUrl: 'https://m.mock.pstmn.io' } }));
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-test',
+      fetchImpl,
+      retrySleep: async () => undefined
+    });
+
+    const mock = await client.createMock('ws-1', 'Mock', 'col-1', 'env-1');
+    expect(mock.uid).toBe('mock-1');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry unrelated 400 responses', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'invalid cron' } }), {
+          status: 400,
+          statusText: 'Bad Request'
+        })
+      );
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-test',
+      fetchImpl,
+      retrySleep: async () => undefined
+    });
+
+    await expect(
+      client.createMonitor('ws-1', 'Smoke', 'col-1', 'env-1', '0 0 * * 0')
+    ).rejects.toThrow('400');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after exhausting attempts when the collection never appears', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => new Response(unableBody, { status: 400, statusText: 'Bad Request' }));
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-test',
+      fetchImpl,
+      retrySleep: async () => undefined
+    });
+
+    await expect(client.createMock('ws-1', 'Mock', 'col-1', 'env-1')).rejects.toThrow(
+      'Unable to load collection'
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
+  });
+});


### PR DESCRIPTION
Postman's backend is eventually consistent: POST /monitors or /mocks referencing a collection created moments earlier can fail with 400 'Unable to load collection'. Wrap both creates in retry (5 attempts, 2s base, x2 backoff, 15s cap) for that 400 plus 5xx/429. Unit tests cover the race, transient 5xx, non-retryable 400s, and exhaustion.