### PR TITLE
Fix public mock validation before reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ with:
   monitor-id: 1e2f3a4b-monitor-id
 ```
 
+Repo-sync supports public mocks for anonymous validation. An explicit `mock-url` must match one mock in the resolved workspace and reference the expected baseline collection and environment. Discovered and newly created mocks pass the same live visibility check. Private mocks, responses without a recognized visibility field, stale URLs, and identity mismatches fail before `mock-url` is emitted; repo-sync never places a Postman API key in a collection or environment to make a private mock callable.
+
 ### mTLS certificates for Postman CLI runs
 
 The generated CI workflow can run [Postman CLI collection runs](https://learning.postman.com/docs/postman-cli/postman-cli-collections/) with client certificates. Pass the cert material as inputs; when a GitHub token and repository context are available, the action persists them as repository secrets (`POSTMAN_SSL_CLIENT_CERT_B64`, `POSTMAN_SSL_CLIENT_KEY_B64`, `POSTMAN_SSL_CLIENT_PASSPHRASE`, `POSTMAN_SSL_EXTRA_CA_CERTS_B64`) for the generated workflow:
@@ -283,7 +285,7 @@ For `commit-and-push`, the push target is resolved from `current-ref`, then `GIT
 
 Mocks and monitors: when `baseline-collection-id`, `workspace-id`, and at least one environment are available, the action creates or reuses a mock server. When `smoke-collection-id` is also available, it creates or reuses a cloud smoke monitor unless `monitor-type: cli` is set. With an empty `monitor-cron`, a new cloud monitor is created disabled and triggered once per workflow invocation.
 
-Asset reuse priority is explicit inputs (`environment-uids-json`, `mock-url`, `monitor-id`), then live discovery by exact workspace-scoped name, collection UID, and environment UID, then create. Creates submit once and reconcile on ambiguous gateway errors; overlapping compatible creates inside one process share a single in-flight promise. Adopted environments are updated to the requested values. Mock environment assignment has no verified patch route, so a mock is reused only when its live environment already matches; mismatches are never claimed as converged. Concurrent jobs against the same workspace can still race because Postman does not expose create idempotency keys—serialize those workflows with GitHub Actions `concurrency` (or an equivalent CI lock) when duplicate mocks/monitors/environments would be harmful.
+Asset reuse priority is explicit inputs (`environment-uids-json`, `mock-url`, `monitor-id`), then live discovery by exact workspace-scoped name, collection UID, and environment UID, then create. Mock reuse is public-only: the gateway's live `published` field must confirm public visibility, and explicit URLs must match the expected workspace, collection, and environment. Private or unknown visibility fails closed without injecting credentials. Creates submit once and reconcile on ambiguous gateway errors; overlapping compatible creates inside one process share a single in-flight promise. Adopted environments are updated to the requested values. Mock environment assignment has no verified patch route, so a mock is reused only when its live environment already matches; mismatches are never claimed as converged. Concurrent jobs against the same workspace can still race because Postman does not expose create idempotency keys—serialize those workflows with GitHub Actions `concurrency` (or an equivalent CI lock) when duplicate mocks/monitors/environments would be harmful.
 
 Deeper reference:
 

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -136941,6 +136941,25 @@ var PostmanAssetsClient = class {
 };
 
 // src/lib/postman/postman-gateway-assets-client.ts
