### PR TITLE
Persist native Flow resource state

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ with:
 | `monitor-type` | Type of monitor to create ("cloud" or "cli"). "cli" will skip cloud monitor creation and rely on the CI workflow. | no | `cloud` |
 | `smoke-collection-id` | Smoke collection ID used for monitor creation. | no |  |
 | `contract-collection-id` | Contract collection ID used for exported artifacts. | no |  |
+| `flow-id` | Native Postman Flow ID to persist into .postman/resources.yaml. | no |  |
+| `flow-name` | Native Postman Flow name used for the exported flow metadata artifact. | no |  |
 | `collection-sync-mode` | Collection sync lifecycle mode (refresh or version). | no | `refresh` |
 | `spec-sync-mode` | Spec sync lifecycle mode (update or version). | no | `update` |
 | `release-label` | Optional release label used for versioned naming. | no |  |

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,12 @@ inputs:
   contract-collection-id:
     description: Contract collection ID used for exported artifacts.
     required: false
+  flow-id:
+    description: Native Postman Flow ID to persist into .postman/resources.yaml.
+    required: false
+  flow-name:
+    description: Native Postman Flow name used for the exported flow metadata artifact.
+    required: false
   collection-sync-mode:
     description: Collection sync lifecycle mode (refresh or version).
     required: false

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -25282,6 +25282,14 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "flow-id": {
+      description: "Native Postman Flow ID to persist into .postman/resources.yaml.",
+      required: false
+    },
+    "flow-name": {
+      description: "Native Postman Flow name used for the exported flow metadata artifact.",
+      required: false
+    },
     "collection-sync-mode": {
       description: "Collection sync lifecycle mode (refresh or version).",
       required: false,
@@ -25987,6 +25995,8 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    flowId: getInput2("flow-id", env),
+    flowName: getInput2("flow-name", env),
     specId: getInput2("spec-id", env),
     specPath: getInput2("spec-path", env),
     collectionSyncMode: normalizeCollectionSyncMode(getInput2("collection-sync-mode", env) || "refresh"),
@@ -26206,6 +26216,8 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_FLOW_ID: readInput(actionCore, "flow-id"),
+    INPUT_FLOW_NAME: readInput(actionCore, "flow-name"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, "collection-sync-mode") || "refresh",
@@ -26384,7 +26396,10 @@ function writeJsonFile(path8, content, normalize3 = false) {
   const data = normalize3 ? stripVolatileFields(content) : content;
   (0, import_node_fs.writeFileSync)(path8, JSON.stringify(data, null, 2));
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
+function sanitizePathSegment2(value) {
+  return value.trim().split("").map((char) => char.charCodeAt(0) < 32 || '<>:"/\\|?*'.includes(char) ? "-" : char).join("").replace(/\s+/g, " ").replace(/-+/g, "-").replace(/^[.\s-]+|[.\s-]+$/g, "").slice(0, 120) || "flow";
+}
+function buildResourcesManifest(workspaceId, collectionMap, envMap, flowMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
     workspace: { id: workspaceId }
   };
@@ -26404,6 +26419,11 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
+  }
+  const flowEntries = Object.entries(flowMap);
+  if (flowEntries.length > 0) {
+    localResources.flows = flowEntries.map(([flowPath]) => flowPath);
+    cloudResources.flows = flowMap;
   }
   if (localSpecRefs.length > 0) {
     localResources.specs = localSpecRefs;
@@ -26477,6 +26497,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     ensureDir(".github/workflows");
   }
   const manifestCollections = {};
+  const manifestFlows = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
   if (inputs.baselineCollectionId) {
@@ -26510,10 +26531,26 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
       true
     );
   }
