### PR TITLE
fix(release): recover unpublished immutable tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   cut:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -76,16 +77,31 @@ jobs:
           # rebuilt dist, which release.yml reads from the tagged commit.
           git push origin "refs/tags/v${VERSION}"
 
-      - name: Start release workflow for the new tag
-        if: steps.plan.outputs.release == 'true'
+      - name: Start or recover release workflow
+        id: release_target
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.plan.outputs.version }}
+          PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |
           set -euo pipefail
-          # Pushes authenticated with GITHUB_TOKEN do not trigger workflows, so
-          # release.yml is started explicitly against the new tag ref.
-          gh workflow run release.yml --ref "v${VERSION}"
+          RELEASE="$(node -p "require(process.env.PLAN_FILE).release === true")"
+          if [ "$RELEASE" = true ]; then
+            TAG="v$(node -p "require(process.env.PLAN_FILE).version")"
+          else
+            TAG="$(node -p "require(process.env.PLAN_FILE).previous || ''")"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [ -z "$TAG" ]; then
+            echo "::notice::No release tag is available to dispatch."
+            exit 0
+          fi
+          if [ "$RELEASE" != true ] && gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists; no recovery dispatch needed."
+            exit 0
+          fi
+          # GITHUB_TOKEN tag pushes do not trigger workflows. On a rerun with
+          # no new cut, retry the latest tag when its GitHub release is absent.
+          gh workflow run release.yml --ref "$TAG"
 
       - name: Report skipped cut
         if: steps.plan.outputs.release != 'true'

--- a/scripts/release-cut.mjs
+++ b/scripts/release-cut.mjs
@@ -28,6 +28,7 @@ const PKG_PATH = path.join(REPO_ROOT, 'package.json');
 const LOCK_PATH = path.join(REPO_ROOT, 'package-lock.json');
 
 const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+const IMMUTABLE_TAG = /^v?(\d+)\.(\d+)(?:\.(\d+))?$/;
 const RELEASE_PATHS = new Set(['package.json', 'package-lock.json']);
 
 /** Conventional-commit subjects that carry no shippable behavior on their own. */
@@ -97,6 +98,12 @@ export function applyBump(version, bump) {
   throw new Error(`unsupported bump ${bump}`);
 }
 