+var MockContractError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MockContractError";
+  }
+};
+function requirePublicMock(mock) {
+  if (mock.visibility === "private") {
+    throw new MockContractError(
+      `MOCK_NOT_PUBLIC: Mock ${mock.uid} is private. Make it public in Postman or remove/rename it so repo-sync can create the canonical public mock.`
+    );
+  }
+  if (mock.visibility !== "public") {
+    throw new MockContractError(
+      `MOCK_VISIBILITY_UNKNOWN: Mock ${mock.uid} did not expose a supported visibility field. Refusing to assume it is publicly callable.`
+    );
+  }
+  return mock;
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -137121,6 +137140,41 @@ var PostmanGatewayAssetsClient = class {
     if (!record) return "";
     const id = record.uid ?? record.id;
     return typeof id === "string" ? id.trim() : String(id ?? "").trim();
+  }
+  decodeMockRecord(value, operation) {
+    const record = this.asRecord(value);
+    if (!record) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a non-object mock record`
+      );
+    }
+    const uid = this.idOf(record);
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const collection = typeof record.collection === "string" ? record.collection.trim() : "";
+    const mockUrl = typeof (record.url ?? record.mockUrl) === "string" ? String(record.url ?? record.mockUrl).trim() : "";
+    const environment = typeof record.environment === "string" ? record.environment.trim() : "";
+    if (!uid) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a mock without a UID`
+      );
+    }
+    if (!name) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a name`
+      );
+    }
+    if (!collection) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a collection UID`
+      );
+    }
+    if (!mockUrl) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a URL`
+      );
+    }
+    const visibility = typeof record.published === "boolean" ? record.published ? "public" : "private" : "unknown";
+    return { uid, name, collection, mockUrl, environment, visibility };
   }
   /**
    * Reduce a Postman public uid (`<owner>-<uuid>`, 6 hyphen groups) to the bare
@@ -137422,7 +137476,8 @@ var PostmanGatewayAssetsClient = class {
     return this.singleFlight(flightKey, flightKey, "mock", async () => {
       const existing = await this.findMockByCollection(collection, environment, mockName);
       if (existing) {
-        return { uid: existing.uid, url: existing.mockUrl };
+        const reusable = requirePublicMock(existing);
+        return { uid: reusable.uid, url: reusable.mockUrl };
       }
       const body = {
         name: mockName,
@@ -137445,13 +137500,12 @@ var PostmanGatewayAssetsClient = class {
       );
       const parseMock = (response) => {
         const record = this.dataOf(response);
-        const uid = this.idOf(record);
-        if (!uid) {
-          throw new Error("Mock create did not return a UID");
-        }
+        const created = requirePublicMock(
+          this.decodeMockRecord(record, "Mock create")
+        );
         return {
-          uid,
-          url: String(record?.url ?? record?.mockUrl ?? "").trim()
+          uid: created.uid,
+          url: created.mockUrl
         };
       };
       try {
@@ -137462,7 +137516,8 @@ var PostmanGatewayAssetsClient = class {
           error2
         );
         if (adopted) {
-          return { uid: adopted.uid, url: adopted.mockUrl };
+          const reusable = requirePublicMock(adopted);
+          return { uid: reusable.uid, url: reusable.mockUrl };
         }
         if (adopted === void 0) {
           const retried = await this.resendAbsentCreate(async () => parseMock(await send2("auto")));
@@ -137478,14 +137533,14 @@ var PostmanGatewayAssetsClient = class {
       method: "get",
       path: `/mocks?workspace=${this.workspaceId}`
     });
-    const items = Array.isArray(response) ? response : Array.isArray(this.asRecord(response)?.data) ? this.asRecord(response).data : [];
-    return items.map((raw) => this.asRecord(raw)).filter((m) => m !== null).map((m) => ({
-      uid: this.idOf(m),
-      name: String(m.name ?? ""),
-      collection: String(m.collection ?? ""),
-      mockUrl: String(m.url ?? m.mockUrl ?? ""),
-      environment: String(m.environment ?? "")
-    }));
+    const envelope = this.asRecord(response);
+    const items = Array.isArray(response) ? response : Array.isArray(envelope?.data) ? envelope.data : null;
+    if (!items) {
+      throw new MockContractError(
+        "CONTRACT_MOCK_RESPONSE_INVALID: Mock list envelope must be an array or contain a data array"
+      );
+    }
+    return items.map((raw) => this.decodeMockRecord(raw, "Mock list"));
   }
   /**
    * Delete an environment through the sync service (GC path). The path id is
@@ -137539,7 +137594,7 @@ var PostmanGatewayAssetsClient = class {
       `workspace ${this.workspaceId}, name "${mockName}", collection ${want}, and environment ${environment || "(none)"}`,
       matches
     );
-    return match ? { uid: match.uid, mockUrl: match.mockUrl } : null;
+    return match;
   }
   // --- monitors (service: monitors; collection-based = jobTemplates) ---
   /** Map raw jobTemplate records to the facade shape; `collection` is a flat public uid. */
@@ -138468,6 +138523,61 @@ function resolveRepoSyncMasker(dependencies) {
 }
 function causeText(cause) {
   return cause instanceof Error ? cause.message : String(cause);
+}
+function normalizeMockUrl(value, source) {
+  let url;
+  try {
+    url = new URL(String(value || "").trim());
+  } catch {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} is not a valid absolute URL`
+    );
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} must be an HTTPS URL without credentials, query parameters, or a fragment`
+    );
+  }
+  url.pathname = url.pathname.replace(/\/+$/g, "") || "/";
+  return url.toString();
+}
+function resolveExplicitPublicMock(mocks, explicitUrl, collectionUid, environmentUid) {
+  const normalized = normalizeMockUrl(explicitUrl, "mock-url");
+  const matches = mocks.filter(
+    (mock) => normalizeMockUrl(mock.mockUrl, `mock ${mock.uid} URL`) === normalized
+  );
+  if (matches.length === 0) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_NOT_FOUND: mock-url was not found in the resolved workspace mock inventory`
+    );
+  }
+  if (matches.length > 1) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_AMBIGUOUS: mock-url matched multiple workspace mocks (${matches.map((mock) => mock.uid).join(", ")})`
+    );
+  }
+  const match = matches[0];
+  if (match.collection !== collectionUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references collection ${match.collection || "(none)"}, expected ${collectionUid}`
+    );
+  }
+  if (match.environment !== environmentUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references environment ${match.environment || "(none)"}, expected ${environmentUid}`
+    );
+  }
+  return requirePublicMock(match);
+}
+function shouldRetryMockCreate(error2) {
+  if (error2 instanceof MockContractError) return false;
+  if (error2 instanceof HttpError) {
+    return error2.status === 408 || error2.status === 429 || error2.status >= 500;
+  }
+  if (error2 instanceof Error && error2.message.startsWith("Multiple mocks match ")) {
+    return false;
+  }
+  return true;
 }
 function toOneLineDisplay(value) {
   return String(value ?? "").replace(/[\r\n\u0085\u2028\u2029\v\f]+/g, " ").replace(/[ \t]{2,}/g, " ").trim();
@@ -140095,20 +140205,37 @@ async function runRepoSyncInner(inputs, dependencies) {
       let resolvedMockUrl = "";
       const mockName = `${assetProjectName} Mock`;
       if (inputs.mockUrl) {
-        resolvedMockUrl = inputs.mockUrl;
+        let mocks;
+        try {
+          mocks = await dependencies.postman.listMocks();
+        } catch (error2) {
+          throw new Error(
+            formatOrchestrationIssue({
+              operation: "Explicit mock-url lookup",
+              entity: `mock-url ${inputs.mockUrl} workspace ${inputs.workspaceId} collection ${inputs.baselineCollectionId} environment ${mockEnvUid}`,
+              cause: error2,
+              remediation: "verify the URL and mock access then rerun",
+              mask
+            }),
+            { cause: error2 }
+          );
+        }
+        resolvedMockUrl = resolveExplicitPublicMock(
+          mocks,
+          inputs.mockUrl,
+          inputs.baselineCollectionId,
+          mockEnvUid
+        ).mockUrl;
         dependencies.core.info(`Reusing mock from explicit input: ${resolvedMockUrl}`);
       }
       if (!resolvedMockUrl && inputs.baselineCollectionId) {
+        let discovered;
         try {
-          const discovered = await dependencies.postman.findMockByCollection(
+          discovered = await dependencies.postman.findMockByCollection(
             inputs.baselineCollectionId,
             mockEnvUid,
             mockName
           );
-          if (discovered) {
-            resolvedMockUrl = discovered.mockUrl;
-            dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
-          }
         } catch (error2) {
           throw new Error(
             formatOrchestrationIssue({
@@ -140120,6 +140247,10 @@ async function runRepoSyncInner(inputs, dependencies) {
             }),
             { cause: error2 }
           );
+        }
+        if (discovered) {
+          resolvedMockUrl = requirePublicMock(discovered).mockUrl;
+          dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
         }
       }
       if (!resolvedMockUrl) {
@@ -140137,6 +140268,7 @@ async function runRepoSyncInner(inputs, dependencies) {
               maxAttempts: 3,
               delayMs: 2e3,
               backoffMultiplier: 2,
+              shouldRetry: (error2) => shouldRetryMockCreate(error2),
               onRetry: ({ attempt, maxAttempts, error: error2 }) => {
                 dependencies.core.warning(
                   formatOrchestrationIssue({

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -135046,6 +135046,25 @@ var PostmanAssetsClient = class {
 };
 
 // src/lib/postman/postman-gateway-assets-client.ts
+var MockContractError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MockContractError";
+  }
+};
+function requirePublicMock(mock) {
+  if (mock.visibility === "private") {
+    throw new MockContractError(
+      `MOCK_NOT_PUBLIC: Mock ${mock.uid} is private. Make it public in Postman or remove/rename it so repo-sync can create the canonical public mock.`
+    );
+  }
+  if (mock.visibility !== "public") {
+    throw new MockContractError(
+      `MOCK_VISIBILITY_UNKNOWN: Mock ${mock.uid} did not expose a supported visibility field. Refusing to assume it is publicly callable.`
+    );
+  }
+  return mock;
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -135226,6 +135245,41 @@ var PostmanGatewayAssetsClient = class {
     if (!record) return "";
     const id = record.uid ?? record.id;
     return typeof id === "string" ? id.trim() : String(id ?? "").trim();
+  }
+  decodeMockRecord(value, operation) {
+    const record = this.asRecord(value);
+    if (!record) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a non-object mock record`
+      );
+    }
+    const uid = this.idOf(record);
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const collection = typeof record.collection === "string" ? record.collection.trim() : "";
+    const mockUrl = typeof (record.url ?? record.mockUrl) === "string" ? String(record.url ?? record.mockUrl).trim() : "";
+    const environment = typeof record.environment === "string" ? record.environment.trim() : "";
+    if (!uid) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a mock without a UID`
+      );
+    }
+    if (!name) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a name`
+      );
+    }
+    if (!collection) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a collection UID`
+      );
+    }
+    if (!mockUrl) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a URL`
+      );
+    }
+    const visibility = typeof record.published === "boolean" ? record.published ? "public" : "private" : "unknown";
+    return { uid, name, collection, mockUrl, environment, visibility };
   }
   /**
    * Reduce a Postman public uid (`<owner>-<uuid>`, 6 hyphen groups) to the bare
@@ -135527,7 +135581,8 @@ var PostmanGatewayAssetsClient = class {
     return this.singleFlight(flightKey, flightKey, "mock", async () => {
       const existing = await this.findMockByCollection(collection, environment, mockName);
       if (existing) {
-        return { uid: existing.uid, url: existing.mockUrl };
+        const reusable = requirePublicMock(existing);
+        return { uid: reusable.uid, url: reusable.mockUrl };
       }
       const body = {
         name: mockName,
@@ -135550,13 +135605,12 @@ var PostmanGatewayAssetsClient = class {
       );
       const parseMock = (response) => {
         const record = this.dataOf(response);
-        const uid = this.idOf(record);
-        if (!uid) {
-          throw new Error("Mock create did not return a UID");
-        }
+        const created = requirePublicMock(
+          this.decodeMockRecord(record, "Mock create")
+        );
         return {
-          uid,
-          url: String(record?.url ?? record?.mockUrl ?? "").trim()
+          uid: created.uid,
+          url: created.mockUrl
         };
       };
       try {
@@ -135567,7 +135621,8 @@ var PostmanGatewayAssetsClient = class {
           error
         );
         if (adopted) {
-          return { uid: adopted.uid, url: adopted.mockUrl };
+          const reusable = requirePublicMock(adopted);
+          return { uid: reusable.uid, url: reusable.mockUrl };
         }
         if (adopted === void 0) {
           const retried = await this.resendAbsentCreate(async () => parseMock(await send2("auto")));
@@ -135583,14 +135638,14 @@ var PostmanGatewayAssetsClient = class {
       method: "get",
       path: `/mocks?workspace=${this.workspaceId}`
     });
-    const items = Array.isArray(response) ? response : Array.isArray(this.asRecord(response)?.data) ? this.asRecord(response).data : [];
-    return items.map((raw) => this.asRecord(raw)).filter((m) => m !== null).map((m) => ({
-      uid: this.idOf(m),
-      name: String(m.name ?? ""),
-      collection: String(m.collection ?? ""),
-      mockUrl: String(m.url ?? m.mockUrl ?? ""),
-      environment: String(m.environment ?? "")
-    }));
+    const envelope = this.asRecord(response);
+    const items = Array.isArray(response) ? response : Array.isArray(envelope?.data) ? envelope.data : null;
+    if (!items) {
+      throw new MockContractError(
+        "CONTRACT_MOCK_RESPONSE_INVALID: Mock list envelope must be an array or contain a data array"
+      );
+    }
+    return items.map((raw) => this.decodeMockRecord(raw, "Mock list"));
   }
   /**
    * Delete an environment through the sync service (GC path). The path id is
@@ -135644,7 +135699,7 @@ var PostmanGatewayAssetsClient = class {
       `workspace ${this.workspaceId}, name "${mockName}", collection ${want}, and environment ${environment || "(none)"}`,
       matches
     );
-    return match ? { uid: match.uid, mockUrl: match.mockUrl } : null;
+    return match;
   }
   // --- monitors (service: monitors; collection-based = jobTemplates) ---
   /** Map raw jobTemplate records to the facade shape; `collection` is a flat public uid. */
