### PR TITLE
ci: skip commitlint body rules for dependabot commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,4 +3,7 @@ export default {
   rules: {
     'header-max-length': [2, 'always', 100],
   },
+  // Dependabot writes release-note bodies that exceed body-max-line-length;
+  // its messages are machine-generated, so linting them only blocks merges.
+  ignores: [(message) => message.includes('Signed-off-by: dependabot[bot]')],
 };


### PR DESCRIPTION
Dependabot release-note bodies exceed body-max-line-length on every PR, so the commitlint job structurally blocks all dependency updates (currently failing on #37, #38, #39, #40, #41). Ignore messages signed by dependabot; human commits still lint.

Verified locally: a dependabot-signed message passes, an over-long human body still fails.