### PR TITLE
fix: pin preview test branch context

### DIFF
--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -3271,6 +3271,10 @@ describe('mock resolution paths', () => {
     try {
       process.chdir(isolatedDir);
       vi.stubEnv('POSTMAN_BRANCH_ASSET_IDS', 'owned');
+      vi.stubEnv('POSTMAN_BRANCH_DECISION', '');
+      vi.stubEnv('GITHUB_HEAD_REF', '');
+      vi.stubEnv('GITHUB_REF_NAME', 'feature/mock-environment');
+      vi.stubEnv('GITHUB_REF', 'refs/heads/feature/mock-environment');
       const createEnvironment = vi.fn().mockResolvedValue('env-preview');
       const { core, warnings } = createCoreStub();
       const postman = makePostman({ createEnvironment });


### PR DESCRIPTION
## Summary

The preview mock-environment test depended on the runner's ambient GitHub ref. Main-branch release jobs therefore classified its fixture as canonical and failed before cutting the release.

The test now owns a feature-branch GitHub context, so it exercises the preview behavior consistently on pull requests, main pushes, and Windows runners.

## Root cause

Branch classification reads `process.env` rather than the fixture's `ResolvedInputs` ref fields. The test pinned branch asset ownership but left GitHub ref variables inherited from CI.

## Validation

- `GITHUB_REF_NAME=main GITHUB_REF=refs/heads/main npx vitest run tests/repo-sync-action.test.ts -t "skips mock environments for preview runs"`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node scripts/verify-dist-artifact.mjs`