@@ -136521,6 +136576,61 @@ function resolveRepoSyncMasker(dependencies) {
 }
 function causeText(cause) {
   return cause instanceof Error ? cause.message : String(cause);
+}
+function normalizeMockUrl(value, source) {
+  let url;
+  try {
+    url = new URL(String(value || "").trim());
+  } catch {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} is not a valid absolute URL`
+    );
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} must be an HTTPS URL without credentials, query parameters, or a fragment`
+    );
+  }
+  url.pathname = url.pathname.replace(/\/+$/g, "") || "/";
+  return url.toString();
+}
+function resolveExplicitPublicMock(mocks, explicitUrl, collectionUid, environmentUid) {
+  const normalized = normalizeMockUrl(explicitUrl, "mock-url");
+  const matches = mocks.filter(
+    (mock) => normalizeMockUrl(mock.mockUrl, `mock ${mock.uid} URL`) === normalized
+  );
+  if (matches.length === 0) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_NOT_FOUND: mock-url was not found in the resolved workspace mock inventory`
+    );
+  }
+  if (matches.length > 1) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_AMBIGUOUS: mock-url matched multiple workspace mocks (${matches.map((mock) => mock.uid).join(", ")})`
+    );
+  }
+  const match = matches[0];
+  if (match.collection !== collectionUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references collection ${match.collection || "(none)"}, expected ${collectionUid}`
+    );
+  }
+  if (match.environment !== environmentUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references environment ${match.environment || "(none)"}, expected ${environmentUid}`
+    );
+  }
+  return requirePublicMock(match);
+}
+function shouldRetryMockCreate(error) {
+  if (error instanceof MockContractError) return false;
+  if (error instanceof HttpError) {
+    return error.status === 408 || error.status === 429 || error.status >= 500;
+  }
+  if (error instanceof Error && error.message.startsWith("Multiple mocks match ")) {
+    return false;
+  }
+  return true;
 }
 function toOneLineDisplay(value) {
   return String(value ?? "").replace(/[\r\n\u0085\u2028\u2029\v\f]+/g, " ").replace(/[ \t]{2,}/g, " ").trim();
@@ -138005,20 +138115,37 @@ async function runRepoSyncInner(inputs, dependencies) {
       let resolvedMockUrl = "";
       const mockName = `${assetProjectName} Mock`;
       if (inputs.mockUrl) {
-        resolvedMockUrl = inputs.mockUrl;
+        let mocks;
+        try {
+          mocks = await dependencies.postman.listMocks();
+        } catch (error) {
+          throw new Error(
+            formatOrchestrationIssue({
+              operation: "Explicit mock-url lookup",
+              entity: `mock-url ${inputs.mockUrl} workspace ${inputs.workspaceId} collection ${inputs.baselineCollectionId} environment ${mockEnvUid}`,
+              cause: error,
+              remediation: "verify the URL and mock access then rerun",
+              mask
+            }),
+            { cause: error }
+          );
+        }
+        resolvedMockUrl = resolveExplicitPublicMock(
+          mocks,
+          inputs.mockUrl,
+          inputs.baselineCollectionId,
+          mockEnvUid
+        ).mockUrl;
         dependencies.core.info(`Reusing mock from explicit input: ${resolvedMockUrl}`);
       }
       if (!resolvedMockUrl && inputs.baselineCollectionId) {
+        let discovered;
         try {
-          const discovered = await dependencies.postman.findMockByCollection(
+          discovered = await dependencies.postman.findMockByCollection(
             inputs.baselineCollectionId,
             mockEnvUid,
             mockName
           );
-          if (discovered) {
-            resolvedMockUrl = discovered.mockUrl;
-            dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
-          }
         } catch (error) {
           throw new Error(
             formatOrchestrationIssue({
@@ -138030,6 +138157,10 @@ async function runRepoSyncInner(inputs, dependencies) {
             }),
             { cause: error }
           );
+        }
+        if (discovered) {
+          resolvedMockUrl = requirePublicMock(discovered).mockUrl;
+          dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
         }
       }
       if (!resolvedMockUrl) {
@@ -138047,6 +138178,7 @@ async function runRepoSyncInner(inputs, dependencies) {
               maxAttempts: 3,
               delayMs: 2e3,
               backoffMultiplier: 2,
+              shouldRetry: (error) => shouldRetryMockCreate(error),
               onRetry: ({ attempt, maxAttempts, error }) => {
                 dependencies.core.warning(
                   formatOrchestrationIssue({

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -136963,6 +136963,25 @@ var PostmanAssetsClient = class {
 };
 
 // src/lib/postman/postman-gateway-assets-client.ts
+var MockContractError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MockContractError";
+  }
+};
+function requirePublicMock(mock) {
+  if (mock.visibility === "private") {
+    throw new MockContractError(
+      `MOCK_NOT_PUBLIC: Mock ${mock.uid} is private. Make it public in Postman or remove/rename it so repo-sync can create the canonical public mock.`
+    );
+  }
+  if (mock.visibility !== "public") {
+    throw new MockContractError(
+      `MOCK_VISIBILITY_UNKNOWN: Mock ${mock.uid} did not expose a supported visibility field. Refusing to assume it is publicly callable.`
+    );
+  }
+  return mock;
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -137143,6 +137162,41 @@ var PostmanGatewayAssetsClient = class {
     if (!record) return "";
     const id = record.uid ?? record.id;
     return typeof id === "string" ? id.trim() : String(id ?? "").trim();
+  }
+  decodeMockRecord(value, operation) {
+    const record = this.asRecord(value);
+    if (!record) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a non-object mock record`
+      );
+    }
+    const uid = this.idOf(record);
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const collection = typeof record.collection === "string" ? record.collection.trim() : "";
+    const mockUrl = typeof (record.url ?? record.mockUrl) === "string" ? String(record.url ?? record.mockUrl).trim() : "";
+    const environment = typeof record.environment === "string" ? record.environment.trim() : "";
+    if (!uid) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a mock without a UID`
+      );
+    }
+    if (!name) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a name`
+      );
+    }
+    if (!collection) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a collection UID`
+      );
+    }
+    if (!mockUrl) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a URL`
+      );
+    }
+    const visibility = typeof record.published === "boolean" ? record.published ? "public" : "private" : "unknown";
+    return { uid, name, collection, mockUrl, environment, visibility };
   }
   /**
    * Reduce a Postman public uid (`<owner>-<uuid>`, 6 hyphen groups) to the bare
@@ -137444,7 +137498,8 @@ var PostmanGatewayAssetsClient = class {
     return this.singleFlight(flightKey, flightKey, "mock", async () => {
       const existing = await this.findMockByCollection(collection, environment, mockName);
       if (existing) {
-        return { uid: existing.uid, url: existing.mockUrl };
+        const reusable = requirePublicMock(existing);
+        return { uid: reusable.uid, url: reusable.mockUrl };
       }
       const body = {
         name: mockName,
@@ -137467,13 +137522,12 @@ var PostmanGatewayAssetsClient = class {
       );
       const parseMock = (response) => {
         const record = this.dataOf(response);
-        const uid = this.idOf(record);
-        if (!uid) {
-          throw new Error("Mock create did not return a UID");
-        }
+        const created = requirePublicMock(
+          this.decodeMockRecord(record, "Mock create")
+        );
         return {
-          uid,
-          url: String(record?.url ?? record?.mockUrl ?? "").trim()
+          uid: created.uid,
+          url: created.mockUrl
         };
       };
       try {
@@ -137484,7 +137538,8 @@ var PostmanGatewayAssetsClient = class {
           error2
         );
         if (adopted) {
-          return { uid: adopted.uid, url: adopted.mockUrl };
+          const reusable = requirePublicMock(adopted);
+          return { uid: reusable.uid, url: reusable.mockUrl };
         }
         if (adopted === void 0) {
           const retried = await this.resendAbsentCreate(async () => parseMock(await send2("auto")));
@@ -137500,14 +137555,14 @@ var PostmanGatewayAssetsClient = class {
       method: "get",
       path: `/mocks?workspace=${this.workspaceId}`
     });
-    const items = Array.isArray(response) ? response : Array.isArray(this.asRecord(response)?.data) ? this.asRecord(response).data : [];
-    return items.map((raw) => this.asRecord(raw)).filter((m) => m !== null).map((m) => ({
-      uid: this.idOf(m),
-      name: String(m.name ?? ""),
-      collection: String(m.collection ?? ""),
-      mockUrl: String(m.url ?? m.mockUrl ?? ""),
-      environment: String(m.environment ?? "")
-    }));
+    const envelope = this.asRecord(response);
+    const items = Array.isArray(response) ? response : Array.isArray(envelope?.data) ? envelope.data : null;
+    if (!items) {
+      throw new MockContractError(
+        "CONTRACT_MOCK_RESPONSE_INVALID: Mock list envelope must be an array or contain a data array"
+      );
+    }
+    return items.map((raw) => this.decodeMockRecord(raw, "Mock list"));
   }
   /**
    * Delete an environment through the sync service (GC path). The path id is
@@ -137561,7 +137616,7 @@ var PostmanGatewayAssetsClient = class {
       `workspace ${this.workspaceId}, name "${mockName}", collection ${want}, and environment ${environment || "(none)"}`,
       matches
     );
-    return match ? { uid: match.uid, mockUrl: match.mockUrl } : null;
+    return match;
   }
   // --- monitors (service: monitors; collection-based = jobTemplates) ---
   /** Map raw jobTemplate records to the facade shape; `collection` is a flat public uid. */
@@ -138490,6 +138545,61 @@ function resolveRepoSyncMasker(dependencies) {
 }
 function causeText(cause) {
   return cause instanceof Error ? cause.message : String(cause);
+}
+function normalizeMockUrl(value, source) {
+  let url;
+  try {
+    url = new URL(String(value || "").trim());
+  } catch {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} is not a valid absolute URL`
+    );
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} must be an HTTPS URL without credentials, query parameters, or a fragment`
+    );
+  }
+  url.pathname = url.pathname.replace(/\/+$/g, "") || "/";
+  return url.toString();
+}
+function resolveExplicitPublicMock(mocks, explicitUrl, collectionUid, environmentUid) {
+  const normalized = normalizeMockUrl(explicitUrl, "mock-url");
+  const matches = mocks.filter(
+    (mock) => normalizeMockUrl(mock.mockUrl, `mock ${mock.uid} URL`) === normalized
+  );
+  if (matches.length === 0) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_NOT_FOUND: mock-url was not found in the resolved workspace mock inventory`
+    );
+  }
+  if (matches.length > 1) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_AMBIGUOUS: mock-url matched multiple workspace mocks (${matches.map((mock) => mock.uid).join(", ")})`
+    );
+  }
+  const match = matches[0];
+  if (match.collection !== collectionUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references collection ${match.collection || "(none)"}, expected ${collectionUid}`
+    );
+  }
+  if (match.environment !== environmentUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references environment ${match.environment || "(none)"}, expected ${environmentUid}`
+    );
+  }
+  return requirePublicMock(match);
+}
+function shouldRetryMockCreate(error2) {
+  if (error2 instanceof MockContractError) return false;
+  if (error2 instanceof HttpError) {
+    return error2.status === 408 || error2.status === 429 || error2.status >= 500;
+  }
+  if (error2 instanceof Error && error2.message.startsWith("Multiple mocks match ")) {
+    return false;
+  }
+  return true;
 }
 function toOneLineDisplay(value) {
   return String(value ?? "").replace(/[\r\n\u0085\u2028\u2029\v\f]+/g, " ").replace(/[ \t]{2,}/g, " ").trim();
@@ -140117,20 +140227,37 @@ async function runRepoSyncInner(inputs, dependencies) {
       let resolvedMockUrl = "";
       const mockName = `${assetProjectName} Mock`;
       if (inputs.mockUrl) {
-        resolvedMockUrl = inputs.mockUrl;
+        let mocks;
+        try {
+          mocks = await dependencies.postman.listMocks();
+        } catch (error2) {
+          throw new Error(
+            formatOrchestrationIssue({
+              operation: "Explicit mock-url lookup",
+              entity: `mock-url ${inputs.mockUrl} workspace ${inputs.workspaceId} collection ${inputs.baselineCollectionId} environment ${mockEnvUid}`,
+              cause: error2,
+              remediation: "verify the URL and mock access then rerun",
+              mask
+            }),
+            { cause: error2 }
+          );
+        }
+        resolvedMockUrl = resolveExplicitPublicMock(
+          mocks,
+          inputs.mockUrl,
+          inputs.baselineCollectionId,
+          mockEnvUid
+        ).mockUrl;
         dependencies.core.info(`Reusing mock from explicit input: ${resolvedMockUrl}`);
       }
       if (!resolvedMockUrl && inputs.baselineCollectionId) {
+        let discovered;
         try {
-          const discovered = await dependencies.postman.findMockByCollection(
+          discovered = await dependencies.postman.findMockByCollection(
             inputs.baselineCollectionId,
             mockEnvUid,
             mockName
           );
-          if (discovered) {
-            resolvedMockUrl = discovered.mockUrl;
-            dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
-          }
         } catch (error2) {
           throw new Error(
             formatOrchestrationIssue({
@@ -140142,6 +140269,10 @@ async function runRepoSyncInner(inputs, dependencies) {
             }),
             { cause: error2 }
           );
+        }
+        if (discovered) {
+          resolvedMockUrl = requirePublicMock(discovered).mockUrl;
+          dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
         }
       }
       if (!resolvedMockUrl) {
@@ -140159,6 +140290,7 @@ async function runRepoSyncInner(inputs, dependencies) {
               maxAttempts: 3,
               delayMs: 2e3,
               backoffMultiplier: 2,
+              shouldRetry: (error2) => shouldRetryMockCreate(error2),
               onRetry: ({ attempt, maxAttempts, error: error2 }) => {
                 dependencies.core.warning(
                   formatOrchestrationIssue({

--- a/scripts/live-write-probe.ts
+++ b/scripts/live-write-probe.ts
@@ -15,7 +15,10 @@
  */
 import { AccessTokenProvider } from '../src/lib/postman/token-provider.js';
 import { AccessTokenGatewayClient } from '../src/lib/postman/gateway-client.js';
-import { PostmanGatewayAssetsClient } from '../src/lib/postman/postman-gateway-assets-client.js';
+import {
+  PostmanGatewayAssetsClient,
+  requirePublicMock
+} from '../src/lib/postman/postman-gateway-assets-client.js';
 import { POSTMAN_ENDPOINT_PROFILES } from '../src/lib/postman/base-urls.js';
 import { HttpError } from '../src/lib/http-error.js';
 
@@ -26,6 +29,38 @@ type JsonRecord = Record<string, unknown>;
 function snippet(value: unknown): string {
   const text = typeof value === 'string' ? value : JSON.stringify(value);
   return String(text ?? '').slice(0, 240).replace(/\s+/g, ' ');
+}
+
+function recordShape(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return typeof value;
+  const record = value as JsonRecord;
+  const fields = Object.keys(record).sort();
+  const visibility = ([
+    ['private', record.private],
+    ['isPublic', record.isPublic],
+    ['visibility', record.visibility],
+    ['active', record.active],
+    ['published', record.published]
+  ] as Array<[string, unknown]>)
+    .filter(([, field]) => field !== undefined)
+    .map(([key, field]) => `${String(key)}=${JSON.stringify(field)}`)
+    .join(',');
+  const config = record.config && typeof record.config === 'object' && !Array.isArray(record.config)
+    ? Object.entries(record.config as JsonRecord)
+        .filter(([, field]) => ['boolean', 'number', 'string'].includes(typeof field))
+        .map(([key, field]) => `${key}=${JSON.stringify(field)}`)
+        .join(',')
+    : '';
+  return `keys=${fields.join(',')}${visibility ? ` scalars=${visibility}` : ''}${config ? ` config=${config}` : ''}`;
+}
+
+function mockRecords(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== 'object') return [];
+  const record = value as JsonRecord;
+  if (Array.isArray(record.data)) return record.data;
+  if (Array.isArray(record.mocks)) return record.mocks;
+  return [record.data ?? record.mock ?? record];
 }
 
 /** Public uid (6 hyphen groups) → bare model id (5 groups); mirrors PostmanGatewayAssetsClient. */
@@ -111,6 +146,7 @@ async function main(): Promise<void> {
   let workspaceId: string;
   let publicCollectionUid: string;
   let mockUid = '';
+  let privateMockUid: string | undefined;
   let monitorUid = '';
   const createdWorkspaces = new Set<string>();
   let failed = false;
@@ -288,10 +324,11 @@ async function main(): Promise<void> {
     }
 
     console.log('\n== mock: PostmanGatewayAssetsClient (production path) ==');
+    const publicMockName = `probe-mock-${stamp}`;
     try {
       const mock = await assets.createMock(
         workspaceId,
-        `probe-mock-${stamp}`,
+        publicMockName,
         publicCollectionUid,
         envUid
       );
@@ -301,13 +338,69 @@ async function main(): Promise<void> {
       fail('createMock', error instanceof Error ? error.message : String(error));
     }
 
+    const privateMockName = `probe-private-mock-${stamp}`;
+    const privateCreate = await gwRaw(gateway, 'mock', 'post', `/mocks?workspace=${workspaceId}`, {
+      name: privateMockName,
+      collection: publicCollectionUid,
+      environment: envUid,
+      private: true
+    });
+    const privateRecord = privateCreate.json?.data ?? privateCreate.json;
+    privateMockUid = String((privateRecord as JsonRecord | null)?.id ?? '').trim();
+    console.log(`  [${privateCreate.status}] private mock create :: ${recordShape(privateRecord)}`);
+
+    const rawMockList = await gwRaw(gateway, 'mock', 'get', `/mocks?workspace=${workspaceId}`);
+    console.log(`  [${rawMockList.status}] raw mock list envelope :: ${recordShape(rawMockList.json)}`);
+    for (const [index, record] of mockRecords(rawMockList.json).entries()) {
+      console.log(`  [shape] mock list record ${index + 1} :: ${recordShape(record)}`);
+    }
+    for (const [label, uid] of [['public', mockUid], ['private', privateMockUid]] as const) {
+      if (!uid) continue;
+      const get = await gwRaw(gateway, 'mock', 'get', `/mocks/${uid}`);
+      console.log(`  [${get.status}] ${label} mock get envelope :: ${recordShape(get.json)}`);
+      for (const record of mockRecords(get.json)) {
+        console.log(`  [shape] ${label} mock get record :: ${recordShape(record)}`);
+      }
+    }
+
     const mocks = await assets.listMocks();
     console.log(`  [ok] listMocks count=${mocks.length}`);
-    const foundMock = await assets.findMockByCollection(publicCollectionUid);
+    const foundMock = await assets.findMockByCollection(publicCollectionUid, envUid, publicMockName);
     if (!foundMock?.uid) {
       fail('findMockByCollection', 'did not rediscover mock by public uid');
     } else {
       console.log(`  [ok] findMockByCollection uid=${foundMock.uid}`);
+    }
+    const foundPrivateMock = await assets.findMockByCollection(
+      publicCollectionUid,
+      envUid,
+      privateMockName
+    );
+    try {
+      if (foundPrivateMock) requirePublicMock(foundPrivateMock);
+      fail('private mock policy', 'private mock was accepted as public');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('MOCK_NOT_PUBLIC')) {
+        fail('private mock policy', message);
+      } else {
+        console.log('  [ok] private mock rejected with MOCK_NOT_PUBLIC');
+      }
+    }
+
+    if (mockUid && privateMockUid) {
+      const [publicCall, privateCall] = await Promise.all([
+        fetch(`https://${mockUid}.mock.pstmn.io`).catch(() => null),
+        fetch(`https://${privateMockUid}.mock.pstmn.io`).catch(() => null)
+      ]);
+      console.log(`  [anonymous] public mock status=${publicCall?.status ?? 'transport-error'}`);
+      console.log(`  [anonymous] private mock status=${privateCall?.status ?? 'transport-error'}`);
+      if (publicCall && [401, 403].includes(publicCall.status)) {
+        fail('public mock anonymous call', `unexpected status ${publicCall.status}`);
+      }
+      if (privateCall && ![401, 403, 404].includes(privateCall.status)) {
+        fail('private mock anonymous call', `unexpected status ${privateCall.status}`);
+      }
     }
 
     console.log('\n== monitor: PostmanGatewayAssetsClient (production path) ==');
