### PR TITLE
ci(release): port automatic release cut

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,28 @@
 #!/bin/sh
+# Release tags are cut by .github/workflows/auto-release.yml, never by hand.
+#
+# A hand-pushed tag creates an immutable public identifier before any gate has
+# run against it. Reject immutable release tags here so the only path to a tag
+# is a passing CI cut.
+#
+# The rolling major alias (v2) is exempt: release.yml advances it from CI after
+# a successful publish, and that push is a legitimate force-update.
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "$remote_ref" ] && continue
+  case "$remote_ref" in
+    refs/tags/v[0-9]*.[0-9]*)
+      # GITHUB_ACTIONS is set by the runner itself, not by a developer
+      # shell, so the automated cut passes while a human push cannot.
+      if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+        echo "refusing to push immutable release tag ${remote_ref#refs/tags/} by hand." >&2
+        echo "Releases cut automatically from main: merge, and auto-release.yml tags only after gates pass." >&2
+        echo "Inspect the pending cut with 'node scripts/release-cut.mjs --plan'." >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
 if git diff HEAD --name-only | grep -Eq '^(src/|package\.json|package-lock\.json|tsconfig)'; then
   npm run verify:dist || {
     echo "dist is stale. Run 'npm run build' and stage dist/ before pushing." >&2

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,96 @@
+name: Auto Release
+
+# Cuts releases automatically from main.
+#
+# The tag is an OUTPUT of a passing run, never an input to one. release.yml
+# still triggers on `push: tags`, but nothing hand-pushes those tags any more:
+# this workflow creates a tag only after the exact bytes of the release commit
+# pass the full gate set. A failed cut therefore leaves no tag and burns no
+# version number, and the next merge to main retries the cut on a fresh one.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One cut at a time. Never cancel a cut in flight: it holds an unpushed tag.
+concurrency:
+  group: auto-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history and tags: the version selector reads every tag ever
+          # cut so it can skip burnt versions instead of reusing them.
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Plan release
+        id: plan
+        env:
+          PLAN_FILE: ${{ runner.temp }}/plan.json
+        run: |
+          set -euo pipefail
+          # Write the plan outside the worktree: the cut refuses to run from a
+          # dirty tree, so a stray artifact here would block every release.
+          node scripts/release-cut.mjs --plan | tee "$PLAN_FILE"
+          {
+            echo "release=$(node -p "require(process.env.PLAN_FILE).release === true")"
+            echo "version=$(node -p "require(process.env.PLAN_FILE).version || ''")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Cut release
+        if: steps.plan.outputs.release == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          node scripts/release-cut.mjs --execute
+
+      - name: Push release tag
+        if: steps.plan.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Push the tag only. main requires pull requests, and the release
+          # commit does not belong there: it carries just the version bump and
+          # rebuilt dist, which release.yml reads from the tagged commit.
+          git push origin "refs/tags/v${VERSION}"
+
+      - name: Start release workflow for the new tag
+        if: steps.plan.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Pushes authenticated with GITHUB_TOKEN do not trigger workflows, so
+          # release.yml is started explicitly against the new tag ref.
+          gh workflow run release.yml --ref "v${VERSION}"
+
+      - name: Report skipped cut
+        if: steps.plan.outputs.release != 'true'
+        env:
+          PLAN_FILE: ${{ runner.temp }}/plan.json
+        run: |
+          set -euo pipefail
+          echo "::notice::No release cut. $(node -p "require(process.env.PLAN_FILE).reason || 'no plan reason'")"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,17 @@ postman/
 
 See workspace `../../docs/CI.md` for shared rationale.
 
+## Releases
+
+Tags are an **output** of passing run, never input. Never push release tags by hand; `.githooks/pre-push` rejects them.
+
+- `.github/workflows/auto-release.yml` runs on every push to `main` and drives `scripts/release-cut.mjs`.
+- `node scripts/release-cut.mjs --plan` reports pending cut (fetch tags first). `--execute` bumps, rebuilds `dist/`, runs typecheck/lint/test, commits, re-verifies committed bytes, then tags last.
+- Version comes from highest tag ever cut, not `package.json`. Existing tags are burnt and skipped, so failed cut never reuses or rewinds version.
+- Conventional-commit type picks bump; `chore`/`ci`/`build`/`test`/`style` alone cut nothing.
+- release commit lives only on tag. `release.yml` reads tagged commit; `main` keeps advancing through pull requests.
+- `RELEASE_POLICY.md` holds full contract.
+
 ## Anti-Patterns
 
 - Never commit AWS credentials, Postman tokens, or secrets; mask before logging

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -15,16 +15,32 @@ Git tags and GitHub releases are the public release identifiers for this action.
 
 ## Release checks
 
-Run the package validators from this directory before pushing an immutable tag:
+Releases are cut automatically. Merging to `main` runs `.github/workflows/auto-release.yml`,
+which derives the next version from the conventional-commit history, then runs
+`scripts/release-cut.mjs`: bump, rebuild `dist/`, run the gate set, commit, and tag.
 
-1. Confirm the working tree is clean.
-2. `npm test`
-3. `npm run typecheck`
-4. `npm run lint`
-5. `npm run build`
-6. `npm run verify:dist`
-7. `npm run docs:tables` when `action.yml` changes, then confirm the `README.md` tables still match.
-8. Confirm `SECURITY.md`, `SUPPORT.md`, and this file still describe the release surface.
+The tag is created only after the exact bytes of the release commit pass every
+gate, so a failed cut leaves no tag and burns no version number. The next merge
+retries on a fresh version, skipping any already-tagged one.
+
+Do not push `vX.Y.Z` tags by hand. The pre-push hook refuses them, because a
+hand-pushed tag becomes a public identifier before any gate has run against it.
+
+To see what the next merge would cut:
+
+```sh
+node scripts/release-cut.mjs --plan
+```
+
+The same gates run locally before any push:
+
+1. `npm test`
+2. `npm run typecheck`
+3. `npm run lint`
+4. `npm run build`
+5. `npm run verify:dist`
+6. `npm run docs:tables` when `action.yml` changes, then confirm the `README.md` tables still match.
+7. Confirm `SECURITY.md`, `SUPPORT.md`, and this file still describe the release surface.
 
 ## npm package
 

--- a/scripts/release-cut.mjs
+++ b/scripts/release-cut.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * Automatic release cut.
+ *
+ * Owns the entire release transition in ONE node process: derive the next
+ * version, bump manifests, rebuild dist, run the declared gate set, commit,
+ * and only then create the tag.
+ *
+ * Two invariants this file exists to enforce:
+ *
+ * 1. Every git sha is read in-process via `git rev-parse`. No sha is ever
+ *    routed through a shell variable.
+ * 2. The tag is the LAST side effect, created only after the exact bytes of
+ *    the release commit pass validation. A failed cut leaves no tag behind.
+ *
+ * Already-taken tags are treated as burnt and skipped, so a previously failed
+ * version number is never reused (release tags are immutable by policy).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const PKG_PATH = path.join(REPO_ROOT, 'package.json');
+const LOCK_PATH = path.join(REPO_ROOT, 'package-lock.json');
+
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+const RELEASE_PATHS = new Set(['package.json', 'package-lock.json']);
+
+/** Conventional-commit subjects that carry no shippable behavior on their own. */
+const NON_SHIPPING_TYPES = new Set(['chore', 'ci', 'build', 'test', 'style']);
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', options.quiet ? 'ignore' : 'pipe']
+  }).trim();
+}
+
+function run(command, args) {
+  execFileSync(command, args, { cwd: REPO_ROOT, encoding: 'utf8', stdio: 'inherit' });
+}
+
+/**
+ * Classify a conventional-commit body into a semver bump.
+ * @param {string[]} messages full commit messages (subject + body)
+ * @returns {'major'|'minor'|'patch'|null} null when nothing shippable landed
+ */
+export function parseConventionalBump(messages) {
+  const entries = (Array.isArray(messages) ? messages : []).filter(
+    (message) => typeof message === 'string' && message.trim()
+  );
+  if (entries.length === 0) return null;
+
+  let bump = null;
+  const rank = { patch: 1, minor: 2, major: 3 };
+  const raise = (next) => {
+    if (!bump || rank[next] > rank[bump]) bump = next;
+  };
+
+  for (const message of entries) {
+    const subject = message.split('\n', 1)[0];
+    const header = /^([a-zA-Z]+)(\([^)]*\))?(!)?:/.exec(subject);
+    const type = header ? header[1].toLowerCase() : '';
+    const breaking = Boolean(header && header[3]) || /^BREAKING[ -]CHANGE:/m.test(message);
+
+    if (breaking) {
+      raise('major');
+      continue;
+    }
+    if (type === 'feat') {
+      raise('minor');
+      continue;
+    }
+    if (header && NON_SHIPPING_TYPES.has(type)) continue;
+    // fix, perf, refactor, revert, docs, and untyped commits all ship as a patch.
+    raise('patch');
+  }
+  return bump;
+}
+
+/**
+ * @param {string} version
+ * @param {'major'|'minor'|'patch'} bump
+ */
+export function applyBump(version, bump) {
+  const parsed = SEMVER.exec(String(version || ''));
+  if (!parsed) throw new Error(`current version ${version} is not plain semver`);
+  const [major, minor, patch] = parsed.slice(1).map(Number);
+  if (bump === 'major') return `${major + 1}.0.0`;
+  if (bump === 'minor') return `${major}.${minor + 1}.0`;
+  if (bump === 'patch') return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`unsupported bump ${bump}`);
+}
+
+/**
+ * Pick the next free version. Any tag that already exists is burnt: release
+ * tags are immutable, so a previously failed cut is skipped rather than reused.
+ *
+ * @param {{current: string, bump: 'major'|'minor'|'patch', takenTags: Iterable<string>}} input
+ */
+export function selectNextVersion({ current, bump, takenTags }) {
+  const taken = new Set(Array.from(takenTags || [], (tag) => String(tag).replace(/^v/, '')));
+  let candidate = applyBump(current, bump);
+  const skipped = [];
+  while (taken.has(candidate)) {
+    skipped.push(candidate);
+    candidate = applyBump(candidate, 'patch');
+    if (skipped.length > 256) throw new Error('exhausted patch space searching for a free release version');
+  }
+  return { version: candidate, skipped };
+}
+
+/**
+ * Set the version in package.json and package-lock.json without reformatting
+ * either file.
+ * @param {string} version
+ */
+export function writeVersion(version) {
+  if (!SEMVER.test(version)) throw new Error(`refusing to write non-semver version ${version}`);
+
+  const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf8'));
+  pkg.version = version;
+  writeFileSync(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  const lock = JSON.parse(readFileSync(LOCK_PATH, 'utf8'));
+  lock.version = version;
+  if (lock.packages && lock.packages['']) lock.packages[''].version = version;
+  writeFileSync(LOCK_PATH, `${JSON.stringify(lock, null, 2)}\n`);
+}
+
+/** Rebuild dist from source. */
+export function rebuildDist() {
+  run('npm', ['run', 'bundle']);
+}
+
+/**
+ * Prove the committed dist matches a fresh rebuild.
+ *
+ * verify:dist:assert diffs the working tree against committed dist, so it is
+ * only meaningful AFTER the release commit exists.
+ */
+export function assertCommittedDistMatchesSource() {
+  run('npm', ['run', 'verify:dist:assert']);
+}
+
+function assertCleanTree() {
+  const dirty = git(['status', '--porcelain']);
+  if (dirty) throw new Error(`refusing to cut a release from a dirty tree:\n${dirty}`);
+}
+
+function allTags() {
+  const local = git(['tag', '--list', 'v*']).split('\n').filter(Boolean);
+  let remote;
+  try {
+    remote = git(['ls-remote', '--tags', 'origin'])
+      .split('\n')
+      .map((line) => line.split('\t')[1] || '')
+      .map((ref) => ref.replace('refs/tags/', '').replace(/\^\{\}$/, ''))
+      .filter((tag) => tag.startsWith('v'));
+  } catch {
+    throw new Error('could not list remote tags; refusing to cut a release blind to burnt versions');
+  }
+  return new Set([...local, ...remote]);
+}
+
+function commitsSince(tag) {
+  const range = tag ? `${tag}..HEAD` : 'HEAD';
+  const raw = git(['log', range, '--no-merges', '--format=%B%x00']);
+  return raw.split('\u0000').map((entry) => entry.trim()).filter(Boolean);
+}
+
+function latestReleaseTag(taken) {
+  const versions = Array.from(taken)
+    .map((tag) => tag.replace(/^v/, ''))
+    .filter((version) => SEMVER.test(version))
+    .sort((a, b) => {
+      const left = a.split('.').map(Number);
+      const right = b.split('.').map(Number);
+      for (let i = 0; i < 3; i += 1) {
+        if (left[i] !== right[i]) return left[i] - right[i];
+      }
+      return 0;
+    });
+  const newest = versions[versions.length - 1];
+  return newest ? `v${newest}` : null;
+}
+
+/**
+ * Decide whether a release is due and which version it takes.
+ * Pure enough to run in --plan mode on any checkout.
+ */
+export function planRelease() {
+  const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf8'));
+  const taken = allTags();
+  const previous = latestReleaseTag(taken);
+  const messages = commitsSince(previous);
+  const bump = parseConventionalBump(messages);
+
+  if (!bump) {
+    return { release: false, reason: 'no shippable commits since the last release tag', previous };
+  }
+
+  const base = previous ? previous.replace(/^v/, '') : pkg.version;
+  const { version, skipped } = selectNextVersion({ current: base, bump, takenTags: taken });
+  return { release: true, previous, bump, version, skipped, commits: messages.length };
+}
+
+function executeRelease(plan) {
+  assertCleanTree();
+
+  const sourceCommit = git(['rev-parse', 'HEAD']);
+
+  writeVersion(plan.version);
+  rebuildDist();
+
+  run('npm', ['run', 'typecheck']);
+  run('npm', ['run', 'lint']);
+  run('npm', ['test']);
+
+  run('git', ['add', 'package.json', 'package-lock.json', 'dist']);
+  const staged = git(['diff', '--cached', '--name-only']).split('\n').filter(Boolean);
+  const offenders = staged.filter(
+    (file) => !RELEASE_PATHS.has(file) && !file.startsWith('dist/')
+  );
+  if (offenders.length > 0) {
+    throw new Error(`release commit touched non-release paths: ${offenders.join(', ')}`);
+  }
+
+  run('git', ['commit', '-m', `chore(release): v${plan.version}`]);
+
+  const releaseCommit = git(['rev-parse', 'HEAD']);
+  assertCommittedDistMatchesSource();
+
+  const committedVersion = JSON.parse(
+    git(['show', `${releaseCommit}:package.json`])
+  ).version;
+  if (committedVersion !== plan.version) {
+    throw new Error(
+      `committed version ${committedVersion} does not match planned ${plan.version}`
+    );
+  }
+
+  run('git', ['tag', '-a', `v${plan.version}`, '-m', `v${plan.version}`, releaseCommit]);
+  return { version: plan.version, releaseCommit, sourceCommit };
+}
+
+function main() {
+  const mode = process.argv[2] || '--plan';
+  if (!['--plan', '--execute'].includes(mode)) {
+    throw new Error('Usage: node scripts/release-cut.mjs --plan|--execute');
+  }
+
+  const plan = planRelease();
+  if (!plan.release) {
+    process.stdout.write(`${JSON.stringify({ ...plan, mode }, null, 2)}\n`);
+    return;
+  }
+
+  if (mode === '--plan') {
+    process.stdout.write(`${JSON.stringify({ ...plan, mode }, null, 2)}\n`);
+    return;
+  }
+
+  const result = executeRelease(plan);
+  process.stdout.write(`${JSON.stringify({ ...plan, ...result, mode }, null, 2)}\n`);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Automatic release-cut contract.
+ *
+ * Pins the invariants whose absence burned immutable release tags: a burnt
+ * version number must be skipped rather than reused, and the tag must be
+ * created only after the committed release bytes pass every gate.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error -- release tooling is plain ESM, intentionally outside tsconfig source roots
+import * as releaseCut from '../scripts/release-cut.mjs';
+
+const parseConventionalBump = releaseCut.parseConventionalBump as (m: string[]) => string | null;
+const applyBump = releaseCut.applyBump as (v: string, b: string) => string;
+const selectNextVersion = releaseCut.selectNextVersion as (input: {
+  current: string;
+  bump: string;
+  takenTags: string[];
+}) => { version: string; skipped: string[] };
+
+const repoRoot = process.cwd();
+const autoReleaseWorkflow = readFileSync(
+  join(repoRoot, '.github/workflows/auto-release.yml'),
+  'utf8'
+).replace(/\r\n/g, '\n');
+const releaseCutSource = readFileSync(join(repoRoot, 'scripts/release-cut.mjs'), 'utf8');
+const prePushHook = readFileSync(join(repoRoot, '.githooks/pre-push'), 'utf8');
+
+describe('release version selection', () => {
+  it('skips a burnt version instead of reusing it', () => {
+    const plan = selectNextVersion({
+      current: '2.1.14',
+      bump: 'patch',
+      takenTags: ['v2.1.14', 'v2.1.15']
+    });
+    expect(plan.version).toBe('2.1.16');
+    expect(plan.skipped).toContain('2.1.15');
+  });
+
+  it('never returns a version that is already tagged', () => {
+    const taken = ['v2.0.0', 'v2.0.1', 'v2.0.2', 'v2.0.3'];
+    const plan = selectNextVersion({ current: '2.0.0', bump: 'patch', takenTags: taken });
+    expect(taken).not.toContain(`v${plan.version}`);
+    expect(plan.version).toBe('2.0.4');
+  });
+
+  it('maps conventional commits onto semver bumps', () => {
+    expect(parseConventionalBump(['feat: add input'])).toBe('minor');
+    expect(parseConventionalBump(['fix: correct reconcile'])).toBe('patch');
+    expect(parseConventionalBump(['feat!: drop legacy input'])).toBe('major');
+    expect(parseConventionalBump(['refactor: x\n\nBREAKING CHANGE: removed'])).toBe('major');
+    expect(parseConventionalBump(['feat: a', 'fix: b'])).toBe('minor');
+    expect(applyBump('2.1.15', 'minor')).toBe('2.2.0');
+  });
+
+  it('does not cut a release for release-plumbing commits alone', () => {
+    expect(parseConventionalBump(['chore(release): v2.1.15'])).toBeNull();
+    expect(parseConventionalBump(['chore: bump lockfile'])).toBeNull();
+    expect(parseConventionalBump(['ci: retune gate queue', 'test: add case'])).toBeNull();
+    expect(parseConventionalBump([])).toBeNull();
+  });
+});
+
+describe('release-cut ordering contract', () => {
+  it('creates the tag only after the committed release bytes are verified', () => {
+    const tagIndex = releaseCutSource.indexOf("'tag', '-a'");
+    const commitIndex = releaseCutSource.indexOf("'commit', '-m'");
+    const verifyAfterCommit = releaseCutSource.indexOf('const releaseCommit');
+    expect(tagIndex).toBeGreaterThan(-1);
+    expect(commitIndex).toBeGreaterThan(-1);
+    expect(commitIndex).toBeLessThan(verifyAfterCommit);
+    expect(verifyAfterCommit).toBeLessThan(tagIndex);
+    expect(releaseCutSource.indexOf('assertCommittedDistMatchesSource();')).toBeLessThan(tagIndex);
+  });
+
+  it('reads every sha in-process rather than through shell variables', () => {
+    expect(releaseCutSource).not.toContain('PREPARE_SHA');
+    expect(releaseCutSource).toContain("git(['rev-parse', 'HEAD'])");
+  });
+
+  it('rebuilds dist before committing and verifies committed dist before tagging', () => {
+    expect(releaseCutSource).toContain("run('npm', ['run', 'bundle'])");
+    const rebuild = releaseCutSource.indexOf('rebuildDist();');
+    const commit = releaseCutSource.indexOf("'commit', '-m'");
+    const assertDist = releaseCutSource.indexOf('assertCommittedDistMatchesSource();');
+    const tag = releaseCutSource.indexOf("'tag', '-a'");
+    expect(rebuild).toBeGreaterThan(-1);
+    expect(rebuild).toBeLessThan(commit);
+    expect(commit).toBeLessThan(assertDist);
+    expect(assertDist).toBeLessThan(tag);
+  });
+
+  it('stages only release paths in the release commit', () => {
+    expect(releaseCutSource).toContain("'package.json', 'package-lock.json', 'dist'");
+    expect(releaseCutSource).not.toContain('validation/evidence');
+  });
+});
+
+describe('auto-release workflow', () => {
+  it('cuts from main pushes instead of hand-pushed tags', () => {
+    expect(autoReleaseWorkflow).toContain('branches: [main]');
+    expect(autoReleaseWorkflow).not.toMatch(/on:\n\s+push:\n\s+tags:/);
+  });
+
+  it('fetches full history and tags so burnt versions are visible', () => {
+    expect(autoReleaseWorkflow).toContain('fetch-depth: 0');
+    expect(autoReleaseWorkflow).toContain('fetch-tags: true');
+  });
+
+  it('plans before it cuts and cuts before it pushes', () => {
+    const plan = autoReleaseWorkflow.indexOf('name: Plan release');
+    const cut = autoReleaseWorkflow.indexOf('name: Cut release');
+    const push = autoReleaseWorkflow.indexOf('name: Push release tag');
+    expect(plan).toBeGreaterThan(-1);
+    expect(plan).toBeLessThan(cut);
+    expect(cut).toBeLessThan(push);
+  });
+
+  it('pushes only the tag, never a commit onto protected main', () => {
+    expect(autoReleaseWorkflow).toContain('git push origin "refs/tags/v${VERSION}"');
+    expect(autoReleaseWorkflow).not.toContain('HEAD:${GITHUB_REF_NAME}');
+    expect(autoReleaseWorkflow).not.toContain('gh pr create');
+  });
+
+  it('starts release.yml explicitly after the tag push', () => {
+    const push = autoReleaseWorkflow.indexOf('name: Push release tag');
+    const dispatch = autoReleaseWorkflow.indexOf('name: Start release workflow for the new tag');
+    expect(dispatch).toBeGreaterThan(push);
+    expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "v${VERSION}"');
+  });
+
+  it('never cancels a cut in flight', () => {
+    expect(autoReleaseWorkflow).toContain('cancel-in-progress: false');
+  });
+
+  it('writes its plan outside the worktree so the cut sees a clean tree', () => {
+    expect(autoReleaseWorkflow).not.toMatch(/tee plan\.json/);
+    expect(autoReleaseWorkflow).toContain('PLAN_FILE: ${{ runner.temp }}/plan.json');
+  });
+});
+
+describe('pre-push tag guard', () => {
+  it('rejects hand-pushed immutable release tags', () => {
+    expect(prePushHook).toContain('refs/tags/v[0-9]*.[0-9]*');
+    expect(prePushHook).toContain('GITHUB_ACTIONS');
+    expect(prePushHook).toContain('refusing to push immutable release tag');
+  });
+
+  it('exempts the rolling major alias from the immutable-tag guard', () => {
+    // v2 matches v[0-9]* but not v[0-9]*.[0-9]* — only dotted semver tags are blocked.
+    expect(prePushHook).toMatch(/refs\/tags\/v\[0-9\]\*\.\[0-9\]\*/);
+  });
+
+  it('preserves the existing dist staleness check', () => {
+    expect(prePushHook).toContain('npm run verify:dist');
+    expect(prePushHook).toContain('dist is stale');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/release-cut.mjs` so tags are created only after the release commit passes typecheck, lint, test, and dist verification.
- Adds `.github/workflows/auto-release.yml` on push to `main` plus `workflow_dispatch`; pushes only the tag and explicitly starts `release.yml`.
- Extends `.githooks/pre-push` to reject hand-pushed immutable release tags (rolling `v2` alias exempt).
- Documents the contract in `AGENTS.md`, `RELEASE_POLICY.md`, and `tests/auto-release.test.ts`.

## Test plan
- [x] `node --check scripts/release-cut.mjs`
- [x] `node scripts/release-cut.mjs --plan` (valid JSON, exit 0)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run bundle && npm run verify:dist:assert`
- [x] `actionlint` on `.github/workflows/auto-release.yml`