+  if (inputs.flowId) {
+    const flowName = inputs.flowName || `[Smoke] ${inputs.projectName} happy path`;
+    const flowFilePath = `${flowsDir}/${sanitizePathSegment2(flowName)}.postman_flow.yaml`;
+    (0, import_node_fs.writeFileSync)(flowFilePath, dump({
+      name: flowName,
+      id: inputs.flowId,
+      type: "native-postman-flow",
+      workspaceId: inputs.workspaceId
+    }, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false
+    }));
+    manifestFlows[`../${flowFilePath}`] = inputs.flowId;
+  }
   (0, import_node_fs.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     inputs.workspaceId,
     manifestCollections,
     envUids,
+    manifestFlows,
     inputs.artifactDir,
     discoveredSpecs.map((spec) => spec.configRelativePath),
     mappedSpec?.configRelativePath,

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -23385,6 +23385,14 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "flow-id": {
+      description: "Native Postman Flow ID to persist into .postman/resources.yaml.",
+      required: false
+    },
+    "flow-name": {
+      description: "Native Postman Flow name used for the exported flow metadata artifact.",
+      required: false
+    },
     "collection-sync-mode": {
       description: "Collection sync lifecycle mode (refresh or version).",
       required: false,
@@ -24035,6 +24043,8 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput("baseline-collection-id", env),
     smokeCollectionId: getInput("smoke-collection-id", env),
     contractCollectionId: getInput("contract-collection-id", env),
+    flowId: getInput("flow-id", env),
+    flowName: getInput("flow-name", env),
     specId: getInput("spec-id", env),
     specPath: getInput("spec-path", env),
     collectionSyncMode: normalizeCollectionSyncMode(getInput("collection-sync-mode", env) || "refresh"),
@@ -24313,7 +24323,10 @@ function writeJsonFile(path4, content, normalize3 = false) {
   const data = normalize3 ? stripVolatileFields(content) : content;
   (0, import_node_fs.writeFileSync)(path4, JSON.stringify(data, null, 2));
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
+function sanitizePathSegment2(value) {
+  return value.trim().split("").map((char) => char.charCodeAt(0) < 32 || '<>:"/\\|?*'.includes(char) ? "-" : char).join("").replace(/\s+/g, " ").replace(/-+/g, "-").replace(/^[.\s-]+|[.\s-]+$/g, "").slice(0, 120) || "flow";
+}
+function buildResourcesManifest(workspaceId, collectionMap, envMap, flowMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
     workspace: { id: workspaceId }
   };
@@ -24333,6 +24346,11 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
+  }
+  const flowEntries = Object.entries(flowMap);
+  if (flowEntries.length > 0) {
+    localResources.flows = flowEntries.map(([flowPath]) => flowPath);
+    cloudResources.flows = flowMap;
   }
   if (localSpecRefs.length > 0) {
     localResources.specs = localSpecRefs;
@@ -24406,6 +24424,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     ensureDir(".github/workflows");
   }
   const manifestCollections = {};
+  const manifestFlows = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
   if (inputs.baselineCollectionId) {
@@ -24439,10 +24458,26 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
       true
     );
   }
+  if (inputs.flowId) {
+    const flowName = inputs.flowName || `[Smoke] ${inputs.projectName} happy path`;
+    const flowFilePath = `${flowsDir}/${sanitizePathSegment2(flowName)}.postman_flow.yaml`;
+    (0, import_node_fs.writeFileSync)(flowFilePath, dump({
+      name: flowName,
+      id: inputs.flowId,
+      type: "native-postman-flow",
+      workspaceId: inputs.workspaceId
+    }, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false
+    }));
+    manifestFlows[`../${flowFilePath}`] = inputs.flowId;
+  }
   (0, import_node_fs.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     inputs.workspaceId,
     manifestCollections,
     envUids,
+    manifestFlows,
     inputs.artifactDir,
     discoveredSpecs.map((spec) => spec.configRelativePath),
     mappedSpec?.configRelativePath,
@@ -24944,6 +24979,8 @@ function parseCliArgs(argv, env = process.env) {
     "baseline-collection-id",
     "smoke-collection-id",
     "contract-collection-id",
+    "flow-id",
+    "flow-name",
     "collection-sync-mode",
     "spec-sync-mode",
     "release-label",

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25297,6 +25297,14 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "flow-id": {
+      description: "Native Postman Flow ID to persist into .postman/resources.yaml.",
+      required: false
+    },
+    "flow-name": {
+      description: "Native Postman Flow name used for the exported flow metadata artifact.",
+      required: false
+    },
     "collection-sync-mode": {
       description: "Collection sync lifecycle mode (refresh or version).",
       required: false,
@@ -26002,6 +26010,8 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    flowId: getInput2("flow-id", env),
+    flowName: getInput2("flow-name", env),
     specId: getInput2("spec-id", env),
     specPath: getInput2("spec-path", env),
     collectionSyncMode: normalizeCollectionSyncMode(getInput2("collection-sync-mode", env) || "refresh"),
@@ -26221,6 +26231,8 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_FLOW_ID: readInput(actionCore, "flow-id"),
+    INPUT_FLOW_NAME: readInput(actionCore, "flow-name"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, "collection-sync-mode") || "refresh",
@@ -26399,7 +26411,10 @@ function writeJsonFile(path8, content, normalize3 = false) {
   const data = normalize3 ? stripVolatileFields(content) : content;
   (0, import_node_fs.writeFileSync)(path8, JSON.stringify(data, null, 2));
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
+function sanitizePathSegment2(value) {
+  return value.trim().split("").map((char) => char.charCodeAt(0) < 32 || '<>:"/\\|?*'.includes(char) ? "-" : char).join("").replace(/\s+/g, " ").replace(/-+/g, "-").replace(/^[.\s-]+|[.\s-]+$/g, "").slice(0, 120) || "flow";
+}
+function buildResourcesManifest(workspaceId, collectionMap, envMap, flowMap, artifactDir, localSpecRefs, mappedSpecRef, specId) {
   const manifest = {
     workspace: { id: workspaceId }
   };
@@ -26419,6 +26434,11 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
+  }
+  const flowEntries = Object.entries(flowMap);
+  if (flowEntries.length > 0) {
+    localResources.flows = flowEntries.map(([flowPath]) => flowPath);
+    cloudResources.flows = flowMap;
   }
   if (localSpecRefs.length > 0) {
     localResources.specs = localSpecRefs;
@@ -26492,6 +26512,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
     ensureDir(".github/workflows");
   }
   const manifestCollections = {};
+  const manifestFlows = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
   if (inputs.baselineCollectionId) {
@@ -26525,10 +26546,26 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName) 
       true
     );
   }
+  if (inputs.flowId) {
+    const flowName = inputs.flowName || `[Smoke] ${inputs.projectName} happy path`;
+    const flowFilePath = `${flowsDir}/${sanitizePathSegment2(flowName)}.postman_flow.yaml`;
+    (0, import_node_fs.writeFileSync)(flowFilePath, dump({
+      name: flowName,
+      id: inputs.flowId,
+      type: "native-postman-flow",
+      workspaceId: inputs.workspaceId
+    }, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false
+    }));
+    manifestFlows[`../${flowFilePath}`] = inputs.flowId;
+  }
   (0, import_node_fs.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     inputs.workspaceId,
     manifestCollections,
     envUids,
+    manifestFlows,
     inputs.artifactDir,
     discoveredSpecs.map((spec) => spec.configRelativePath),
     mappedSpec?.configRelativePath,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,8 @@ export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.en
     'baseline-collection-id',
     'smoke-collection-id',
     'contract-collection-id',
+    'flow-id',
+    'flow-name',
     'collection-sync-mode',
     'spec-sync-mode',
     'release-label',

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -100,6 +100,14 @@ export const postmanRepoSyncActionContract: {
       description: 'Contract collection ID used for exported artifacts.',
       required: false
     },
+    'flow-id': {
+      description: 'Native Postman Flow ID to persist into .postman/resources.yaml.',
+      required: false
+    },
+    'flow-name': {
+      description: 'Native Postman Flow name used for the exported flow metadata artifact.',
+      required: false
+    },
     'collection-sync-mode': {
       description: 'Collection sync lifecycle mode (refresh or version).',
       required: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,8 @@ export interface ResolvedInputs {
   baselineCollectionId: string;
   smokeCollectionId: string;
   contractCollectionId: string;
+  flowId: string;
+  flowName: string;
   collectionSyncMode: 'refresh' | 'version';
   specSyncMode: 'update' | 'version';
   releaseLabel?: string;
@@ -298,6 +300,8 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     baselineCollectionId: getInput('baseline-collection-id', env),
     smokeCollectionId: getInput('smoke-collection-id', env),
     contractCollectionId: getInput('contract-collection-id', env),
+    flowId: getInput('flow-id', env),
+    flowName: getInput('flow-name', env),
     specId: getInput('spec-id', env),
     specPath: getInput('spec-path', env),
     collectionSyncMode: normalizeCollectionSyncMode(getInput('collection-sync-mode', env) || 'refresh'),
@@ -375,6 +379,7 @@ type PostmanResourcesState = {
   cloudResources?: {
     collections?: CloudResourceMap;
     environments?: CloudResourceMap;
+    flows?: CloudResourceMap;
     specs?: CloudResourceMap;
   };
 };
@@ -586,6 +591,8 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
+    INPUT_FLOW_ID: readInput(actionCore, 'flow-id'),
+    INPUT_FLOW_NAME: readInput(actionCore, 'flow-name'),
     INPUT_SPEC_ID: readInput(actionCore, 'spec-id'),
     INPUT_SPEC_PATH: readInput(actionCore, 'spec-path'),
     INPUT_COLLECTION_SYNC_MODE: readInput(actionCore, 'collection-sync-mode') || 'refresh',
@@ -799,10 +806,23 @@ function writeJsonFile(path: string, content: unknown, normalize = false): void 
   writeFileSync(path, JSON.stringify(data, null, 2));
 }
 
+function sanitizePathSegment(value: string): string {
+  return value
+    .trim()
+    .split('')
+    .map((char) => (char.charCodeAt(0) < 32 || '<>:"/\\|?*'.includes(char) ? '-' : char))
+    .join('')
+    .replace(/\s+/g, ' ')
+    .replace(/-+/g, '-')
+    .replace(/^[.\s-]+|[.\s-]+$/g, '')
+    .slice(0, 120) || 'flow';
+}
+
 function buildResourcesManifest(
   workspaceId: string,
   collectionMap: Record<string, string>,
   envMap: Record<string, string>,
+  flowMap: Record<string, string>,
   artifactDir: string,
   localSpecRefs: string[],
   mappedSpecRef?: string,
@@ -832,6 +852,12 @@ function buildResourcesManifest(
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
+  }
+
+  const flowEntries = Object.entries(flowMap);
+  if (flowEntries.length > 0) {
+    localResources.flows = flowEntries.map(([flowPath]) => flowPath);
+    cloudResources.flows = flowMap;
   }
 
   if (localSpecRefs.length > 0) {
@@ -923,6 +949,7 @@ async function exportArtifacts(
   }
 
   const manifestCollections: Record<string, string> = {};
+  const manifestFlows: Record<string, string> = {};
   const discoveredSpecs = scanLocalSpecReferences();
   const mappedSpec = resolveMappedSpecReference(inputs.specPath, discoveredSpecs);
 
@@ -962,10 +989,27 @@ async function exportArtifacts(
     );
   }
 
+  if (inputs.flowId) {
+    const flowName = inputs.flowName || `[Smoke] ${inputs.projectName} happy path`;
+    const flowFilePath = `${flowsDir}/${sanitizePathSegment(flowName)}.postman_flow.yaml`;
+    writeFileSync(flowFilePath, dumpYaml({
+      name: flowName,
+      id: inputs.flowId,
+      type: 'native-postman-flow',
+      workspaceId: inputs.workspaceId
+    }, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false
+    }));
+    manifestFlows[`../${flowFilePath}`] = inputs.flowId;
+  }
+
   writeFileSync('.postman/resources.yaml', buildResourcesManifest(
     inputs.workspaceId,
     manifestCollections,
     envUids,
+    manifestFlows,
     inputs.artifactDir,
     discoveredSpecs.map((spec) => spec.configRelativePath),
     mappedSpec?.configRelativePath,

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -31,6 +31,8 @@ describe('postman-repo-sync-action contract', () => {
       'monitor-type',
       'smoke-collection-id',
       'contract-collection-id',
+      'flow-id',
+      'flow-name',
       'collection-sync-mode',
       'spec-sync-mode',
       'release-label',

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -28,6 +28,7 @@ import { createInternalIntegrationAdapter } from '../src/lib/postman/internal-in
 type ResourcesYamlShape = {
   cloudResources?: {
     collections?: Record<string, string>;
+    flows?: Record<string, string>;
   };
 };
 
@@ -38,6 +39,8 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    flowId: '',
+    flowName: '',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',
     releaseLabel: undefined,
@@ -536,6 +539,53 @@ describe('repo sync action', () => {
       '../postman/collections/core-payments': 'col-baseline-existing',
       '../postman/collections/[Smoke] core-payments': 'col-smoke-existing',
       '../postman/collections/[Contract] core-payments': 'col-contract-existing'
+    });
+  });
+
+  it('writes native Flow state into artifacts and resources.yaml when flow-id is supplied', async () => {
+    const postman = {
+      createEnvironment: vi.fn(),
+      updateEnvironment: vi.fn().mockResolvedValue(undefined),
+      createMock: vi.fn().mockResolvedValue({ uid: 'mock-1', url: 'https://mock.pstmn.io' }),
+      createMonitor: vi.fn().mockResolvedValue('mon-1'),
+      getCollection: vi.fn().mockResolvedValue(createCollectionFixture('[Smoke] core-payments')),
+      getEnvironment: vi.fn().mockResolvedValue({ values: [] }),
+      listMonitors: vi.fn().mockResolvedValue([]),
+      listMocks: vi.fn().mockResolvedValue([]),
+      monitorExists: vi.fn().mockResolvedValue(false),
+      mockExists: vi.fn().mockResolvedValue(false),
+      findMonitorByCollection: vi.fn().mockResolvedValue(null),
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      runMonitor: vi.fn().mockResolvedValue(undefined)
+    };
+
+    await runRepoSync(
+      createInputs({
+        environments: [],
+        generateCiWorkflow: false,
+        repoWriteMode: 'none',
+        flowId: 'flow-123',
+        flowName: '[Smoke] Core Payments happy path'
+      }),
+      {
+        core: createCoreStub().core,
+        postman
+      }
+    );
+
+    const flowYaml = loadYaml(
+      readFileSync('postman/flows/[Smoke] Core Payments happy path.postman_flow.yaml', 'utf8')
+    ) as Record<string, unknown>;
+    const resourcesYaml = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+
+    expect(flowYaml).toMatchObject({
+      name: '[Smoke] Core Payments happy path',
+      id: 'flow-123',
+      type: 'native-postman-flow',
+      workspaceId: 'ws-123'
+    });
+    expect(resourcesYaml.cloudResources?.flows).toEqual({
+      '../postman/flows/[Smoke] Core Payments happy path.postman_flow.yaml': 'flow-123'
     });
   });
 


### PR DESCRIPTION
## Summary
- add `flow-id` and `flow-name` inputs
- export native Flow metadata under `postman/flows`
- write Flow mappings into `.postman/resources.yaml` without disturbing existing collection, environment, or spec mappings

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`

## Companion branches
- `postman-cs/postman-smoke-flow-action@codex/flow-draft-generation`
- `postman-cs/postman-flow-test@codex/flow-draft-acceptance`