@@ -326,7 +419,11 @@ async function main(): Promise<void> {
 
     const monitors = await assets.listMonitors();
     console.log(`  [ok] listMonitors count=${monitors.length}`);
-    const foundMonitor = await assets.findMonitorByCollection(publicCollectionUid);
+    const foundMonitor = await assets.findMonitorByCollection(
+      publicCollectionUid,
+      envUid,
+      `probe-mon-${stamp}`
+    );
     if (!foundMonitor?.uid) {
       fail('findMonitorByCollection', 'did not rediscover monitor by public uid');
     } else {
@@ -346,6 +443,10 @@ async function main(): Promise<void> {
     if (mockUid) {
       const del = await gwRaw(gateway, 'mock', 'delete', `/mocks/${mockUid}`);
       console.log(`  [${del.status}] DELETE mock ${mockUid}`);
+    }
+    if (privateMockUid) {
+      const del = await gwRaw(gateway, 'mock', 'delete', `/mocks/${privateMockUid}`);
+      console.log(`  [${del.status}] DELETE private mock ${privateMockUid}`);
     }
     if (monitorUid) {
       const del = await gwRaw(gateway, 'monitorsV2', 'delete', `/monitors/${monitorUid}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,12 @@ import { HttpError } from './lib/http-error.js';
 import { retry } from './lib/retry.js';
 import { postmanRepoSyncActionContract } from './contracts.js';
 import { PostmanAssetsClient } from './lib/postman/postman-assets-client.js';
-import { PostmanGatewayAssetsClient } from './lib/postman/postman-gateway-assets-client.js';
+import {
+  MockContractError,
+  PostmanGatewayAssetsClient,
+  requirePublicMock,
+  type MockRecord
+} from './lib/postman/postman-gateway-assets-client.js';
 import { AccessTokenProvider, mintAccessTokenIfNeeded } from './lib/postman/token-provider.js';
 import { AccessTokenGatewayClient } from './lib/postman/gateway-client.js';
 import {
@@ -224,6 +229,69 @@ function resolveRepoSyncMasker(dependencies: RepoSyncDependencies): SecretMasker
 
 function causeText(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
+}
+
+function normalizeMockUrl(value: string, source: string): string {
+  let url: URL;
+  try {
+    url = new URL(String(value || '').trim());
+  } catch {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} is not a valid absolute URL`
+    );
+  }
+  if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_INVALID: ${source} must be an HTTPS URL without credentials, query parameters, or a fragment`
+    );
+  }
+  url.pathname = url.pathname.replace(/\/+$/g, '') || '/';
+  return url.toString();
+}
+
+function resolveExplicitPublicMock(
+  mocks: MockRecord[],
+  explicitUrl: string,
+  collectionUid: string,
+  environmentUid: string
+): MockRecord {
+  const normalized = normalizeMockUrl(explicitUrl, 'mock-url');
+  const matches = mocks.filter(
+    (mock) => normalizeMockUrl(mock.mockUrl, `mock ${mock.uid} URL`) === normalized
+  );
+  if (matches.length === 0) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_NOT_FOUND: mock-url was not found in the resolved workspace mock inventory`
+    );
+  }
+  if (matches.length > 1) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_URL_AMBIGUOUS: mock-url matched multiple workspace mocks (${matches.map((mock) => mock.uid).join(', ')})`
+    );
+  }
+  const match = matches[0];
+  if (match.collection !== collectionUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references collection ${match.collection || '(none)'}, expected ${collectionUid}`
+    );
+  }
+  if (match.environment !== environmentUid) {
+    throw new MockContractError(
+      `EXPLICIT_MOCK_IDENTITY_MISMATCH: Mock ${match.uid} references environment ${match.environment || '(none)'}, expected ${environmentUid}`
+    );
+  }
+  return requirePublicMock(match);
+}
+
+function shouldRetryMockCreate(error: unknown): boolean {
+  if (error instanceof MockContractError) return false;
+  if (error instanceof HttpError) {
+    return error.status === 408 || error.status === 429 || error.status >= 500;
+  }
+  if (error instanceof Error && error.message.startsWith('Multiple mocks match ')) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -2415,21 +2483,38 @@ async function runRepoSyncInner(
       const mockName = `${assetProjectName} Mock`;
 
       if (inputs.mockUrl) {
-        resolvedMockUrl = inputs.mockUrl;
+        let mocks: MockRecord[];
+        try {
+          mocks = await dependencies.postman.listMocks();
+        } catch (error) {
+          throw new Error(
+            formatOrchestrationIssue({
+              operation: 'Explicit mock-url lookup',
+              entity: `mock-url ${inputs.mockUrl} workspace ${inputs.workspaceId} collection ${inputs.baselineCollectionId} environment ${mockEnvUid}`,
+              cause: error,
+              remediation: 'verify the URL and mock access then rerun',
+              mask
+            }),
+            { cause: error }
+          );
+        }
+        resolvedMockUrl = resolveExplicitPublicMock(
+          mocks,
+          inputs.mockUrl,
+          inputs.baselineCollectionId,
+          mockEnvUid
+        ).mockUrl;
         dependencies.core.info(`Reusing mock from explicit input: ${resolvedMockUrl}`);
       }
 
       if (!resolvedMockUrl && inputs.baselineCollectionId) {
+        let discovered: MockRecord | null;
         try {
-          const discovered = await dependencies.postman.findMockByCollection(
+          discovered = await dependencies.postman.findMockByCollection(
             inputs.baselineCollectionId,
             mockEnvUid,
             mockName
           );
-          if (discovered) {
-            resolvedMockUrl = discovered.mockUrl;
-            dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
-          }
         } catch (error) {
           throw new Error(
             formatOrchestrationIssue({
@@ -2441,6 +2526,10 @@ async function runRepoSyncInner(
             }),
             { cause: error }
           );
+        }
+        if (discovered) {
+          resolvedMockUrl = requirePublicMock(discovered).mockUrl;
+          dependencies.core.info(`Discovered existing mock for collection ${inputs.baselineCollectionId}: ${resolvedMockUrl}`);
         }
       }
 
@@ -2463,6 +2552,7 @@ async function runRepoSyncInner(
               maxAttempts: 3,
               delayMs: 2000,
               backoffMultiplier: 2,
+              shouldRetry: (error) => shouldRetryMockCreate(error),
               onRetry: ({ attempt, maxAttempts, error }) => {
                 dependencies.core.warning(
                   formatOrchestrationIssue({

--- a/src/lib/postman/postman-gateway-assets-client.ts
+++ b/src/lib/postman/postman-gateway-assets-client.ts
@@ -4,6 +4,38 @@ import { retry, sleep as defaultSleep } from '../retry.js';
 
 type JsonRecord = Record<string, unknown>;
 
+export type MockVisibility = 'public' | 'private' | 'unknown';
+
+export interface MockRecord {
+  uid: string;
+  name: string;
+  collection: string;
+  mockUrl: string;
+  environment: string;
+  visibility: MockVisibility;
+}
+
+export class MockContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MockContractError';
+  }
+}
+
+export function requirePublicMock(mock: MockRecord): MockRecord {
+  if (mock.visibility === 'private') {
+    throw new MockContractError(
+      `MOCK_NOT_PUBLIC: Mock ${mock.uid} is private. Make it public in Postman or remove/rename it so repo-sync can create the canonical public mock.`
+    );
+  }
+  if (mock.visibility !== 'public') {
+    throw new MockContractError(
+      `MOCK_VISIBILITY_UNKNOWN: Mock ${mock.uid} did not expose a supported visibility field. Refusing to assume it is publicly callable.`
+    );
+  }
+  return mock;
+}
+
 const MAX_CREATE_FLIGHTS = 256;
 interface CreateFlight {
   fingerprint: string;
@@ -237,6 +269,46 @@ export class PostmanGatewayAssetsClient {
     if (!record) return '';
     const id = record.uid ?? record.id;
     return typeof id === 'string' ? id.trim() : String(id ?? '').trim();
+  }
+
+  private decodeMockRecord(value: unknown, operation: string): MockRecord {
+    const record = this.asRecord(value);
+    if (!record) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a non-object mock record`
+      );
+    }
+    const uid = this.idOf(record);
+    const name = typeof record.name === 'string' ? record.name.trim() : '';
+    const collection = typeof record.collection === 'string' ? record.collection.trim() : '';
+    const mockUrl = typeof (record.url ?? record.mockUrl) === 'string'
+      ? String(record.url ?? record.mockUrl).trim()
+      : '';
+    const environment = typeof record.environment === 'string' ? record.environment.trim() : '';
+    if (!uid) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned a mock without a UID`
+      );
+    }
+    if (!name) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a name`
+      );
+    }
+    if (!collection) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a collection UID`
+      );
+    }
+    if (!mockUrl) {
+      throw new MockContractError(
+        `CONTRACT_MOCK_RESPONSE_INVALID: ${operation} returned mock ${uid} without a URL`
+      );
+    }
+    const visibility: MockVisibility = typeof record.published === 'boolean'
+      ? (record.published ? 'public' : 'private')
+      : 'unknown';
+    return { uid, name, collection, mockUrl, environment, visibility };
   }
 
   /**
@@ -593,7 +665,8 @@ export class PostmanGatewayAssetsClient {
     return this.singleFlight(flightKey, flightKey, 'mock', async () => {
       const existing = await this.findMockByCollection(collection, environment, mockName);
       if (existing) {
-        return { uid: existing.uid, url: existing.mockUrl };
+        const reusable = requirePublicMock(existing);
+        return { uid: reusable.uid, url: reusable.mockUrl };
       }
 
       const body: JsonRecord = {
@@ -619,13 +692,12 @@ export class PostmanGatewayAssetsClient {
         );
       const parseMock = (response: JsonRecord | null) => {
         const record = this.dataOf(response);
-        const uid = this.idOf(record);
-        if (!uid) {
-          throw new Error('Mock create did not return a UID');
-        }
+        const created = requirePublicMock(
+          this.decodeMockRecord(record, 'Mock create')
+        );
         return {
-          uid,
-          url: String(record?.url ?? record?.mockUrl ?? '').trim()
+          uid: created.uid,
+          url: created.mockUrl
         };
       };
       try {
@@ -636,7 +708,8 @@ export class PostmanGatewayAssetsClient {
           error
         );
         if (adopted) {
-          return { uid: adopted.uid, url: adopted.mockUrl };
+          const reusable = requirePublicMock(adopted);
+          return { uid: reusable.uid, url: reusable.mockUrl };
         }
         if (adopted === undefined) {
           const retried = await this.resendAbsentCreate(async () => parseMock(await send('auto')));
@@ -647,29 +720,24 @@ export class PostmanGatewayAssetsClient {
     });
   }
 
-  async listMocks(): Promise<
-    Array<{ uid: string; name: string; collection: string; mockUrl: string; environment: string }>
-  > {
+  async listMocks(): Promise<MockRecord[]> {
     const response = await this.gateway.requestJson<unknown>({
       service: 'mock',
       method: 'get',
       path: `/mocks?workspace=${this.workspaceId}`
     });
+    const envelope = this.asRecord(response);
     const items = Array.isArray(response)
       ? response
-      : Array.isArray(this.asRecord(response)?.data)
-        ? ((this.asRecord(response) as JsonRecord).data as unknown[])
-        : [];
-    return items
-      .map((raw) => this.asRecord(raw))
-      .filter((m): m is JsonRecord => m !== null)
-      .map((m) => ({
-        uid: this.idOf(m),
-        name: String(m.name ?? ''),
-        collection: String(m.collection ?? ''),
-        mockUrl: String(m.url ?? m.mockUrl ?? ''),
-        environment: String(m.environment ?? '')
-      }));
+      : Array.isArray(envelope?.data)
+        ? (envelope.data as unknown[])
+        : null;
+    if (!items) {
+      throw new MockContractError(
+        'CONTRACT_MOCK_RESPONSE_INVALID: Mock list envelope must be an array or contain a data array'
+      );
+    }
+    return items.map((raw) => this.decodeMockRecord(raw, 'Mock list'));
   }
 
   /**
@@ -719,7 +787,7 @@ export class PostmanGatewayAssetsClient {
     collectionUid: string,
     environmentUid: string,
     name: string
-  ): Promise<{ uid: string; mockUrl: string } | null> {
+  ): Promise<MockRecord | null> {
     const mocks = await this.listMocks();
     // Both sides are public uids (`<owner>-<uuid>`): the mock list echoes the
     // `collection` uid it was created with, and the caller passes the same uid.
@@ -736,7 +804,7 @@ export class PostmanGatewayAssetsClient {
       `workspace ${this.workspaceId}, name "${mockName}", collection ${want}, and environment ${environment || '(none)'}`,
       matches
     );
-    return match ? { uid: match.uid, mockUrl: match.mockUrl } : null;
+    return match;
   }
 
   // --- monitors (service: monitors; collection-based = jobTemplates) ---

--- a/tests/access-token-routing.test.ts
+++ b/tests/access-token-routing.test.ts
@@ -93,10 +93,18 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe('createRepoSyncDependencies access-token-primary routing', () => {
   it('routes mock + monitor asset ops through the gateway when an access token is present', async () => {
-    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
       const u = String(url);
       if (u.includes('/ws/proxy')) {
-        return jsonResponse({ id: 'mock-uuid', url: 'https://mock-uuid.mock.pstmn.io' });
+        const request = JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>;
+        if (request.method === 'get') return jsonResponse([]);
+        return jsonResponse({
+          id: 'mock-uuid',
+          name: 'm',
+          collection: 'col-1',
+          url: 'https://mock-uuid.mock.pstmn.io',
+          published: true
+        });
       }
       return jsonResponse({}, { status: 500 });
     });

--- a/tests/contract/credential-matrix.test.ts
+++ b/tests/contract/credential-matrix.test.ts
@@ -167,7 +167,15 @@ function createPlatform(options: PlatformOptions = {}) {
         }
         if (pmethod === 'post' && ppath.startsWith('/mocks')) {
           mockCreated = true;
-          return json({ data: { uid: 'mock-123', url: 'https://mock-123.mock.pstmn.io' } });
+          const body = (proxy.body ?? {}) as Record<string, unknown>;
+          return json({ data: {
+            id: 'mock-123',
+            name: String(body.name ?? ''),
+            collection: String(body.collection ?? ''),
+            environment: String(body.environment ?? ''),
+            url: 'https://mock-123.mock.pstmn.io',
+            published: true
+          } });
         }
         return json({ data: {} });
       }

--- a/tests/create-reconciliation.test.ts
+++ b/tests/create-reconciliation.test.ts
@@ -43,7 +43,7 @@ function buildClient(fetchImpl: typeof fetch): PostmanGatewayAssetsClient {
 
 interface LiveAssets {
   environments: Array<{ id: string; name: string; owner: string }>;
-  mocks: Array<{ id: string; name: string; collection: string; environment?: string; url: string }>;
+  mocks: Array<{ id: string; name: string; collection: string; environment?: string; url: string; published: boolean }>;
   monitors: Array<{ id: string; name: string; collection: string; environment?: string; active: boolean }>;
 }
 
@@ -80,7 +80,8 @@ function liveApi(state: LiveAssets, ambiguousCreates = false) {
         name: String(body.name),
         collection: String(body.collection),
         ...(body.environment ? { environment: String(body.environment) } : {}),
-        url: 'https://mock-1.mock.pstmn.io'
+        url: 'https://mock-1.mock.pstmn.io',
+        published: true
       };
       state.mocks.push(mock);
       return ambiguousCreates
@@ -177,7 +178,8 @@ describe('accepted write followed by an ambiguous response', () => {
           name: 'Acme Mock',
           collection: COLLECTION_UID,
           environment: ENVIRONMENT_UID,
-          url: 'https://mock-adopted.mock.pstmn.io'
+          url: 'https://mock-adopted.mock.pstmn.io',
+          published: true
         }] : []);
       }
       if (method === 'post' && path.startsWith('/mocks?')) {
@@ -346,8 +348,8 @@ describe('exact live identity and duplicate handling', () => {
 
   it('fails closed when two mocks match name, collection, and environment', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([
-      { id: 'mock-a', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://a.mock' },
-      { id: 'mock-b', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://b.mock' }
+      { id: 'mock-a', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://a.mock', published: true },
+      { id: 'mock-b', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://b.mock', published: true }
     ]));
 
     await expect(buildClient(fetchImpl).findMockByCollection(
@@ -361,8 +363,8 @@ describe('exact live identity and duplicate handling', () => {
     let created = false;
     let posts = 0;
     const duplicates = [
-      { id: 'mock-a', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://a.mock' },
-      { id: 'mock-b', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://b.mock' }
+      { id: 'mock-a', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://a.mock', published: true },
+      { id: 'mock-b', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://b.mock', published: true }
     ];
     const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
       const request = envelope(init);
@@ -406,16 +408,23 @@ describe('exact live identity and duplicate handling', () => {
 
   it('adopts exactly one full mock identity and ignores wrong name/environment siblings', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([
-      { id: 'wrong-name', name: 'Other Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://wrong-name.mock' },
-      { id: 'wrong-env', name: 'Acme Mock', collection: COLLECTION_UID, environment: 'env-other', url: 'https://wrong-env.mock' },
-      { id: 'mock-exact', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://exact.mock' }
+      { id: 'wrong-name', name: 'Other Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://wrong-name.mock', published: true },
+      { id: 'wrong-env', name: 'Acme Mock', collection: COLLECTION_UID, environment: 'env-other', url: 'https://wrong-env.mock', published: true },
+      { id: 'mock-exact', name: 'Acme Mock', collection: COLLECTION_UID, environment: ENVIRONMENT_UID, url: 'https://exact.mock', published: true }
     ]));
 
     await expect(buildClient(fetchImpl).findMockByCollection(
       COLLECTION_UID,
       ENVIRONMENT_UID,
       'Acme Mock'
-    )).resolves.toEqual({ uid: 'mock-exact', mockUrl: 'https://exact.mock' });
+    )).resolves.toEqual({
+      uid: 'mock-exact',
+      name: 'Acme Mock',
+      collection: COLLECTION_UID,
+      environment: ENVIRONMENT_UID,
+      mockUrl: 'https://exact.mock',
+      visibility: 'public'
+    });
   });
 
   it('does not use a monitor fallback when no full identity matches', async () => {
@@ -442,7 +451,8 @@ describe('exact live identity and duplicate handling', () => {
           name: 'Acme Mock',
           collection: COLLECTION_UID,
           environment: 'env-other',
-          url: 'https://wrong-env.mock'
+          url: 'https://wrong-env.mock',
+          published: true
         }]);
       }
       if (method === 'post' && path.startsWith('/mocks?')) {
@@ -644,7 +654,14 @@ describe('fresh-process orchestration live discovery reuse', () => {
     const findMockByCollection = vi
       .fn()
       .mockResolvedValueOnce(null)
-      .mockResolvedValue({ uid: 'mock-1', mockUrl: 'https://mock-1.mock.pstmn.io' });
+      .mockResolvedValue({
+        uid: 'mock-1',
+        name: 'Acme Mock',
+        collection: COLLECTION_UID,
+        environment: ENVIRONMENT_UID,
+        mockUrl: 'https://mock-1.mock.pstmn.io',
+        visibility: 'public'
+      });
     const createMock = vi.fn().mockResolvedValue({
       uid: 'mock-1',
       url: 'https://mock-1.mock.pstmn.io'

--- a/tests/postman-gateway-assets-client.test.ts
+++ b/tests/postman-gateway-assets-client.test.ts
@@ -89,7 +89,7 @@ describe('PostmanGatewayAssetsClient', () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValue(jsonResponse({ id: 'mock-uuid', url: 'https://mock-uuid.mock.pstmn.io' }));
+      .mockResolvedValue(jsonResponse({ id: 'mock-uuid', name: 'm', collection: PUBLIC_UID, environment: ENV_PUBLIC_UID, url: 'https://mock-uuid.mock.pstmn.io', published: true }));
     const { assets } = buildClient(fetchImpl);
 
     await assets.createMock('ws-1', 'm', PUBLIC_UID, ENV_PUBLIC_UID);
@@ -105,7 +105,7 @@ describe('PostmanGatewayAssetsClient', () => {
       .fn<typeof fetch>()
       .mockResolvedValueOnce(jsonResponse([]))
       .mockResolvedValue(
-        jsonResponse({ id: 'mock-uuid', url: 'https://mock-uuid.mock.pstmn.io', collection: 'col-1' })
+        jsonResponse({ id: 'mock-uuid', name: 'm', url: 'https://mock-uuid.mock.pstmn.io', collection: 'col-1', published: true })
       );
     const { assets } = buildClient(fetchImpl);
 
@@ -121,6 +121,20 @@ describe('PostmanGatewayAssetsClient', () => {
     const headers = (fetchImpl.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
     expect(headers['x-access-token']).toBe('tok-initial');
     expect(headers['X-Api-Key']).toBeUndefined();
+  });
+
+  it('createMock refuses a mock the service reports as private', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValue(
+        jsonResponse({ id: 'mock-private', name: 'm', collection: 'col-1', url: 'https://mock-private.mock.pstmn.io', published: false })
+      );
+    const { assets } = buildClient(fetchImpl);
+
+    await expect(assets.createMock('ws-1', 'm', 'col-1', '')).rejects.toThrow(
+      /MOCK_NOT_PUBLIC.*mock-private/
+    );
   });
 
   it('createEnvironment returns the owner-prefixed public uid built from the import response', async () => {
@@ -140,24 +154,53 @@ describe('PostmanGatewayAssetsClient', () => {
 
   it('listMocks parses the bare-array mock service response', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse([{ id: 'm1', name: 'a', collection: 'col-1', url: 'https://m1.mock' }])
+      jsonResponse([
+        { id: 'm1', name: 'a', collection: 'col-1', environment: 'env-1', url: 'https://m1.mock', published: true },
+        { id: 'm2', name: 'b', collection: 'col-2', environment: '', url: 'https://m2.mock', published: false }
+      ])
     );
     const { assets } = buildClient(fetchImpl);
     const mocks = await assets.listMocks();
     expect(mocks).toEqual([
-      { uid: 'm1', name: 'a', collection: 'col-1', mockUrl: 'https://m1.mock', environment: '' }
+      { uid: 'm1', name: 'a', collection: 'col-1', mockUrl: 'https://m1.mock', environment: 'env-1', visibility: 'public' },
+      { uid: 'm2', name: 'b', collection: 'col-2', mockUrl: 'https://m2.mock', environment: '', visibility: 'private' }
     ]);
     expect(parseEnvelope(fetchImpl.mock.calls[0]).path).toBe('/mocks?workspace=ws-1');
   });
 
+  it('listMocks preserves unknown visibility but rejects malformed envelopes and records', async () => {
+    const unknownFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse([{ id: 'm1', name: 'a', collection: 'col-1', url: 'https://m1.mock' }])
+    );
+    await expect(buildClient(unknownFetch).assets.listMocks()).resolves.toEqual([
+      { uid: 'm1', name: 'a', collection: 'col-1', mockUrl: 'https://m1.mock', environment: '', visibility: 'unknown' }
+    ]);
+
+    const envelopeFetch = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ unexpected: [] }));
+    await expect(buildClient(envelopeFetch).assets.listMocks()).rejects.toThrow(
+      /CONTRACT_MOCK_RESPONSE_INVALID.*list envelope/
+    );
+
+    const recordFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse([{ id: 'm1', name: 'a', collection: 'col-1', published: true }])
+    );
+    await expect(buildClient(recordFetch).assets.listMocks()).rejects.toThrow(
+      /CONTRACT_MOCK_RESPONSE_INVALID.*URL/
+    );
+  });
+
   it('findMockByCollection matches the public uid the mock list echoes', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse([{ id: 'm1', name: 'a', collection: PUBLIC_UID, url: 'https://m1.mock' }])
+      jsonResponse([{ id: 'm1', name: 'a', collection: PUBLIC_UID, url: 'https://m1.mock', published: true }])
     );
     const { assets } = buildClient(fetchImpl);
     await expect(assets.findMockByCollection(PUBLIC_UID, '', 'a')).resolves.toEqual({
       uid: 'm1',
-      mockUrl: 'https://m1.mock'
+      name: 'a',
+      collection: PUBLIC_UID,
+      environment: '',
+      mockUrl: 'https://m1.mock',
+      visibility: 'public'
     });
   });
 

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -3068,16 +3068,60 @@ describe('mock resolution paths', () => {
   }; }
 
   it('reuses explicit mock-url from input', async () => {
-    const postman = makePostman();
+    const postman = makePostman({
+      listMocks: vi.fn().mockResolvedValue([{
+        uid: 'explicit-mock',
+        name: 'Existing Mock',
+        collection: 'col-baseline',
+        environment: 'env-prod',
+        mockUrl: 'https://explicit-mock.pstmn.io/',
+        visibility: 'public'
+      }])
+    });
     const github = makeGithub();
     await runRepoSync(createInputs({ environments: ['prod'], generateCiWorkflow: false, mockUrl: 'https://explicit-mock.pstmn.io' }), makeDeps(postman, github));
-    
+
     expect(postman.createMock).not.toHaveBeenCalled();
+    expect(postman.findMockByCollection).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for private, unknown, stale, and unrelated explicit mocks', async () => {
+    const base = {
+      uid: 'explicit-mock',
+      name: 'Existing Mock',
+      collection: 'col-baseline',
+      environment: 'env-prod',
+      mockUrl: 'https://explicit-mock.pstmn.io'
+    };
+    for (const [label, listMocks, message] of [
+      ['private', [{ ...base, visibility: 'private' }], /MOCK_NOT_PUBLIC.*explicit-mock/],
+      ['unknown', [{ ...base, visibility: 'unknown' }], /MOCK_VISIBILITY_UNKNOWN.*explicit-mock/],
+      ['stale', [], /EXPLICIT_MOCK_URL_NOT_FOUND/],
+      ['wrong collection', [{ ...base, collection: 'other-col', visibility: 'public' }], /EXPLICIT_MOCK_IDENTITY_MISMATCH.*collection/],
+      ['wrong environment', [{ ...base, environment: 'other-env', visibility: 'public' }], /EXPLICIT_MOCK_IDENTITY_MISMATCH.*environment/]
+    ] as const) {
+      const postman = makePostman({ listMocks: vi.fn().mockResolvedValue(listMocks) });
+      await expect(
+        runRepoSync(
+          createInputs({ environments: ['prod'], generateCiWorkflow: false, mockUrl: base.mockUrl }),
+          makeDeps(postman, makeGithub())
+        ),
+        label
+      ).rejects.toThrow(message);
+      expect(postman.createMock, label).not.toHaveBeenCalled();
+    }
   });
 
   it('discovers existing mock by baseline collection ID', async () => {
     const postman = makePostman({
-      findMockByCollection: vi.fn().mockResolvedValue({ uid: 'discovered-mock', mockUrl: 'https://discovered-mock.pstmn.io' })
+      findMockByCollection: vi.fn().mockResolvedValue({
+        uid: 'discovered-mock',
+        name: 'core-payments Mock',
+        collection: 'col-baseline',
+        environment: 'env-prod',
+        mockUrl: 'https://discovered-mock.pstmn.io',
+        visibility: 'public'
+      })
     });
     const github = makeGithub();
     await runRepoSync(createInputs({ environments: ['prod'], generateCiWorkflow: false }), makeDeps(postman, github));
@@ -3088,6 +3132,31 @@ describe('mock resolution paths', () => {
       'env-prod',
       'core-payments Mock'
     );
+  });
+
+  it('fails closed instead of reusing a discovered private or unknown mock', async () => {
+    for (const [visibility, message] of [
+      ['private', /MOCK_NOT_PUBLIC.*discovered-mock/],
+      ['unknown', /MOCK_VISIBILITY_UNKNOWN.*discovered-mock/]
+    ] as const) {
+      const postman = makePostman({
+        findMockByCollection: vi.fn().mockResolvedValue({
+          uid: 'discovered-mock',
+          name: 'core-payments Mock',
+          collection: 'col-baseline',
+          environment: 'env-prod',
+          mockUrl: 'https://discovered-mock.pstmn.io',
+          visibility
+        })
+      });
+      await expect(
+        runRepoSync(
+          createInputs({ environments: ['prod'], generateCiWorkflow: false }),
+          makeDeps(postman, makeGithub())
+        )
+      ).rejects.toThrow(message);
+      expect(postman.createMock).not.toHaveBeenCalled();
+    }
   });
 
   it('creates a new mock when no existing asset is found', async () => {


### PR DESCRIPTION
## Summary

Repo-sync could discover an existing private mock and publish its URL as if anonymous validation could use it. Explicit `mock-url` values also bypassed the validation promised by the action contract, so stale or unrelated mocks failed later in CI without useful context.

Mock resolution now requires a live, public mock record before emitting `mock-url`. Private, unknown, malformed, stale, duplicate, and identity-mismatched mocks fail at the owning repo-sync step without placing API credentials in collections or environments.

## What changed

- Decode the gateway's live `published` field into public, private, or unknown visibility.
- Apply one public-callability policy to explicit URLs, discovered mocks, new creates, and ambiguous-create adoption.
- Validate explicit URLs against the resolved workspace, baseline collection, and environment without assuming a production-only hostname shape.
- Stop retrying deterministic policy, contract, duplicate, and ordinary 4xx failures while preserving transport retries and ambiguous-create reconciliation.
- Extend the disposable live probe to cover public and private create, list, GET, anonymous call, and cleanup behavior.
- Document the public-only reuse contract and credential boundary.

## Safety

The change doesn't alter existing mock visibility and doesn't create a duplicate public twin when a private mock exists. It fails with remediation before setting `mock-url`. Existing public mocks and newly created public mocks keep their current reuse and idempotency behavior.

## Validation

- `npm ci`
- `npm test` (592 Vitest tests and 7 Node tests)
- `npm run lint`
- `npm run typecheck`
- `npm run docs:tables`
- `npm run build`
- `node scripts/verify-dist-artifact.mjs`
- Disposable live gateway probe: public and private mock records exposed `published=true/false`; anonymous public request reached the mock with HTTP 404; anonymous private request returned HTTP 401; private reuse failed with `MOCK_NOT_PUBLIC`; all created assets were deleted.
