### PR TITLE
fix: mask percent-encoded secret variants in redaction

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -24203,19 +24203,30 @@ var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
 function isIterable(value) {
   return value !== null && value !== void 0 && typeof value !== "string" && typeof value[Symbol.iterator] === "function";
 }
+function appendStringSecret(value, results) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return;
+  }
+  results.push(normalized);
+  try {
+    const encoded = encodeURIComponent(normalized);
+    if (encoded !== normalized) {
+      results.push(encoded);
+    }
+  } catch {
+  }
+}
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {
     return;
   }
   if (typeof value === "string") {
-    const normalized = value.trim();
-    if (normalized) {
-      results.push(normalized);
-    }
+    appendStringSecret(value, results);
     return;
   }
   if (typeof value === "number" || typeof value === "boolean") {
-    results.push(String(value));
+    appendStringSecret(String(value), results);
     return;
   }
   if (Array.isArray(value) || isIterable(value)) {

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -23992,6 +23992,14 @@ function appendStringSecret(value, results) {
     }
   } catch {
   }
+  try {
+    const url = new URL("http://localhost/");
+    url.password = normalized;
+    if (url.password && url.password !== normalized) {
+      results.push(url.password);
+    }
+  } catch {
+  }
 }
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -22306,19 +22306,30 @@ var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
 function isIterable(value) {
   return value !== null && value !== void 0 && typeof value !== "string" && typeof value[Symbol.iterator] === "function";
 }
+function appendStringSecret(value, results) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return;
+  }
+  results.push(normalized);
+  try {
+    const encoded = encodeURIComponent(normalized);
+    if (encoded !== normalized) {
+      results.push(encoded);
+    }
+  } catch {
+  }
+}
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {
     return;
   }
   if (typeof value === "string") {
-    const normalized = value.trim();
-    if (normalized) {
-      results.push(normalized);
-    }
+    appendStringSecret(value, results);
     return;
   }
   if (typeof value === "number" || typeof value === "boolean") {
-    results.push(String(value));
+    appendStringSecret(String(value), results);
     return;
   }
   if (Array.isArray(value) || isIterable(value)) {

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -22095,6 +22095,14 @@ function appendStringSecret(value, results) {
     }
   } catch {
   }
+  try {
+    const url = new URL("http://localhost/");
+    url.password = normalized;
+    if (url.password && url.password !== normalized) {
+      results.push(url.password);
+    }
+  } catch {
+  }
 }
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24218,19 +24218,30 @@ var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
 function isIterable(value) {
   return value !== null && value !== void 0 && typeof value !== "string" && typeof value[Symbol.iterator] === "function";
 }
+function appendStringSecret(value, results) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return;
+  }
+  results.push(normalized);
+  try {
+    const encoded = encodeURIComponent(normalized);
+    if (encoded !== normalized) {
+      results.push(encoded);
+    }
+  } catch {
+  }
+}
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {
     return;
   }
   if (typeof value === "string") {
-    const normalized = value.trim();
-    if (normalized) {
-      results.push(normalized);
-    }
+    appendStringSecret(value, results);
     return;
   }
   if (typeof value === "number" || typeof value === "boolean") {
-    results.push(String(value));
+    appendStringSecret(String(value), results);
     return;
   }
   if (Array.isArray(value) || isIterable(value)) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -24007,6 +24007,14 @@ function appendStringSecret(value, results) {
     }
   } catch {
   }
