### PR TITLE
fix: retry creates only on collection-visibility 400 and 429

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -25414,8 +25414,10 @@ var PostmanAssetsClient = class {
    * Monitor and mock creation reference a collection that may have been
    * created moments earlier; the Postman backend is eventually consistent
    * and can reject the reference with a 400 "Unable to load collection"
-   * until the collection becomes visible. Retry that specific 400 plus
-   * generic transient statuses with backoff.
+   * until the collection becomes visible. Retry only that specific 400 and
+   * 429 throttling: both guarantee nothing was created. A 5xx on these
+   * non-idempotent creates is ambiguous (the asset may exist server-side),
+   * so it is not retried to avoid duplicate mocks and monitors.
    */
   async requestWithCollectionRetry(path8, init) {
     return retry(() => this.request(path8, init), {
@@ -25428,7 +25430,7 @@ var PostmanAssetsClient = class {
         if (!(error2 instanceof HttpError)) {
           return false;
         }
-        if (error2.status >= 500 || error2.status === 429) {
+        if (error2.status === 429) {
           return true;
         }
         return error2.status === 400 && /unable to load collection/i.test(error2.responseBody);

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -23517,8 +23517,10 @@ var PostmanAssetsClient = class {
    * Monitor and mock creation reference a collection that may have been
    * created moments earlier; the Postman backend is eventually consistent
    * and can reject the reference with a 400 "Unable to load collection"
-   * until the collection becomes visible. Retry that specific 400 plus
-   * generic transient statuses with backoff.
+   * until the collection becomes visible. Retry only that specific 400 and
+   * 429 throttling: both guarantee nothing was created. A 5xx on these
+   * non-idempotent creates is ambiguous (the asset may exist server-side),
+   * so it is not retried to avoid duplicate mocks and monitors.
    */
   async requestWithCollectionRetry(path4, init) {
     return retry(() => this.request(path4, init), {
@@ -23531,7 +23533,7 @@ var PostmanAssetsClient = class {
         if (!(error instanceof HttpError)) {
           return false;
         }
-        if (error.status >= 500 || error.status === 429) {
+        if (error.status === 429) {
           return true;
         }
         return error.status === 400 && /unable to load collection/i.test(error.responseBody);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25429,8 +25429,10 @@ var PostmanAssetsClient = class {
    * Monitor and mock creation reference a collection that may have been
    * created moments earlier; the Postman backend is eventually consistent
    * and can reject the reference with a 400 "Unable to load collection"
-   * until the collection becomes visible. Retry that specific 400 plus
-   * generic transient statuses with backoff.
+   * until the collection becomes visible. Retry only that specific 400 and
+   * 429 throttling: both guarantee nothing was created. A 5xx on these
+   * non-idempotent creates is ambiguous (the asset may exist server-side),
+   * so it is not retried to avoid duplicate mocks and monitors.
    */
   async requestWithCollectionRetry(path8, init) {
     return retry(() => this.request(path8, init), {
@@ -25443,7 +25445,7 @@ var PostmanAssetsClient = class {
         if (!(error2 instanceof HttpError)) {
           return false;
         }
-        if (error2.status >= 500 || error2.status === 429) {
+        if (error2.status === 429) {
           return true;
         }
         return error2.status === 400 && /unable to load collection/i.test(error2.responseBody);

--- a/src/lib/postman/postman-assets-client.ts
+++ b/src/lib/postman/postman-assets-client.ts
@@ -132,8 +132,10 @@ export class PostmanAssetsClient {
    * Monitor and mock creation reference a collection that may have been
    * created moments earlier; the Postman backend is eventually consistent
    * and can reject the reference with a 400 "Unable to load collection"
-   * until the collection becomes visible. Retry that specific 400 plus
-   * generic transient statuses with backoff.
+   * until the collection becomes visible. Retry only that specific 400 and
+   * 429 throttling: both guarantee nothing was created. A 5xx on these
+   * non-idempotent creates is ambiguous (the asset may exist server-side),
+   * so it is not retried to avoid duplicate mocks and monitors.
    */
   private async requestWithCollectionRetry(
     path: string,
@@ -149,7 +151,7 @@ export class PostmanAssetsClient {
         if (!(error instanceof HttpError)) {
           return false;
         }
-        if (error.status >= 500 || error.status === 429) {
+        if (error.status === 429) {
           return true;
         }
         return (

--- a/tests/postman-assets-client.test.ts
+++ b/tests/postman-assets-client.test.ts
@@ -338,11 +338,11 @@ describe('collection visibility retry', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
-  it('retries mock creation on transient 5xx responses', async () => {
+  it('retries mock creation on 429 throttling', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response('oops', { status: 500, statusText: 'Internal Server Error' }))
-      .mockResolvedValue(jsonResponse({ mock: { uid: 'mock-1', mockUrl: 'https://m.mock.pstmn.io' } }));
+      .mockImplementationOnce(async () => new Response('slow down', { status: 429, statusText: 'Too Many Requests' }))
+      .mockImplementation(async () => jsonResponse({ mock: { uid: 'mock-1', mockUrl: 'https://m.mock.pstmn.io' } }));
     const client = new PostmanAssetsClient({
       apiKey: 'pmak-test',
       fetchImpl,
@@ -352,6 +352,20 @@ describe('collection visibility retry', () => {
     const mock = await client.createMock('ws-1', 'Mock', 'col-1', 'env-1');
     expect(mock.uid).toBe('mock-1');
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry ambiguous 5xx responses on non-idempotent creates', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => new Response('oops', { status: 500, statusText: 'Internal Server Error' }));
+    const client = new PostmanAssetsClient({
+      apiKey: 'pmak-test',
+      fetchImpl,
+      retrySleep: async () => undefined
+    });
+
+    await expect(client.createMock('ws-1', 'Mock', 'col-1', 'env-1')).rejects.toThrow('500');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('does not retry unrelated 400 responses', async () => {


### PR DESCRIPTION
Codex review follow-up on #44: a 5xx on POST /monitors or /mocks is ambiguous because the asset may have been created server-side before the response failed, so retrying can duplicate mocks and monitors. Narrow the retry predicate to the 400 'Unable to load collection' visibility race and 429 throttling, both of which guarantee nothing was created. Tests updated accordingly.