### PR TITLE
fix(tests): increase npm pack timeout for Windows CI

### DIFF
--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -258,5 +258,5 @@ describe('CLI packaging contract', () => {
       version: string;
     };
     expect(version.stdout.trim()).toBe(packageJson.version);
-  }, 60_000);
+  }, 120_000);
 });


### PR DESCRIPTION
The npm pack/install/help cycle takes longer on Windows runners. Increases the test timeout from 60s to 120s.