### PR TITLE
perf(ci): drop live e2e gate timeout to smoke-tier reality

### DIFF
--- a/.github/scripts/wait-for-e2e-gate.mjs
+++ b/.github/scripts/wait-for-e2e-gate.mjs
@@ -4,7 +4,10 @@ import { pathToFileURL } from 'node:url';
 const DEFAULT_E2E_REPOSITORY = 'postman-cs/postman-actions-e2e';
 const DEFAULT_E2E_WORKFLOW = 'e2e.yml';
 const DEFAULT_E2E_REF = 'main';
-const DEFAULT_TIMEOUT_SECONDS = 13200;
+// Live smoke-tier runs complete in 3-4 minutes with parallel sandbox
+// isolation (no cross-run serialize wait). 30 minutes is 7-10x headroom;
+// E2E_GATE_TIMEOUT_SECONDS overrides for exceptional runs.
+const DEFAULT_TIMEOUT_SECONDS = 1800;
 const DEFAULT_POLL_SECONDS = 10;
 const TRANSIENT_BACKOFF_BASE_SECONDS = 15;
 const TRANSIENT_BACKOFF_CAP_SECONDS = 120;

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     name: live e2e gate
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 45
     steps:
       - name: Require same-repository PR branch
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}

--- a/tests/e2e-gate-timeout.test.ts
+++ b/tests/e2e-gate-timeout.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const gateScript = readFileSync(join(process.cwd(), '.github/scripts/wait-for-e2e-gate.mjs'), 'utf8');
+const liveE2eWorkflow = readFileSync(join(process.cwd(), '.github/workflows/live-e2e.yml'), 'utf8');
+
+describe('e2e gate timeout bounds', () => {
+  it('keeps the default gate poll timeout at 30 minutes (smoke runs finish in 3-4)', () => {
+    const match = gateScript.match(/const DEFAULT_TIMEOUT_SECONDS = (\d+);/);
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBe(1800);
+  });
+
+  it('keeps the env override hook for exceptional runs', () => {
+    expect(gateScript).toContain("parsePositiveInteger(process.env.E2E_GATE_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS, 'E2E_GATE_TIMEOUT_SECONDS')");
+  });
+
+  it('caps the live e2e job ceiling at 45 minutes, not the legacy 240', () => {
+    expect(liveE2eWorkflow).toMatch(/timeout-minutes: 45\b/);
+    expect(liveE2eWorkflow).not.toMatch(/timeout-minutes: 240\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- default wait-for-e2e-gate poll timeout: 13200s (3h40m) -> 1800s (30m); smoke-tier release-gate runs complete in 3-4 minutes with parallel sandbox isolation, so 30m is 7-10x headroom
- live-e2e job ceiling: timeout-minutes 240 -> 45
- E2E_GATE_TIMEOUT_SECONDS env override retained for exceptional runs
- regression tests pin both bounds (tests/e2e-gate-timeout.test.ts)

## Testing
- npx vitest run tests/e2e-gate-timeout.test.ts: 3 passed (all four gate repos)