+export function normalizeReleaseVersion(value) {
+  const parsed = IMMUTABLE_TAG.exec(String(value || ''));
+  if (!parsed) return null;
+  return `${Number(parsed[1])}.${Number(parsed[2])}.${Number(parsed[3] ?? 0)}`;
+}
+
 /**
  * Pick the next free version. Any tag that already exists is burnt: release
  * tags are immutable, so a previously failed cut is skipped rather than reused.
@@ -104,7 +111,9 @@ export function applyBump(version, bump) {
  * @param {{current: string, bump: 'major'|'minor'|'patch', takenTags: Iterable<string>}} input
  */
 export function selectNextVersion({ current, bump, takenTags }) {
-  const taken = new Set(Array.from(takenTags || [], (tag) => String(tag).replace(/^v/, '')));
+  const taken = new Set(
+    Array.from(takenTags || [], normalizeReleaseVersion).filter(Boolean)
+  );
   let candidate = applyBump(current, bump);
   const skipped = [];
   while (taken.has(candidate)) {
@@ -145,7 +154,7 @@ export function rebuildDist() {
  * only meaningful AFTER the release commit exists.
  */
 export function assertCommittedDistMatchesSource() {
-  run('npm', ['run', 'verify:dist:assert']);
+  run('npm', ['run', 'verify:dist']);
 }
 
 function assertCleanTree() {
@@ -174,20 +183,22 @@ function commitsSince(tag) {
   return raw.split('\u0000').map((entry) => entry.trim()).filter(Boolean);
 }
 
-function latestReleaseTag(taken) {
-  const versions = Array.from(taken)
-    .map((tag) => tag.replace(/^v/, ''))
-    .filter((version) => SEMVER.test(version))
+export function latestReleaseTag(taken) {
+  const versions = Array.from(taken || [], (tag) => ({
+    tag: String(tag),
+    version: normalizeReleaseVersion(tag)
+  }))
+    .filter((entry) => entry.version)
     .sort((a, b) => {
-      const left = a.split('.').map(Number);
-      const right = b.split('.').map(Number);
+      const left = a.version.split('.').map(Number);
+      const right = b.version.split('.').map(Number);
       for (let i = 0; i < 3; i += 1) {
         if (left[i] !== right[i]) return left[i] - right[i];
       }
-      return 0;
+      return a.tag.split('.').length - b.tag.split('.').length;
     });
   const newest = versions[versions.length - 1];
-  return newest ? `v${newest}` : null;
+  return newest?.tag ?? null;
 }
 
 /**
@@ -205,7 +216,7 @@ export function planRelease() {
     return { release: false, reason: 'no shippable commits since the last release tag', previous };
   }
 
-  const base = previous ? previous.replace(/^v/, '') : pkg.version;
+  const base = previous ? normalizeReleaseVersion(previous) : pkg.version;
   const { version, skipped } = selectNextVersion({ current: base, bump, takenTags: taken });
   return { release: true, previous, bump, version, skipped, commits: messages.length };
 }

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -20,6 +20,7 @@ const selectNextVersion = releaseCut.selectNextVersion as (input: {
   bump: string;
   takenTags: string[];
 }) => { version: string; skipped: string[] };
+const latestReleaseTag = releaseCut.latestReleaseTag as (tags: string[]) => string | null;
 
 const repoRoot = process.cwd();
 const autoReleaseWorkflow = readFileSync(
@@ -45,6 +46,13 @@ describe('release version selection', () => {
     const plan = selectNextVersion({ current: '2.0.0', bump: 'patch', takenTags: taken });
     expect(taken).not.toContain(`v${plan.version}`);
     expect(plan.version).toBe('2.0.4');
+  });
+
+  it('normalizes accepted zero-patch minor tags', () => {
+    expect(latestReleaseTag(['v2.9.9', 'v3.0', 'v3'])).toBe('v3.0');
+    expect(
+      selectNextVersion({ current: '2.9.9', bump: 'major', takenTags: ['v3.0'] })
+    ).toEqual({ version: '3.0.1', skipped: ['3.0.0'] });
   });
 
   it('maps conventional commits onto semver bumps', () => {
@@ -83,6 +91,7 @@ describe('release-cut ordering contract', () => {
 
   it('rebuilds dist before committing and verifies committed dist before tagging', () => {
     expect(releaseCutSource).toContain("run('npm', ['run', 'bundle'])");
+    expect(releaseCutSource).toContain("run('npm', ['run', 'verify:dist'])");
     const rebuild = releaseCutSource.indexOf('rebuildDist();');
     const commit = releaseCutSource.indexOf("'commit', '-m'");
     const assertDist = releaseCutSource.indexOf('assertCommittedDistMatchesSource();');
@@ -105,6 +114,10 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).not.toMatch(/on:\n\s+push:\n\s+tags:/);
   });
 
+  it('rejects manually dispatched cuts outside main', () => {
+    expect(autoReleaseWorkflow).toContain("if: github.ref == 'refs/heads/main'");
+  });
+
   it('fetches full history and tags so burnt versions are visible', () => {
     expect(autoReleaseWorkflow).toContain('fetch-depth: 0');
     expect(autoReleaseWorkflow).toContain('fetch-tags: true');
@@ -125,11 +138,13 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).not.toContain('gh pr create');
   });
 
-  it('starts release.yml explicitly after the tag push', () => {
+  it('starts or recovers release.yml after the tag push', () => {
     const push = autoReleaseWorkflow.indexOf('name: Push release tag');
-    const dispatch = autoReleaseWorkflow.indexOf('name: Start release workflow for the new tag');
+    const dispatch = autoReleaseWorkflow.indexOf('name: Start or recover release workflow');
     expect(dispatch).toBeGreaterThan(push);
-    expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "v${VERSION}"');
+    expect(autoReleaseWorkflow).toContain('require(process.env.PLAN_FILE).previous');
+    expect(autoReleaseWorkflow).toContain('gh release view "$TAG"');
+    expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "$TAG"');
   });
 
   it('never cancels a cut in flight', () => {


### PR DESCRIPTION
## Summary

An immutable tag could be pushed before the release workflow dispatch failed, leaving that tag without a GitHub release or package and no rerun path. Manual dispatch also accepted feature refs, and two-component zero-patch tags could be ignored during version planning.

Automatic cuts now run only from `main`, reconcile the newest unpublished tag on rerun, treat `vN.x` as `N.x.0` for ordering and collision checks, and rebuild the committed bundle before tagging. This keeps release state recoverable and prevents unmerged or duplicate version cuts.

## Safety

- A tag that already has a GitHub release is a recovery no-op.
- Git history ranges retain the existing immutable tag text while version comparisons use its normalized numeric form.
- The committed `dist/` is rebuilt and diffed before the tag is pushed.

## Validation

- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run verify:dist`
- `actionlint .github/workflows/auto-release.yml`
