### PR TITLE
chore: prepare v2.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-repo-sync",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Prepare repo-sync `v2.1.11` from the current `main` release bytes. This patch advances package and lockfile metadata for the Windows parity release without changing the shipped action contract.

## Validation

- Repository CI, native Windows tests, dist integrity, and release artifact checks run on this branch.
