### PR TITLE
fix: harden repo sync stage paths

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -1068,14 +1068,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path8 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path9 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path8 && path8[0] !== "/") {
-          path8 = `/${path8}`;
+        if (path9 && path9[0] !== "/") {
+          path9 = `/${path9}`;
         }
-        return new URL(`${origin}${path8}`);
+        return new URL(`${origin}${path9}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1526,39 +1526,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin }
+          request: { method, path: path9, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path8);
+        debuglog("sending request to %s %s/%s", method, origin, path9);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin },
+          request: { method, path: path9, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path8,
+          path9,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin }
+          request: { method, path: path9, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path8);
+        debuglog("trailers received from %s %s/%s", method, origin, path9);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin },
+          request: { method, path: path9, origin },
           error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path8,
+          path9,
           error2.message
         );
       });
@@ -1607,9 +1607,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path8, origin }
+            request: { method, path: path9, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path8);
+          debuglog("sending request to %s %s/%s", method, origin, path9);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1672,7 +1672,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path8,
+        path: path9,
         method,
         body,
         headers,
@@ -1687,11 +1687,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path8 !== "string") {
+        if (typeof path9 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path8[0] !== "/" && !(path8.startsWith("http://") || path8.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path9[0] !== "/" && !(path9.startsWith("http://") || path9.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path8)) {
+        } else if (invalidPathRegex.test(path9)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1757,7 +1757,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path8, query) : path8;
+        this.path = query ? buildURL(path9, query) : path9;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6321,7 +6321,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request) {
-      const { method, path: path8, host, upgrade, blocking, reset } = request;
+      const { method, path: path9, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util.isFormDataLike(body)) {
@@ -6387,7 +6387,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path8} HTTP/1.1\r
+      let header = `${method} ${path9} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -6913,7 +6913,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path: path8, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path9, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -6980,7 +6980,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path8;
+      headers[HTTP2_HEADER_PATH] = path9;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7333,9 +7333,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path8 = search ? `${pathname}${search}` : pathname;
+        const path9 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path8;
+        this.opts.path = path9;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8570,10 +8570,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path8 = "/",
+          path: path9 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path8;
+        opts.path = origin + path9;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10494,20 +10494,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path8) {
-      if (typeof path8 !== "string") {
-        return path8;
+    function safeUrl(path9) {
+      if (typeof path9 !== "string") {
+        return path9;
       }
-      const pathSegments = path8.split("?");
+      const pathSegments = path9.split("?");
       if (pathSegments.length !== 2) {
-        return path8;
+        return path9;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path8, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path8);
+    function matchKey(mockDispatch2, { path: path9, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path9);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10529,7 +10529,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path8 }) => matchValue(safeUrl(path8), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path9 }) => matchValue(safeUrl(path9), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10567,9 +10567,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path8, method, body, headers, query } = opts;
+      const { path: path9, method, body, headers, query } = opts;
       return {
-        path: path8,
+        path: path9,
         method,
         body,
         headers,
@@ -11032,10 +11032,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path8, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path9, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path8,
+            Path: path9,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -15916,9 +15916,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path8) {
-      for (let i = 0; i < path8.length; ++i) {
-        const code = path8.charCodeAt(i);
+    function validateCookiePath(path9) {
+      for (let i = 0; i < path9.length; ++i) {
+        const code = path9.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18595,11 +18595,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path8 = opts.path;
+          let path9 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path8 = `/${path8}`;
+            path9 = `/${path9}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path8);
+          url = new URL(util.parseOrigin(url).origin + path9);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -20950,7 +20950,7 @@ function getIDToken(aud) {
 
 // src/index.ts
 var import_node_fs = require("node:fs");
-var path7 = __toESM(require("node:path"), 1);
+var path8 = __toESM(require("node:path"), 1);
 
 // node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
@@ -24190,6 +24190,9 @@ function buildCiWorkflowLines(installUrl) {
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
+// src/lib/github/repo-mutation.ts
+var import_node_path = __toESM(require("node:path"), 1);
+
 // src/lib/secrets.ts
 var REDACTED = "[REDACTED]";
 var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
@@ -24297,6 +24300,31 @@ function resolveCurrentRef(context) {
   }
   return normalizeBranchRef(currentRef) || normalizeBranchRef(context.githubHeadRef) || normalizeBranchRef(context.githubRefName);
 }
+function hasControlCharacter(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
+function normalizeStagePaths(stagePaths) {
+  const normalized = [];
+  for (const entry of stagePaths) {
+    const rawPath = String(entry || "");
+    const stagePath = rawPath.trim();
+    if (!stagePath) {
+      continue;
+    }
+    const segments = stagePath.split(/[\\/]+/).filter(Boolean);
+    if (hasControlCharacter(rawPath) || import_node_path.default.isAbsolute(stagePath) || import_node_path.default.win32.isAbsolute(stagePath) || segments.includes("..") || stagePath.startsWith(":") || hasControlCharacter(stagePath)) {
+      throw new Error(`Unsafe git stage path: ${stagePath}`);
+    }
+    normalized.push(stagePath);
+  }
+  return normalized;
+}
 var RepoMutationService = class {
   execute;
   repository;
@@ -24308,14 +24336,22 @@ var RepoMutationService = class {
   }
   async commitAndPush(options) {
     const resolvedCurrentRef = resolveCurrentRef(options);
+    const stagePaths = normalizeStagePaths(options.stagePaths);
     const tokens = buildPushTokenOrder({
       fallbackToken: options.fallbackToken,
       githubToken: options.githubToken
     });
     const secretMasker = createSecretMasker(tokens);
+    if (stagePaths.length === 0) {
+      return {
+        commitSha: "",
+        pushed: false,
+        resolvedCurrentRef
+      };
+    }
     await this.execute("git", ["config", "user.name", options.committerName]);
     await this.execute("git", ["config", "user.email", options.committerEmail]);
-    await this.execute("git", ["add", "-A", "--", ...options.stagePaths]);
+    await this.execute("git", ["add", "-A", "--", ...stagePaths]);
     const staged = await this.execute("git", ["diff", "--cached", "--quiet"]);
     if (staged.exitCode === 0) {
       return {
@@ -24401,8 +24437,8 @@ function normalizeRepoUrl(url) {
   const sshMatch = raw.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch) {
     const host = sshMatch[1];
-    const path8 = sshMatch[2];
-    return `https://${host}/${path8}`;
+    const path9 = sshMatch[2];
+    return `https://${host}/${path9}`;
   }
   return raw.replace(/\.git$/, "");
 }
@@ -25355,8 +25391,8 @@ var PostmanAssetsClient = class {
   getBifrostBaseUrl() {
     return this.bifrostBaseUrl;
   }
-  async request(path8, init = {}) {
-    const url = path8.startsWith("http") ? path8 : `${this.baseUrl}${path8}`;
+  async request(path9, init = {}) {
+    const url = path9.startsWith("http") ? path9 : `${this.baseUrl}${path9}`;
     const response = await this.fetchImpl(url, {
       ...init,
       headers: {
@@ -25419,8 +25455,8 @@ var PostmanAssetsClient = class {
    * non-idempotent creates is ambiguous (the asset may exist server-side),
    * so it is not retried to avoid duplicate mocks and monitors.
    */
-  async requestWithCollectionRetry(path8, init) {
-    return retry(() => this.request(path8, init), {
+  async requestWithCollectionRetry(path9, init) {
+    return retry(() => this.request(path9, init), {
       maxAttempts: 5,
       delayMs: 2e3,
       backoffMultiplier: 2,
@@ -25820,7 +25856,7 @@ function getEnvironmentUidsFromResources(resourcesState) {
   );
 }
 function normalizeToPosix(filePath) {
-  return filePath.split(path7.sep).join("/");
+  return filePath.split(path8.sep).join("/");
 }
 function isOpenApiSpecFile(filePath) {
   if (!(filePath.endsWith(".json") || filePath.endsWith(".yaml") || filePath.endsWith(".yml"))) {
@@ -25860,7 +25896,7 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (ignoredDirs.has(entry.name)) {
         continue;
       }
-      const fullPath = path7.join(currentDir, entry.name);
+      const fullPath = path8.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         visit(fullPath);
         continue;
@@ -25868,14 +25904,14 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (!entry.isFile() || !isOpenApiSpecFile(fullPath)) {
         continue;
       }
-      const repoRelativePath = normalizeToPosix(path7.relative(baseDir, fullPath));
+      const repoRelativePath = normalizeToPosix(path8.relative(baseDir, fullPath));
       if (found.has(repoRelativePath)) {
         continue;
       }
       found.add(repoRelativePath);
       refs.push({
         repoRelativePath,
-        configRelativePath: normalizeToPosix(path7.join("..", repoRelativePath))
+        configRelativePath: normalizeToPosix(path8.join("..", repoRelativePath))
       });
     }
   };
@@ -25885,11 +25921,11 @@ function scanLocalSpecReferences(baseDir = ".") {
 function resolveMappedSpecReference(explicitSpecPath, discoveredSpecs) {
   const normalizedExplicitPath = normalizeToPosix(explicitSpecPath.trim());
   if (normalizedExplicitPath) {
-    const explicitFullPath = path7.resolve(normalizedExplicitPath);
+    const explicitFullPath = path8.resolve(normalizedExplicitPath);
     if ((0, import_node_fs.existsSync)(explicitFullPath) && (0, import_node_fs.statSync)(explicitFullPath).isFile()) {
       return {
         repoRelativePath: normalizedExplicitPath,
-        configRelativePath: normalizeToPosix(path7.join("..", normalizedExplicitPath))
+        configRelativePath: normalizeToPosix(path8.join("..", normalizedExplicitPath))
       };
     }
   }
@@ -26084,8 +26120,8 @@ async function upsertEnvironments(inputs, dependencies, resourcesState) {
   }
   return envUids;
 }
-function ensureDir(path8) {
-  (0, import_node_fs.mkdirSync)(path8, { recursive: true });
+function ensureDir(path9) {
+  (0, import_node_fs.mkdirSync)(path9, { recursive: true });
 }
 function getCollectionDirectoryName(kind, projectName) {
   return `[${kind}] ${projectName}`;
@@ -26117,9 +26153,9 @@ function stripVolatileFields(obj) {
   }
   return obj;
 }
-function writeJsonFile(path8, content, normalize2 = false) {
+function writeJsonFile(path9, content, normalize2 = false) {
   const data = normalize2 ? stripVolatileFields(content) : content;
-  (0, import_node_fs.writeFileSync)(path8, JSON.stringify(data, null, 2));
+  (0, import_node_fs.writeFileSync)(path9, JSON.stringify(data, null, 2));
 }
 function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
@@ -26177,11 +26213,39 @@ function buildSpecCollectionWorkflowManifest(specRef, collectionRefs) {
     }
   );
 }
+function hasControlCharacter2(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
 function assertPathWithinCwd(targetPath, fieldName) {
-  const base = path7.resolve(".");
-  const resolved = path7.resolve(base, targetPath);
-  const relative3 = path7.relative(base, resolved);
-  if (relative3.startsWith("..") || path7.isAbsolute(relative3)) {
+  const originalPath = String(targetPath || "");
+  const rawPath = originalPath.trim();
+  const segments = rawPath.split(/[\\/]+/).filter(Boolean);
+  if (!rawPath || hasControlCharacter2(originalPath) || path8.isAbsolute(rawPath) || path8.win32.isAbsolute(rawPath) || segments.includes("..") || rawPath.startsWith(":") || hasControlCharacter2(rawPath)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  const base = (0, import_node_fs.realpathSync)(process.cwd());
+  const resolved = path8.resolve(base, rawPath);
+  const relative3 = path8.relative(base, resolved);
+  if (relative3.startsWith("..") || path8.isAbsolute(relative3)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  let existingPath = resolved;
+  while (!(0, import_node_fs.existsSync)(existingPath)) {
+    const parent = path8.dirname(existingPath);
+    if (parent === existingPath) {
+      break;
+    }
+    existingPath = parent;
+  }
+  const realExistingPath = (0, import_node_fs.realpathSync)(existingPath);
+  const realRelative = path8.relative(base, realExistingPath);
+  if (realRelative.startsWith("..") || path8.isAbsolute(realRelative)) {
     throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
   }
 }
@@ -26309,7 +26373,19 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     provisionExists ? ".github/workflows/provision.yml" : null
   ].filter((entry) => typeof entry === "string" && ((0, import_node_fs.existsSync)(entry) || entry === ".github/workflows/provision.yml"));
-  const effectiveStagePaths = stagePaths.length > 0 ? stagePaths : ["."];
+  if (stagePaths.length === 0) {
+    dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
+    return {
+      commitSha: "",
+      pushed: false,
+      resolvedCurrentRef: resolveCurrentRef({
+        currentRef: inputs.currentRef,
+        githubHeadRef: inputs.githubHeadRef,
+        githubRefName: inputs.githubRefName,
+        repoWriteMode: inputs.repoWriteMode
+      })
+    };
+  }
   const result = await dependencies.repoMutation.commitAndPush({
     repoWriteMode: inputs.repoWriteMode,
     currentRef: inputs.currentRef,
@@ -26319,7 +26395,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     committerEmail: inputs.committerEmail,
     githubToken: inputs.githubToken,
     fallbackToken: inputs.ghFallbackToken,
-    stagePaths: effectiveStagePaths
+    stagePaths
   });
   return {
     commitSha: result.commitSha,

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -1069,14 +1069,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path5 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path4 && path4[0] !== "/") {
-          path4 = `/${path4}`;
+        if (path5 && path5[0] !== "/") {
+          path5 = `/${path5}`;
         }
-        return new URL(`${origin}${path4}`);
+        return new URL(`${origin}${path5}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1527,39 +1527,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path4, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path4);
+        debuglog("sending request to %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path4, origin },
+          request: { method, path: path5, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path4,
+          path5,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path4, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path4);
+        debuglog("trailers received from %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path4, origin },
+          request: { method, path: path5, origin },
           error
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path4,
+          path5,
           error.message
         );
       });
@@ -1608,9 +1608,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path4, origin }
+            request: { method, path: path5, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path4);
+          debuglog("sending request to %s %s/%s", method, origin, path5);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1673,7 +1673,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path4,
+        path: path5,
         method,
         body,
         headers,
@@ -1688,11 +1688,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path4 !== "string") {
+        if (typeof path5 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path5[0] !== "/" && !(path5.startsWith("http://") || path5.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path4)) {
+        } else if (invalidPathRegex.test(path5)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1758,7 +1758,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path4, query) : path4;
+        this.path = query ? buildURL(path5, query) : path5;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6322,7 +6322,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request) {
-      const { method, path: path4, host, upgrade, blocking, reset } = request;
+      const { method, path: path5, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util.isFormDataLike(body)) {
@@ -6388,7 +6388,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path4} HTTP/1.1\r
+      let header = `${method} ${path5} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -6914,7 +6914,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path5, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -6981,7 +6981,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path4;
+      headers[HTTP2_HEADER_PATH] = path5;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7334,9 +7334,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path4 = search ? `${pathname}${search}` : pathname;
+        const path5 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path4;
+        this.opts.path = path5;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8571,10 +8571,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path4 = "/",
+          path: path5 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path4;
+        opts.path = origin + path5;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10495,20 +10495,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path4) {
-      if (typeof path4 !== "string") {
-        return path4;
+    function safeUrl(path5) {
+      if (typeof path5 !== "string") {
+        return path5;
       }
-      const pathSegments = path4.split("?");
+      const pathSegments = path5.split("?");
       if (pathSegments.length !== 2) {
-        return path4;
+        return path5;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path4);
+    function matchKey(mockDispatch2, { path: path5, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path5);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10530,7 +10530,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path5 }) => matchValue(safeUrl(path5), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10568,9 +10568,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path4, method, body, headers, query } = opts;
+      const { path: path5, method, body, headers, query } = opts;
       return {
-        path: path4,
+        path: path5,
         method,
         body,
         headers,
@@ -11033,10 +11033,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path5, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path4,
+            Path: path5,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -15917,9 +15917,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path4) {
-      for (let i = 0; i < path4.length; ++i) {
-        const code = path4.charCodeAt(i);
+    function validateCookiePath(path5) {
+      for (let i = 0; i < path5.length; ++i) {
+        const code = path5.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18596,11 +18596,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path4 = opts.path;
+          let path5 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path4 = `/${path4}`;
+            path5 = `/${path5}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path4);
+          url = new URL(util.parseOrigin(url).origin + path5);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -18686,7 +18686,7 @@ module.exports = __toCommonJS(cli_exports);
 var import_node_child_process = require("node:child_process");
 var import_node_fs2 = require("node:fs");
 var import_promises = require("node:fs/promises");
-var import_node_path = __toESM(require("node:path"), 1);
+var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_util = require("node:util");
 
 // node_modules/@actions/http-client/lib/index.js
@@ -19053,7 +19053,7 @@ var ExitCode;
 
 // src/index.ts
 var import_node_fs = require("node:fs");
-var path2 = __toESM(require("node:path"), 1);
+var path3 = __toESM(require("node:path"), 1);
 
 // node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
@@ -22293,6 +22293,9 @@ function buildCiWorkflowLines(installUrl) {
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
+// src/lib/github/repo-mutation.ts
+var import_node_path = __toESM(require("node:path"), 1);
+
 // src/lib/secrets.ts
 var REDACTED = "[REDACTED]";
 var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
@@ -22400,6 +22403,31 @@ function resolveCurrentRef(context) {
   }
   return normalizeBranchRef(currentRef) || normalizeBranchRef(context.githubHeadRef) || normalizeBranchRef(context.githubRefName);
 }
+function hasControlCharacter(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
+function normalizeStagePaths(stagePaths) {
+  const normalized = [];
+  for (const entry of stagePaths) {
+    const rawPath = String(entry || "");
+    const stagePath = rawPath.trim();
+    if (!stagePath) {
+      continue;
+    }
+    const segments = stagePath.split(/[\\/]+/).filter(Boolean);
+    if (hasControlCharacter(rawPath) || import_node_path.default.isAbsolute(stagePath) || import_node_path.default.win32.isAbsolute(stagePath) || segments.includes("..") || stagePath.startsWith(":") || hasControlCharacter(stagePath)) {
+      throw new Error(`Unsafe git stage path: ${stagePath}`);
+    }
+    normalized.push(stagePath);
+  }
+  return normalized;
+}
 var RepoMutationService = class {
   execute;
   repository;
@@ -22411,14 +22439,22 @@ var RepoMutationService = class {
   }
   async commitAndPush(options) {
     const resolvedCurrentRef = resolveCurrentRef(options);
+    const stagePaths = normalizeStagePaths(options.stagePaths);
     const tokens = buildPushTokenOrder({
       fallbackToken: options.fallbackToken,
       githubToken: options.githubToken
     });
     const secretMasker = createSecretMasker(tokens);
+    if (stagePaths.length === 0) {
+      return {
+        commitSha: "",
+        pushed: false,
+        resolvedCurrentRef
+      };
+    }
     await this.execute("git", ["config", "user.name", options.committerName]);
     await this.execute("git", ["config", "user.email", options.committerEmail]);
-    await this.execute("git", ["add", "-A", "--", ...options.stagePaths]);
+    await this.execute("git", ["add", "-A", "--", ...stagePaths]);
     const staged = await this.execute("git", ["diff", "--cached", "--quiet"]);
     if (staged.exitCode === 0) {
       return {
@@ -22504,8 +22540,8 @@ function normalizeRepoUrl(url) {
   const sshMatch = raw.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch) {
     const host = sshMatch[1];
-    const path4 = sshMatch[2];
-    return `https://${host}/${path4}`;
+    const path5 = sshMatch[2];
+    return `https://${host}/${path5}`;
   }
   return raw.replace(/\.git$/, "");
 }
@@ -23458,8 +23494,8 @@ var PostmanAssetsClient = class {
   getBifrostBaseUrl() {
     return this.bifrostBaseUrl;
   }
-  async request(path4, init = {}) {
-    const url = path4.startsWith("http") ? path4 : `${this.baseUrl}${path4}`;
+  async request(path5, init = {}) {
+    const url = path5.startsWith("http") ? path5 : `${this.baseUrl}${path5}`;
     const response = await this.fetchImpl(url, {
       ...init,
       headers: {
@@ -23522,8 +23558,8 @@ var PostmanAssetsClient = class {
    * non-idempotent creates is ambiguous (the asset may exist server-side),
    * so it is not retried to avoid duplicate mocks and monitors.
    */
-  async requestWithCollectionRetry(path4, init) {
-    return retry(() => this.request(path4, init), {
+  async requestWithCollectionRetry(path5, init) {
+    return retry(() => this.request(path5, init), {
       maxAttempts: 5,
       delayMs: 2e3,
       backoffMultiplier: 2,
@@ -23868,7 +23904,7 @@ function getEnvironmentUidsFromResources(resourcesState) {
   );
 }
 function normalizeToPosix(filePath) {
-  return filePath.split(path2.sep).join("/");
+  return filePath.split(path3.sep).join("/");
 }
 function isOpenApiSpecFile(filePath) {
   if (!(filePath.endsWith(".json") || filePath.endsWith(".yaml") || filePath.endsWith(".yml"))) {
@@ -23908,7 +23944,7 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (ignoredDirs.has(entry.name)) {
         continue;
       }
-      const fullPath = path2.join(currentDir, entry.name);
+      const fullPath = path3.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         visit(fullPath);
         continue;
@@ -23916,14 +23952,14 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (!entry.isFile() || !isOpenApiSpecFile(fullPath)) {
         continue;
       }
-      const repoRelativePath = normalizeToPosix(path2.relative(baseDir, fullPath));
+      const repoRelativePath = normalizeToPosix(path3.relative(baseDir, fullPath));
       if (found.has(repoRelativePath)) {
         continue;
       }
       found.add(repoRelativePath);
       refs.push({
         repoRelativePath,
-        configRelativePath: normalizeToPosix(path2.join("..", repoRelativePath))
+        configRelativePath: normalizeToPosix(path3.join("..", repoRelativePath))
       });
     }
   };
@@ -23933,11 +23969,11 @@ function scanLocalSpecReferences(baseDir = ".") {
 function resolveMappedSpecReference(explicitSpecPath, discoveredSpecs) {
   const normalizedExplicitPath = normalizeToPosix(explicitSpecPath.trim());
   if (normalizedExplicitPath) {
-    const explicitFullPath = path2.resolve(normalizedExplicitPath);
+    const explicitFullPath = path3.resolve(normalizedExplicitPath);
     if ((0, import_node_fs.existsSync)(explicitFullPath) && (0, import_node_fs.statSync)(explicitFullPath).isFile()) {
       return {
         repoRelativePath: normalizedExplicitPath,
-        configRelativePath: normalizeToPosix(path2.join("..", normalizedExplicitPath))
+        configRelativePath: normalizeToPosix(path3.join("..", normalizedExplicitPath))
       };
     }
   }
@@ -24014,8 +24050,8 @@ async function upsertEnvironments(inputs, dependencies, resourcesState) {
   }
   return envUids;
 }
-function ensureDir(path4) {
-  (0, import_node_fs.mkdirSync)(path4, { recursive: true });
+function ensureDir(path5) {
+  (0, import_node_fs.mkdirSync)(path5, { recursive: true });
 }
 function getCollectionDirectoryName(kind, projectName) {
   return `[${kind}] ${projectName}`;
@@ -24047,9 +24083,9 @@ function stripVolatileFields(obj) {
   }
   return obj;
 }
-function writeJsonFile(path4, content, normalize2 = false) {
+function writeJsonFile(path5, content, normalize2 = false) {
   const data = normalize2 ? stripVolatileFields(content) : content;
-  (0, import_node_fs.writeFileSync)(path4, JSON.stringify(data, null, 2));
+  (0, import_node_fs.writeFileSync)(path5, JSON.stringify(data, null, 2));
 }
 function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
@@ -24107,11 +24143,39 @@ function buildSpecCollectionWorkflowManifest(specRef, collectionRefs) {
     }
   );
 }
+function hasControlCharacter2(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
 function assertPathWithinCwd(targetPath, fieldName) {
-  const base = path2.resolve(".");
-  const resolved = path2.resolve(base, targetPath);
-  const relative2 = path2.relative(base, resolved);
-  if (relative2.startsWith("..") || path2.isAbsolute(relative2)) {
+  const originalPath = String(targetPath || "");
+  const rawPath = originalPath.trim();
+  const segments = rawPath.split(/[\\/]+/).filter(Boolean);
+  if (!rawPath || hasControlCharacter2(originalPath) || path3.isAbsolute(rawPath) || path3.win32.isAbsolute(rawPath) || segments.includes("..") || rawPath.startsWith(":") || hasControlCharacter2(rawPath)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  const base = (0, import_node_fs.realpathSync)(process.cwd());
+  const resolved = path3.resolve(base, rawPath);
+  const relative2 = path3.relative(base, resolved);
+  if (relative2.startsWith("..") || path3.isAbsolute(relative2)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  let existingPath = resolved;
+  while (!(0, import_node_fs.existsSync)(existingPath)) {
+    const parent = path3.dirname(existingPath);
+    if (parent === existingPath) {
+      break;
+    }
+    existingPath = parent;
+  }
+  const realExistingPath = (0, import_node_fs.realpathSync)(existingPath);
+  const realRelative = path3.relative(base, realExistingPath);
+  if (realRelative.startsWith("..") || path3.isAbsolute(realRelative)) {
     throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
   }
 }
@@ -24239,7 +24303,19 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     provisionExists ? ".github/workflows/provision.yml" : null
   ].filter((entry) => typeof entry === "string" && ((0, import_node_fs.existsSync)(entry) || entry === ".github/workflows/provision.yml"));
-  const effectiveStagePaths = stagePaths.length > 0 ? stagePaths : ["."];
+  if (stagePaths.length === 0) {
+    dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
+    return {
+      commitSha: "",
+      pushed: false,
+      resolvedCurrentRef: resolveCurrentRef({
+        currentRef: inputs.currentRef,
+        githubHeadRef: inputs.githubHeadRef,
+        githubRefName: inputs.githubRefName,
+        repoWriteMode: inputs.repoWriteMode
+      })
+    };
+  }
   const result = await dependencies.repoMutation.commitAndPush({
     repoWriteMode: inputs.repoWriteMode,
     currentRef: inputs.currentRef,
@@ -24249,7 +24325,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     committerEmail: inputs.committerEmail,
     githubToken: inputs.githubToken,
     fallbackToken: inputs.ghFallbackToken,
-    stagePaths: effectiveStagePaths
+    stagePaths
   });
   return {
     commitSha: result.commitSha,
@@ -24730,13 +24806,13 @@ async function writeOptionalFile(filePath, content) {
   if (!filePath) {
     return;
   }
-  const workspaceRoot = import_node_path.default.resolve(process.cwd());
-  const resolved = import_node_path.default.resolve(workspaceRoot, filePath);
-  const relative2 = import_node_path.default.relative(workspaceRoot, resolved);
-  if (relative2.startsWith("..") || import_node_path.default.isAbsolute(relative2)) {
+  const workspaceRoot = import_node_path2.default.resolve(process.cwd());
+  const resolved = import_node_path2.default.resolve(workspaceRoot, filePath);
+  const relative2 = import_node_path2.default.relative(workspaceRoot, resolved);
+  if (relative2.startsWith("..") || import_node_path2.default.isAbsolute(relative2)) {
     throw new Error(`Output path must stay within workspace: ${filePath}`);
   }
-  await (0, import_promises.mkdir)(import_node_path.default.dirname(resolved), { recursive: true });
+  await (0, import_promises.mkdir)(import_node_path2.default.dirname(resolved), { recursive: true });
   await (0, import_promises.writeFile)(resolved, content, "utf8");
 }
 function createCliDependencies(inputs, resolved) {
@@ -24826,7 +24902,7 @@ function isEntrypoint(currentPath, entrypointPath) {
   try {
     return (0, import_node_fs2.realpathSync)(currentPath) === (0, import_node_fs2.realpathSync)(entrypointPath);
   } catch {
-    return import_node_path.default.resolve(currentPath) === import_node_path.default.resolve(entrypointPath);
+    return import_node_path2.default.resolve(currentPath) === import_node_path2.default.resolve(entrypointPath);
   }
 }
 if (isEntrypoint(currentModulePath, entrypoint)) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -1069,14 +1069,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path8 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path9 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path8 && path8[0] !== "/") {
-          path8 = `/${path8}`;
+        if (path9 && path9[0] !== "/") {
+          path9 = `/${path9}`;
         }
-        return new URL(`${origin}${path8}`);
+        return new URL(`${origin}${path9}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1527,39 +1527,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin }
+          request: { method, path: path9, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path8);
+        debuglog("sending request to %s %s/%s", method, origin, path9);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin },
+          request: { method, path: path9, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path8,
+          path9,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin }
+          request: { method, path: path9, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path8);
+        debuglog("trailers received from %s %s/%s", method, origin, path9);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path8, origin },
+          request: { method, path: path9, origin },
           error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path8,
+          path9,
           error2.message
         );
       });
@@ -1608,9 +1608,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path8, origin }
+            request: { method, path: path9, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path8);
+          debuglog("sending request to %s %s/%s", method, origin, path9);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1673,7 +1673,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path8,
+        path: path9,
         method,
         body,
         headers,
@@ -1688,11 +1688,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path8 !== "string") {
+        if (typeof path9 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path8[0] !== "/" && !(path8.startsWith("http://") || path8.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path9[0] !== "/" && !(path9.startsWith("http://") || path9.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path8)) {
+        } else if (invalidPathRegex.test(path9)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1758,7 +1758,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path8, query) : path8;
+        this.path = query ? buildURL(path9, query) : path9;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6322,7 +6322,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request) {
-      const { method, path: path8, host, upgrade, blocking, reset } = request;
+      const { method, path: path9, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util.isFormDataLike(body)) {
@@ -6388,7 +6388,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path8} HTTP/1.1\r
+      let header = `${method} ${path9} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -6914,7 +6914,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path: path8, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path9, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -6981,7 +6981,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path8;
+      headers[HTTP2_HEADER_PATH] = path9;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7334,9 +7334,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path8 = search ? `${pathname}${search}` : pathname;
+        const path9 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path8;
+        this.opts.path = path9;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8571,10 +8571,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path8 = "/",
+          path: path9 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path8;
+        opts.path = origin + path9;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10495,20 +10495,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path8) {
-      if (typeof path8 !== "string") {
-        return path8;
+    function safeUrl(path9) {
+      if (typeof path9 !== "string") {
+        return path9;
       }
-      const pathSegments = path8.split("?");
+      const pathSegments = path9.split("?");
       if (pathSegments.length !== 2) {
-        return path8;
+        return path9;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path8, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path8);
+    function matchKey(mockDispatch2, { path: path9, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path9);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10530,7 +10530,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path8 }) => matchValue(safeUrl(path8), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path9 }) => matchValue(safeUrl(path9), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10568,9 +10568,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path8, method, body, headers, query } = opts;
+      const { path: path9, method, body, headers, query } = opts;
       return {
-        path: path8,
+        path: path9,
         method,
         body,
         headers,
@@ -11033,10 +11033,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path8, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path9, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path8,
+            Path: path9,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -15917,9 +15917,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path8) {
-      for (let i = 0; i < path8.length; ++i) {
-        const code = path8.charCodeAt(i);
+    function validateCookiePath(path9) {
+      for (let i = 0; i < path9.length; ++i) {
+        const code = path9.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18596,11 +18596,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path8 = opts.path;
+          let path9 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path8 = `/${path8}`;
+            path9 = `/${path9}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path8);
+          url = new URL(util.parseOrigin(url).origin + path9);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -20965,7 +20965,7 @@ function getIDToken(aud) {
 
 // src/index.ts
 var import_node_fs = require("node:fs");
-var path7 = __toESM(require("node:path"), 1);
+var path8 = __toESM(require("node:path"), 1);
 
 // node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
@@ -24205,6 +24205,9 @@ function buildCiWorkflowLines(installUrl) {
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
+// src/lib/github/repo-mutation.ts
+var import_node_path = __toESM(require("node:path"), 1);
+
 // src/lib/secrets.ts
 var REDACTED = "[REDACTED]";
 var SENSITIVE_HEADER_NAMES = /* @__PURE__ */ new Set([
@@ -24312,6 +24315,31 @@ function resolveCurrentRef(context) {
   }
   return normalizeBranchRef(currentRef) || normalizeBranchRef(context.githubHeadRef) || normalizeBranchRef(context.githubRefName);
 }
+function hasControlCharacter(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
+function normalizeStagePaths(stagePaths) {
+  const normalized = [];
+  for (const entry of stagePaths) {
+    const rawPath = String(entry || "");
+    const stagePath = rawPath.trim();
+    if (!stagePath) {
+      continue;
+    }
+    const segments = stagePath.split(/[\\/]+/).filter(Boolean);
+    if (hasControlCharacter(rawPath) || import_node_path.default.isAbsolute(stagePath) || import_node_path.default.win32.isAbsolute(stagePath) || segments.includes("..") || stagePath.startsWith(":") || hasControlCharacter(stagePath)) {
+      throw new Error(`Unsafe git stage path: ${stagePath}`);
+    }
+    normalized.push(stagePath);
+  }
+  return normalized;
+}
 var RepoMutationService = class {
   execute;
   repository;
@@ -24323,14 +24351,22 @@ var RepoMutationService = class {
   }
   async commitAndPush(options) {
     const resolvedCurrentRef = resolveCurrentRef(options);
+    const stagePaths = normalizeStagePaths(options.stagePaths);
     const tokens = buildPushTokenOrder({
       fallbackToken: options.fallbackToken,
       githubToken: options.githubToken
     });
     const secretMasker = createSecretMasker(tokens);
+    if (stagePaths.length === 0) {
+      return {
+        commitSha: "",
+        pushed: false,
+        resolvedCurrentRef
+      };
+    }
     await this.execute("git", ["config", "user.name", options.committerName]);
     await this.execute("git", ["config", "user.email", options.committerEmail]);
-    await this.execute("git", ["add", "-A", "--", ...options.stagePaths]);
+    await this.execute("git", ["add", "-A", "--", ...stagePaths]);
     const staged = await this.execute("git", ["diff", "--cached", "--quiet"]);
     if (staged.exitCode === 0) {
       return {
@@ -24416,8 +24452,8 @@ function normalizeRepoUrl(url) {
   const sshMatch = raw.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch) {
     const host = sshMatch[1];
-    const path8 = sshMatch[2];
-    return `https://${host}/${path8}`;
+    const path9 = sshMatch[2];
+    return `https://${host}/${path9}`;
   }
   return raw.replace(/\.git$/, "");
 }
@@ -25370,8 +25406,8 @@ var PostmanAssetsClient = class {
   getBifrostBaseUrl() {
     return this.bifrostBaseUrl;
   }
-  async request(path8, init = {}) {
-    const url = path8.startsWith("http") ? path8 : `${this.baseUrl}${path8}`;
+  async request(path9, init = {}) {
+    const url = path9.startsWith("http") ? path9 : `${this.baseUrl}${path9}`;
     const response = await this.fetchImpl(url, {
       ...init,
       headers: {
@@ -25434,8 +25470,8 @@ var PostmanAssetsClient = class {
    * non-idempotent creates is ambiguous (the asset may exist server-side),
    * so it is not retried to avoid duplicate mocks and monitors.
    */
-  async requestWithCollectionRetry(path8, init) {
-    return retry(() => this.request(path8, init), {
+  async requestWithCollectionRetry(path9, init) {
+    return retry(() => this.request(path9, init), {
       maxAttempts: 5,
       delayMs: 2e3,
       backoffMultiplier: 2,
@@ -25835,7 +25871,7 @@ function getEnvironmentUidsFromResources(resourcesState) {
   );
 }
 function normalizeToPosix(filePath) {
-  return filePath.split(path7.sep).join("/");
+  return filePath.split(path8.sep).join("/");
 }
 function isOpenApiSpecFile(filePath) {
   if (!(filePath.endsWith(".json") || filePath.endsWith(".yaml") || filePath.endsWith(".yml"))) {
@@ -25875,7 +25911,7 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (ignoredDirs.has(entry.name)) {
         continue;
       }
-      const fullPath = path7.join(currentDir, entry.name);
+      const fullPath = path8.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         visit(fullPath);
         continue;
@@ -25883,14 +25919,14 @@ function scanLocalSpecReferences(baseDir = ".") {
       if (!entry.isFile() || !isOpenApiSpecFile(fullPath)) {
         continue;
       }
-      const repoRelativePath = normalizeToPosix(path7.relative(baseDir, fullPath));
+      const repoRelativePath = normalizeToPosix(path8.relative(baseDir, fullPath));
       if (found.has(repoRelativePath)) {
         continue;
       }
       found.add(repoRelativePath);
       refs.push({
         repoRelativePath,
-        configRelativePath: normalizeToPosix(path7.join("..", repoRelativePath))
+        configRelativePath: normalizeToPosix(path8.join("..", repoRelativePath))
       });
     }
   };
@@ -25900,11 +25936,11 @@ function scanLocalSpecReferences(baseDir = ".") {
 function resolveMappedSpecReference(explicitSpecPath, discoveredSpecs) {
   const normalizedExplicitPath = normalizeToPosix(explicitSpecPath.trim());
   if (normalizedExplicitPath) {
-    const explicitFullPath = path7.resolve(normalizedExplicitPath);
+    const explicitFullPath = path8.resolve(normalizedExplicitPath);
     if ((0, import_node_fs.existsSync)(explicitFullPath) && (0, import_node_fs.statSync)(explicitFullPath).isFile()) {
       return {
         repoRelativePath: normalizedExplicitPath,
-        configRelativePath: normalizeToPosix(path7.join("..", normalizedExplicitPath))
+        configRelativePath: normalizeToPosix(path8.join("..", normalizedExplicitPath))
       };
     }
   }
@@ -26099,8 +26135,8 @@ async function upsertEnvironments(inputs, dependencies, resourcesState) {
   }
   return envUids;
 }
-function ensureDir(path8) {
-  (0, import_node_fs.mkdirSync)(path8, { recursive: true });
+function ensureDir(path9) {
+  (0, import_node_fs.mkdirSync)(path9, { recursive: true });
 }
 function getCollectionDirectoryName(kind, projectName) {
   return `[${kind}] ${projectName}`;
@@ -26132,9 +26168,9 @@ function stripVolatileFields(obj) {
   }
   return obj;
 }
-function writeJsonFile(path8, content, normalize2 = false) {
+function writeJsonFile(path9, content, normalize2 = false) {
   const data = normalize2 ? stripVolatileFields(content) : content;
-  (0, import_node_fs.writeFileSync)(path8, JSON.stringify(data, null, 2));
+  (0, import_node_fs.writeFileSync)(path9, JSON.stringify(data, null, 2));
 }
 function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
@@ -26192,11 +26228,39 @@ function buildSpecCollectionWorkflowManifest(specRef, collectionRefs) {
     }
   );
 }
+function hasControlCharacter2(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
 function assertPathWithinCwd(targetPath, fieldName) {
-  const base = path7.resolve(".");
-  const resolved = path7.resolve(base, targetPath);
-  const relative3 = path7.relative(base, resolved);
-  if (relative3.startsWith("..") || path7.isAbsolute(relative3)) {
+  const originalPath = String(targetPath || "");
+  const rawPath = originalPath.trim();
+  const segments = rawPath.split(/[\\/]+/).filter(Boolean);
+  if (!rawPath || hasControlCharacter2(originalPath) || path8.isAbsolute(rawPath) || path8.win32.isAbsolute(rawPath) || segments.includes("..") || rawPath.startsWith(":") || hasControlCharacter2(rawPath)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  const base = (0, import_node_fs.realpathSync)(process.cwd());
+  const resolved = path8.resolve(base, rawPath);
+  const relative3 = path8.relative(base, resolved);
+  if (relative3.startsWith("..") || path8.isAbsolute(relative3)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+  let existingPath = resolved;
+  while (!(0, import_node_fs.existsSync)(existingPath)) {
+    const parent = path8.dirname(existingPath);
+    if (parent === existingPath) {
+      break;
+    }
+    existingPath = parent;
+  }
+  const realExistingPath = (0, import_node_fs.realpathSync)(existingPath);
+  const realRelative = path8.relative(base, realExistingPath);
+  if (realRelative.startsWith("..") || path8.isAbsolute(realRelative)) {
     throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
   }
 }
@@ -26324,7 +26388,19 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     provisionExists ? ".github/workflows/provision.yml" : null
   ].filter((entry) => typeof entry === "string" && ((0, import_node_fs.existsSync)(entry) || entry === ".github/workflows/provision.yml"));
-  const effectiveStagePaths = stagePaths.length > 0 ? stagePaths : ["."];
+  if (stagePaths.length === 0) {
+    dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
+    return {
+      commitSha: "",
+      pushed: false,
+      resolvedCurrentRef: resolveCurrentRef({
+        currentRef: inputs.currentRef,
+        githubHeadRef: inputs.githubHeadRef,
+        githubRefName: inputs.githubRefName,
+        repoWriteMode: inputs.repoWriteMode
+      })
+    };
+  }
   const result = await dependencies.repoMutation.commitAndPush({
     repoWriteMode: inputs.repoWriteMode,
     currentRef: inputs.currentRef,
@@ -26334,7 +26410,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     committerEmail: inputs.committerEmail,
     githubToken: inputs.githubToken,
     fallbackToken: inputs.ghFallbackToken,
-    stagePaths: effectiveStagePaths
+    stagePaths
   });
   return {
     commitSha: result.commitSha,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync
@@ -851,12 +852,52 @@ function buildSpecCollectionWorkflowManifest(
   );
 }
 
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
+
 
 export function assertPathWithinCwd(targetPath: string, fieldName: string): void {
-  const base = path.resolve('.');
-  const resolved = path.resolve(base, targetPath);
+  const originalPath = String(targetPath || '');
+  const rawPath = originalPath.trim();
+  const segments = rawPath.split(/[\\/]+/).filter(Boolean);
+  if (
+    !rawPath ||
+    hasControlCharacter(originalPath) ||
+    path.isAbsolute(rawPath) ||
+    path.win32.isAbsolute(rawPath) ||
+    segments.includes('..') ||
+    rawPath.startsWith(':') ||
+    hasControlCharacter(rawPath)
+  ) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+
+  const base = realpathSync(process.cwd());
+  const resolved = path.resolve(base, rawPath);
   const relative = path.relative(base, resolved);
   if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
+  }
+
+  let existingPath = resolved;
+  while (!existsSync(existingPath)) {
+    const parent = path.dirname(existingPath);
+    if (parent === existingPath) {
+      break;
+    }
+    existingPath = parent;
+  }
+
+  const realExistingPath = realpathSync(existingPath);
+  const realRelative = path.relative(base, realExistingPath);
+  if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
     throw new Error(`${fieldName} must stay within the repository root; received ${targetPath}`);
   }
 }
@@ -1018,7 +1059,19 @@ async function commitAndPushGeneratedFiles(
     provisionExists ? '.github/workflows/provision.yml' : null
   ].filter((entry) => typeof entry === 'string' && (existsSync(entry) || entry === '.github/workflows/provision.yml')) as string[];
 
-  const effectiveStagePaths = stagePaths.length > 0 ? stagePaths : ['.'];
+  if (stagePaths.length === 0) {
+    dependencies.core.info('No generated repository paths were found; skipping repo mutation.');
+    return {
+      commitSha: '',
+      pushed: false,
+      resolvedCurrentRef: resolveCurrentRef({
+        currentRef: inputs.currentRef,
+        githubHeadRef: inputs.githubHeadRef,
+        githubRefName: inputs.githubRefName,
+        repoWriteMode: inputs.repoWriteMode
+      })
+    };
+  }
 
   const result = await dependencies.repoMutation.commitAndPush({
     repoWriteMode: inputs.repoWriteMode,
@@ -1029,7 +1082,7 @@ async function commitAndPushGeneratedFiles(
     committerEmail: inputs.committerEmail,
     githubToken: inputs.githubToken,
     fallbackToken: inputs.ghFallbackToken,
-    stagePaths: effectiveStagePaths
+    stagePaths
   });
 
   return {

--- a/src/lib/github/repo-mutation.ts
+++ b/src/lib/github/repo-mutation.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { createSecretMasker, type SecretMasker } from '../secrets.js';
 
 export type RepoWriteMode = 'none' | 'commit-only' | 'commit-and-push';
@@ -82,6 +84,44 @@ export function resolveCurrentRef(context: RepoMutationContext): string {
   );
 }
 
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeStagePaths(stagePaths: string[]): string[] {
+  const normalized: string[] = [];
+
+  for (const entry of stagePaths) {
+    const rawPath = String(entry || '');
+    const stagePath = rawPath.trim();
+    if (!stagePath) {
+      continue;
+    }
+
+    const segments = stagePath.split(/[\\/]+/).filter(Boolean);
+    if (
+      hasControlCharacter(rawPath) ||
+      path.isAbsolute(stagePath) ||
+      path.win32.isAbsolute(stagePath) ||
+      segments.includes('..') ||
+      stagePath.startsWith(':') ||
+      hasControlCharacter(stagePath)
+    ) {
+      throw new Error(`Unsafe git stage path: ${stagePath}`);
+    }
+
+    normalized.push(stagePath);
+  }
+
+  return normalized;
+}
+
 export class RepoMutationService {
   private readonly execute: ExecuteFn;
   private readonly repository: string;
@@ -100,15 +140,24 @@ export class RepoMutationService {
     resolvedCurrentRef: string;
   }> {
     const resolvedCurrentRef = resolveCurrentRef(options);
+    const stagePaths = normalizeStagePaths(options.stagePaths);
     const tokens = buildPushTokenOrder({
       fallbackToken: options.fallbackToken,
       githubToken: options.githubToken
     });
     const secretMasker = createSecretMasker(tokens);
 
+    if (stagePaths.length === 0) {
+      return {
+        commitSha: '',
+        pushed: false,
+        resolvedCurrentRef
+      };
+    }
+
     await this.execute('git', ['config', 'user.name', options.committerName]);
     await this.execute('git', ['config', 'user.email', options.committerEmail]);
-    await this.execute('git', ['add', '-A', '--', ...options.stagePaths]);
+    await this.execute('git', ['add', '-A', '--', ...stagePaths]);
 
     const staged = await this.execute('git', ['diff', '--cached', '--quiet']);
     if (staged.exitCode === 0) {

--- a/tests/path-sandboxing.test.ts
+++ b/tests/path-sandboxing.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 import { assertPathWithinCwd } from '../src/index.js';
 
@@ -27,10 +31,45 @@ describe('assertPathWithinCwd', () => {
     expect(() => assertPathWithinCwd('/tmp/output', 'ci-workflow-path')).toThrow(
       'ci-workflow-path must stay within the repository root; received /tmp/output'
     );
+    expect(() => assertPathWithinCwd('C:\\tmp\\output', 'ci-workflow-path')).toThrow(
+      'ci-workflow-path must stay within the repository root; received C:\\tmp\\output'
+    );
+  });
+
+  it('rejects pathspec magic and control characters', () => {
+    expect(() => assertPathWithinCwd(':(top)', 'artifact-dir')).toThrow(
+      'artifact-dir must stay within the repository root; received :(top)'
+    );
+    expect(() => assertPathWithinCwd('postman\nout', 'artifact-dir')).toThrow(
+      'artifact-dir must stay within the repository root'
+    );
+    expect(() => assertPathWithinCwd('postman\x1Fout', 'artifact-dir')).toThrow(
+      'artifact-dir must stay within the repository root'
+    );
   });
 
   it('allows current directory reference', () => {
     expect(() => assertPathWithinCwd('.', 'artifact-dir')).not.toThrow();
     expect(() => assertPathWithinCwd('./postman', 'artifact-dir')).not.toThrow();
+  });
+
+  it('rejects paths whose existing parent resolves outside the repo root', () => {
+    const originalCwd = process.cwd();
+    const repoRoot = mkdtempSync(join(tmpdir(), 'repo-sync-sandbox-'));
+    const outsideRoot = mkdtempSync(join(tmpdir(), 'repo-sync-outside-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'postman'), { recursive: true });
+      symlinkSync(outsideRoot, join(repoRoot, 'postman', 'escaped'));
+      process.chdir(repoRoot);
+
+      expect(() => assertPathWithinCwd('postman/escaped/generated', 'artifact-dir')).toThrow(
+        'artifact-dir must stay within the repository root; received postman/escaped/generated'
+      );
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(repoRoot, { recursive: true, force: true });
+      rmSync(outsideRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/repo-mutation.test.ts
+++ b/tests/repo-mutation.test.ts
@@ -197,6 +197,59 @@ describe('repo mutation helpers', () => {
     ]);
   });
 
+  it('returns before git mutations when no stage paths are provided', async () => {
+    const execute = createExecuteMock(createCommandMap({}));
+    const repoMutation = new RepoMutationService({
+      repository: 'postman-cs/repo-sync-demo',
+      execute
+    });
+
+    const result = await repoMutation.commitAndPush({
+      repoWriteMode: 'commit-and-push',
+      currentRef: 'feature/sync-artifacts',
+      committerName: 'Postman CSE',
+      committerEmail: 'help@postman.com',
+      stagePaths: ['', '  ']
+    });
+
+    expect(result).toEqual({
+      commitSha: '',
+      pushed: false,
+      resolvedCurrentRef: 'feature/sync-artifacts'
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['/tmp/out'],
+    ['C:\\tmp\\out'],
+    ['../outside'],
+    ['postman/../../outside'],
+    [':(top)'],
+    ['postman\0out'],
+    ['postman\rout'],
+    ['postman\nout'],
+    ['postman\x1Fout']
+  ])('rejects unsafe git stage path %j before git mutations', async (stagePath) => {
+    const execute = createExecuteMock(createCommandMap({}));
+    const repoMutation = new RepoMutationService({
+      repository: 'postman-cs/repo-sync-demo',
+      execute
+    });
+
+    await expect(
+      repoMutation.commitAndPush({
+        repoWriteMode: 'commit-and-push',
+        currentRef: 'feature/sync-artifacts',
+        githubToken: 'primary-token',
+        committerName: 'Postman CSE',
+        committerEmail: 'help@postman.com',
+        stagePaths: [stagePath]
+      })
+    ).rejects.toThrow('Unsafe git stage path');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('redacts secrets from git push failures', async () => {
     const execute = createExecuteMock(
       createCommandMap({

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -580,6 +580,38 @@ describe('repo sync action', () => {
     expect(callArgs.stagePaths).not.toContain('.github/workflows/provision.yml');
   });
 
+  it('skips repo mutation instead of falling back to staging the repository root when no generated paths exist', async () => {
+    const { core, infos } = createCoreStub();
+    const repoMutation = {
+      commitAndPush: vi.fn()
+    };
+
+    const result = await runRepoSync(
+      createInputs({
+        workspaceId: '',
+        baselineCollectionId: '',
+        smokeCollectionId: '',
+        contractCollectionId: '',
+        environments: [],
+        workspaceLinkEnabled: false,
+        environmentSyncEnabled: false,
+        generateCiWorkflow: false
+      }),
+      {
+        core,
+        postman: {} as unknown as RepoSyncDependencies['postman'],
+        repoMutation: repoMutation as unknown as Parameters<typeof runRepoSync>[1]['repoMutation']
+      }
+    );
+
+    expect(repoMutation.commitAndPush).not.toHaveBeenCalled();
+    expect(infos).toContain('No generated repository paths were found; skipping repo mutation.');
+    expect(result).toMatchObject({
+      'commit-sha': '',
+      'resolved-current-ref': 'feature/repo-sync'
+    });
+  });
+
   it('writes the generated CI workflow to a custom path when configured', async () => {
     const postman = {
       createEnvironment: vi.fn().mockResolvedValue('env-prod'),


### PR DESCRIPTION
Split from PR #29. Scope: empty generated stage paths skip repo mutation, unsafe git stage paths are rejected before git runs, and path sandboxing now realpath-checks existing parents to reject symlink escapes. Validation: npm test; npm run typecheck; npm run lint; npm run build; git diff --check. Excludes Azure DevOps support, PR #49 CI_ENVIRONMENT fix, PR #50 encoded secret masking, and additional-collections-dir.