### PR TITLE
ci: consolidate checks into one backgrounded gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  gate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so commitlint can lint the PR commit range.
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -23,55 +29,41 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm run lint
-      - run: npm test
-      - run: npm run typecheck
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          echo "ACTIONLINT_BIN=$RUNNER_TEMP/actionlint" >> "$GITHUB_ENV"
+      # All checks run in parallel as backgrounded shell processes on one runner,
+      # so wall-clock is max(gate), not sum, and setup/npm-ci run once. Failures
+      # aggregate under ::group:: logs, so one pass shows every result.
+      - name: Run gates
+        run: |
+          set -uo pipefail
+          declare -A pid
+          run() { local n=$1; shift; ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
 
-  check-dist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: npm
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: rm -rf dist && npm run build
-      - name: Compare committed dist
-        id: diff
-        run: git diff --ignore-space-at-eol --text --exit-code -- dist
+          run lint       npm run lint
+          run test       npm test
+          run typecheck  npm run typecheck
+          run dist       npm run verify:dist
+          run actionlint "$ACTIONLINT_BIN"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            run commitlint npx commitlint \
+              --from "${{ github.event.pull_request.base.sha }}" \
+              --to "${{ github.event.pull_request.head.sha }}"
+          fi
+
+          fail=0
+          for n in "${!pid[@]}"; do
+            if wait "${pid[$n]}"; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi
+          done
+          for n in "${!pid[@]}"; do
+            echo "::group::$n"; cat "$n.log"; echo "::endgroup::"
+          done
+          exit $fail
       - name: Upload expected dist on mismatch
-        if: ${{ failure() && steps.diff.outcome == 'failure' }}
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: expected-dist
           path: dist/
-
-  actionlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.24'
-      - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
-      - name: Run actionlint
-        run: |
-          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
-          "$ACTIONLINT_BIN"
-
-  commitlint:
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,12 @@ postman/
 - Collection v3 format uses `$schema: https://schema.postman.com/json/draft-2020-12/collection/v3.0.0/` -- not the standard v2.1 JSON format
 - `commit-and-push` mode requires write permissions on the checked-out ref
 - `repo-mutation.ts` handles detached HEAD via `current-ref` input
+
+## CI
+
+`.github/workflows/ci.yml` runs a single `gate` job that fans out lint, test, typecheck, dist, commitlint, and actionlint
+as backgrounded shell processes on one runner: wall-clock is `max(gate)`, not
+`sum`, setup runs once, and every gate prints its result under a `::group::`
+block even when another fails.
+
+See the workspace `docs/CI.md` for the shared rationale.


### PR DESCRIPTION
## What
Consolidates the per-PR/push CI into a single `gate` job that runs every check as
a backgrounded shell process on one runner (`&` / `wait`), folds commitlint in via
`npx commitlint`, and installs `actionlint` via the pinned official downloader (no
Go toolchain job).

## Why
GitHub's only parallelism primitive is the job; steps within a job serialize, but
processes within one `run:` step run concurrently. One backgrounded job gets the
same wall-clock as N parallel jobs (`max`, not `sum`) while paying setup + `npm ci`
once instead of per job, and spinning up fewer runners.

## Gates
lint · test · typecheck · dist · commitlint · actionlint.

## Tradeoff
One check instead of several: a failure is one red X to expand and a rerun is the
whole job. The gate runs every check even after one fails and prints each under a
`::group::` block to keep failures legible.