### PR TITLE
fix: configure registry for release install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-repo-sync",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -85,6 +85,8 @@ describe('release workflow publishing contract', () => {
     expect(verify).not.toContain('cache:');
     expect(verify).toContain('npm ci');
     expect(verify.match(/^\s*- run: npm ci$/gm) ?? []).toHaveLength(1);
+    expect(verify).toContain('registry-url:');
+    expect(verify).toContain('https://registry.npmjs.org');
     expect(verify).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
     expect(verify).toContain('npm run bundle');
     expect(verify.indexOf('npm run bundle')).toBeLessThan(verify.indexOf('Run gates'));


### PR DESCRIPTION
## Summary

Prepare repo-sync `v2.1.13` and configure npm's registry for the release verifier. The existing step-scoped token is now consumed through the `setup-node` npmrc, matching the proven `main` CI dependency-install boundary.

## Safety

The registry configuration is limited to the unprivileged verifier job and the token remains scoped to `npm ci`. Tests, bundle generation, artifact staging, publication, and the privileged publish job don't receive the credential. Workflow contract assertions pin both required halves of authenticated install.

`v2.1.11` and `v2.1.12` remain immutable and unpublished after failing before build; this release supersedes them without moving either tag.

## Validation

- Repository CI, native Windows tests, dist integrity, and release artifact checks run on this branch.
- The immutable release workflow verifies authenticated dependency installation before it can publish.