+  try {
+    const url = new URL("http://localhost/");
+    url.password = normalized;
+    if (url.password && url.password !== normalized) {
+      results.push(url.password);
+    }
+  } catch {
+  }
 }
 function appendSecretValues(value, results) {
   if (value === null || value === void 0) {

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -23,19 +23,32 @@ function isIterable(value: unknown): value is Iterable<unknown> {
   );
 }
 
+function appendStringSecret(value: string, results: string[]): void {
+  const normalized = value.trim();
+  if (!normalized) {
+    return;
+  }
+  results.push(normalized);
+  try {
+    const encoded = encodeURIComponent(normalized);
+    if (encoded !== normalized) {
+      results.push(encoded);
+    }
+  } catch {
+    // Ignore malformed surrogate pairs; the raw value is still registered.
+  }
+}
+
 function appendSecretValues(value: unknown, results: string[]): void {
   if (value === null || value === undefined) {
     return;
   }
   if (typeof value === 'string') {
-    const normalized = value.trim();
-    if (normalized) {
-      results.push(normalized);
-    }
+    appendStringSecret(value, results);
     return;
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
-    results.push(String(value));
+    appendStringSecret(String(value), results);
     return;
   }
   if (Array.isArray(value) || isIterable(value)) {

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -37,6 +37,19 @@ function appendStringSecret(value: string, results: string[]): void {
   } catch {
     // Ignore malformed surrogate pairs; the raw value is still registered.
   }
+  try {
+    // WHATWG URL serialization percent-encodes userinfo with a narrower set than
+    // encodeURIComponent (for example it leaves "+" intact), so a credentialed
+    // remote URL produced through the URL API can surface a mixed-encoding token
+    // form that neither the raw nor the fully-encoded variant matches.
+    const url = new URL('http://localhost/');
+    url.password = normalized;
+    if (url.password && url.password !== normalized) {
+      results.push(url.password);
+    }
+  } catch {
+    // Ignore values the URL parser rejects; other variants remain registered.
+  }
 }
 
 function appendSecretValues(value: unknown, results: string[]): void {

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -32,6 +32,27 @@ describe('secret safety rails', () => {
     expect(sanitized).toBe(`Authorization: Bearer ${REDACTED} and key ${REDACTED}`);
   });
 
+  it('redacts percent-encoded variants of secrets embedded in URLs', () => {
+    const token = 'pat with/special+chars&unsafe';
+    const encoded = encodeURIComponent(token);
+    const sanitized = redactSecrets(
+      `push failed for https://user:${encoded}@dev.azure.com/org/repo and raw ${token}`,
+      [token]
+    );
+
+    expect(sanitized).not.toContain(token);
+    expect(sanitized).not.toContain(encoded);
+    expect(sanitized).toBe(
+      `push failed for https://user:${REDACTED}@dev.azure.com/org/repo and raw ${REDACTED}`
+    );
+  });
+
+  it('leaves secrets without encodable characters registered once', () => {
+    const sanitized = redactSecrets('plain token-abc here', ['token-abc']);
+
+    expect(sanitized).toBe(`plain ${REDACTED} here`);
+  });
+
   it('sanitizes headers before surfacing them', () => {
     const headers = sanitizeHeaders(
       {

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -47,6 +47,28 @@ describe('secret safety rails', () => {
     );
   });
 
+  it('redacts URL-serialized (userinfo) token variants in remote URLs', () => {
+    const token = 'pat/abc+def';
+    const url = new URL('http://localhost/');
+    url.password = token;
+    const userinfoForm = url.password;
+
+    // The mixed form keeps "+" literal while encoding "/", so it matches neither
+    // the raw token nor its encodeURIComponent variant.
+    expect(userinfoForm).not.toBe(token);
+    expect(userinfoForm).not.toBe(encodeURIComponent(token));
+
+    const sanitized = redactSecrets(
+      `remote: rejected https://x-access-token:${userinfoForm}@github.com/org/repo.git`,
+      [token]
+    );
+
+    expect(sanitized).not.toContain(userinfoForm);
+    expect(sanitized).toBe(
+      `remote: rejected https://x-access-token:${REDACTED}@github.com/org/repo.git`
+    );
+  });
+
   it('leaves secrets without encodable characters registered once', () => {
     const sanitized = redactSecrets('plain token-abc here', ['token-abc']);
 


### PR DESCRIPTION
Tokens get percent-encoded when embedded in authenticated remote URLs (git push auth), so the raw-only masker left a leak window in push error output: the encoded form of the secret passed through redaction untouched.

Register the `encodeURIComponent` variant of every string secret alongside the raw value. Masker change lifted from @andrewpostymt's #29 (see review discussion there); tests covering the encoded-URL leak added here. Landing standalone since the leak exists on main regardless of the ADO work.

- `npm test` 159 passed
- dist rebuilt