### PR TITLE
chore: prepare v2.1.15 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-repo-sync",
-      "version": "2.1.14",
+      "version": "2.1.15",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-repo-sync",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Postman repo sync GitHub Action.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Version bump to 2.1.15 for release. Carries the transient GC delete retry fix (#100): preview collection GC deletes now retry on transient failures instead of failing the sync step.

## Validation

- Main CI green on merge commit 9713952 (CI + SEA binary).
- Release workflow publishes GH release assets and advances the rolling v2 alias on tag.
