### PR TITLE
fix(release): reconcile incomplete cuts before new tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
 
 permissions:
   contents: read
@@ -23,7 +26,7 @@ concurrency:
 
 jobs:
   cut:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,17 +38,81 @@ jobs:
           # cut so it can skip burnt versions instead of reusing them.
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Reconcile prior release
+        id: reconcile
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROLLING_ALIASES: major
+        run: |
+          set -euo pipefail
+          LATEST=""
+          while IFS= read -r CANDIDATE; do
+            if [[ "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              EXPECTED="${CANDIDATE#v}"
+            elif [[ "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              EXPECTED="${CANDIDATE#v}.0"
+            else
+              continue
+            fi
+            if ! PACKAGE_VERSION="$(git show "${CANDIDATE}^{commit}:package.json" 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null)"; then
+              continue
+            fi
+            [ "$PACKAGE_VERSION" = "$EXPECTED" ] || continue
+            LATEST="$CANDIDATE"
+          done < <(git tag --list 'v*' --sort=v:refname)
+
+          TAG=""
+          if [ -n "$LATEST" ] && ! gh release view "$LATEST" >/dev/null 2>&1; then
+            TAG="$LATEST"
+          elif [ -n "$LATEST" ]; then
+            VERSION="${LATEST#v}"
+            IFS='.' read -r MAJOR MINOR _ <<< "$VERSION"
+            if [ "$MAJOR" != 0 ]; then
+              TARGET="$(git rev-parse "${LATEST}^{commit}")"
+              read -r -a ALIAS_KINDS <<< "$ROLLING_ALIASES"
+              for KIND in "${ALIAS_KINDS[@]}"; do
+                case "$KIND" in
+                  major) ALIAS="v$MAJOR" ;;
+                  minor) ALIAS="v$MAJOR.$MINOR" ;;
+                  *) echo "::error::Unsupported rolling alias kind: $KIND"; exit 1 ;;
+                esac
+                if ! ALIAS_COMMIT="$(git rev-parse --verify "${ALIAS}^{commit}" 2>/dev/null)" ||
+                  [ "$ALIAS_COMMIT" != "$TARGET" ]; then
+                  TAG="$LATEST"
+                  break
+                fi
+              done
+            fi
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [ -z "$TAG" ]; then
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "blocked=true" >> "$GITHUB_OUTPUT"
+          ACTIVE="$(gh run list --workflow release.yml --branch "$TAG" --limit 20 --json status --jq '[.[] | select(.status != "completed")] | length')"
+          if [ "$ACTIVE" -gt 0 ]; then
+            echo "::notice::Release $TAG is already queued or in progress."
+            exit 0
+          fi
+          gh workflow run release.yml --ref "$TAG"
+
       - uses: actions/setup-node@v7
+        if: steps.reconcile.outputs.blocked != 'true'
         with:
           node-version: '24'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+        if: steps.reconcile.outputs.blocked != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Plan release
         id: plan
+        if: steps.reconcile.outputs.blocked != 'true'
         env:
           PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |
@@ -79,6 +146,7 @@ jobs:
 
       - name: Start or recover release workflow
         id: release_target
+        if: steps.reconcile.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PLAN_FILE: ${{ runner.temp }}/plan.json
@@ -104,7 +172,7 @@ jobs:
           gh workflow run release.yml --ref "$TAG"
 
       - name: Report skipped cut
-        if: steps.plan.outputs.release != 'true'
+        if: steps.reconcile.outputs.blocked != 'true' && steps.plan.outputs.release != 'true'
         env:
           PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -23,6 +23,11 @@ The tag is created only after the exact bytes of the release commit pass every
 gate, so a failed cut leaves no tag and burns no version number. The next merge
 retries on a fresh version, skipping any already-tagged one.
 
+Before planning another cut, auto-release reconciles the latest immutable tag
+when its GitHub release is missing or its rolling alias has not advanced. It
+does not duplicate an active release run, and a successful release completion
+resumes planning.
+
 Do not push `vX.Y.Z` tags by hand. The pre-push hook refuses them, because a
 hand-pushed tag becomes a public identifier before any gate has run against it.
 

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -147,6 +147,28 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "$TAG"');
   });
 
+  it('reconciles the prior incomplete tag before planning another cut', () => {
+    const reconcile = autoReleaseWorkflow.indexOf('name: Reconcile prior release');
+    const plan = autoReleaseWorkflow.indexOf('name: Plan release');
+    expect(reconcile).toBeGreaterThan(-1);
+    expect(reconcile).toBeLessThan(plan);
+    expect(autoReleaseWorkflow).toContain("git tag --list 'v*'");
+    expect(autoReleaseWorkflow).toContain('if ! PACKAGE_VERSION="$(git show');
+    expect(autoReleaseWorkflow).toContain('gh run list --workflow release.yml --branch "$TAG"');
+    expect(autoReleaseWorkflow).toContain("steps.reconcile.outputs.blocked != 'true'");
+    const activeRun = autoReleaseWorkflow.indexOf('gh run list --workflow release.yml');
+    expect(autoReleaseWorkflow.indexOf('gh workflow run release.yml', activeRun)).toBeGreaterThan(
+      activeRun
+    );
+  });
+
+  it('recovers alias failures and resumes after a successful release', () => {
+    expect(autoReleaseWorkflow).toContain('workflow_run:');
+    expect(autoReleaseWorkflow).toContain('workflows: [Release]');
+    expect(autoReleaseWorkflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(autoReleaseWorkflow).toContain('git rev-parse --verify "${ALIAS}^{commit}"');
+  });
+
   it('never cancels a cut in flight', () => {
     expect(autoReleaseWorkflow).toContain('cancel-in-progress: false');
   });


### PR DESCRIPTION
## Summary

An immutable tag could remain unpublished after a release dispatch failure, while a later main push cut another version. Auto-release now reconciles the latest immutable tag before planning a new cut, avoids redispatching an active release, and resumes planning after a successful Release workflow.

## What changed

- Treat a missing GitHub release or stale rolling major alias as an incomplete latest cut.
- Pause cut steps while the incomplete tag is queued or in progress.
- Skip legacy tags that do not contain a matching package manifest.
- Document the recovery contract in `RELEASE_POLICY.md`.

## Validation

- `npm ci && npm test && npm run typecheck && npm run build && npm run verify:dist:assert`
- `npx vitest run tests/auto-release.test.ts`
- `actionlint .github/workflows/auto-release.yml`
- Live tag-history probe selected `v2.1.16` and confirmed its GitHub release and `v2` alias target.
