### PR TITLE
chore(deps): bump the actions group and follow the pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           # node_modules is exact-lock cached below; skip setup-node's npm
           # package-manager cache restore/save on this warm-sensitive lane.
           package-manager-cache: false
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: windows-node-modules
         with:
           path: node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: release-${{ github.run_id }}-${{ github.run_attempt }}
           path: release-artifacts

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -150,7 +150,7 @@ describe('CI and SEA PR workflow contracts', () => {
     expect(windows).toMatch(/^\s*package-manager-cache:\s*false\s*$/m);
 
     expect(windows).toContain(
-      'uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0',
+      'uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0',
     );
     expect(windows).toContain('id: windows-node-modules');
     expect(windows).toContain('path: node_modules');

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -67,7 +67,7 @@ describe('release workflow publishing contract', () => {
     expect(releaseWorkflow).toMatch(/verify-package:[\s\S]*?permissions:\n\s+contents: read/);
     const publish = job('publish');
     expect(publish).toMatch(/permissions:\n\s+contents: write\n\s+id-token: write/);
-    expect(publish).toContain('actions/download-artifact@v7');
+    expect(publish).toContain('actions/download-artifact@v8');
     expect(publish).not.toContain('actions/checkout');
     expect(publish).not.toContain('npm ci');
     expect(publish).not.toMatch(/\bnpm pack\b/);


### PR DESCRIPTION
## Change

Takes the grouped GitHub Actions bump that Dependabot proposed, rebased onto current `main`, plus the test-side changes the bump requires.

The workflow contract tests assert exact pinned action versions. A bump that moves a pin therefore fails them until the expectation moves with it, which is why the Dependabot branches were red on `gate` and `Windows gate`.

Where a bump moved a version that the workflow also references in plain text, those references are aligned too, so the workflow stays internally consistent rather than pinning one version and verifying another.

## Verification

`npm run typecheck`, `npm run lint`, and `npm test` all green locally on this branch.

Supersedes the Dependabot PR for the same group.
