### PR TITLE
fix: authenticate release dependency install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           node-version: '24'
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Install actionlint
         run: |
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-repo-sync",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -85,6 +85,7 @@ describe('release workflow publishing contract', () => {
     expect(verify).not.toContain('cache:');
     expect(verify).toContain('npm ci');
     expect(verify.match(/^\s*- run: npm ci$/gm) ?? []).toHaveLength(1);
+    expect(verify).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
     expect(verify).toContain('npm run bundle');
     expect(verify.indexOf('npm run bundle')).toBeLessThan(verify.indexOf('Run gates'));
     expect(verify).toContain('MAX_PARALLEL_GATES=2');


### PR DESCRIPTION
## Summary

Prepare repo-sync `v2.1.12` and authenticate the unprivileged release verifier's dependency install. The release lock includes a private Postman package, so the verifier now uses the same scoped registry credential as the green `main` CI install.

## Safety

The token is scoped to the single `npm ci` step. It isn't available to tests, bundle generation, artifact staging, publication, logs, or the privileged publish job. A workflow contract test pins that boundary.

`v2.1.11` remains immutable and unpublished after its verifier failed before build; this release supersedes it without rewriting the tag.

## Validation

- `npm view @postman/yaml-serialize@0.1.0 version --json` resolves with the configured registry credential.
- Repository CI, native Windows tests, dist integrity, and release artifact checks run on this branch.
