### PR TITLE
fix: bind private mock runtime auth in production

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -140950,6 +140950,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
     // uid (the gateway services key access off it, exactly like the public REST
     // API); the bare model id 403s "request access from the collection editor".
     createMock: gatewayAssets.createMock.bind(gatewayAssets),
+    configurePrivateMockRuntimeAuth: gatewayAssets.configurePrivateMockRuntimeAuth.bind(gatewayAssets),
     listMocks: gatewayAssets.listMocks.bind(gatewayAssets),
     mockExists: gatewayAssets.mockExists.bind(gatewayAssets),
     findMockByCollection: gatewayAssets.findMockByCollection.bind(gatewayAssets),

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -138858,6 +138858,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
     // uid (the gateway services key access off it, exactly like the public REST
     // API); the bare model id 403s "request access from the collection editor".
     createMock: gatewayAssets.createMock.bind(gatewayAssets),
+    configurePrivateMockRuntimeAuth: gatewayAssets.configurePrivateMockRuntimeAuth.bind(gatewayAssets),
     listMocks: gatewayAssets.listMocks.bind(gatewayAssets),
     mockExists: gatewayAssets.mockExists.bind(gatewayAssets),
     findMockByCollection: gatewayAssets.findMockByCollection.bind(gatewayAssets),

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -140972,6 +140972,7 @@ function createRepoSyncDependencies(inputs, resolved, factories, options = {}) {
     // uid (the gateway services key access off it, exactly like the public REST
     // API); the bare model id 403s "request access from the collection editor".
     createMock: gatewayAssets.createMock.bind(gatewayAssets),
+    configurePrivateMockRuntimeAuth: gatewayAssets.configurePrivateMockRuntimeAuth.bind(gatewayAssets),
     listMocks: gatewayAssets.listMocks.bind(gatewayAssets),
     mockExists: gatewayAssets.mockExists.bind(gatewayAssets),
     findMockByCollection: gatewayAssets.findMockByCollection.bind(gatewayAssets),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3301,6 +3301,7 @@ export function createRepoSyncDependencies(
     // uid (the gateway services key access off it, exactly like the public REST
     // API); the bare model id 403s "request access from the collection editor".
     createMock: gatewayAssets.createMock.bind(gatewayAssets),
+    configurePrivateMockRuntimeAuth: gatewayAssets.configurePrivateMockRuntimeAuth.bind(gatewayAssets),
     listMocks: gatewayAssets.listMocks.bind(gatewayAssets),
     mockExists: gatewayAssets.mockExists.bind(gatewayAssets),
     findMockByCollection: gatewayAssets.findMockByCollection.bind(gatewayAssets),

--- a/tests/access-token-routing.test.ts
+++ b/tests/access-token-routing.test.ts
@@ -118,6 +118,7 @@ describe('createRepoSyncDependencies access-token-primary routing', () => {
       { apiKey: 'pmak-test', teamId: '10490519' },
       factory
     );
+    expect(deps.postman.configurePrivateMockRuntimeAuth).toBeTypeOf('function');
 
     const result = await deps.postman.createMock('ws-123', 'm', 'col-1', '');
     expect(result.uid).toBe('mock-uuid');


### PR DESCRIPTION
## Root cause

The v2.3.0 client implemented `configurePrivateMockRuntimeAuth`, and unit orchestration tests supplied it in their mock dependency object, but `createRepoSyncDependencies` omitted the binding from the production adapter. A real private run therefore created the mock and then failed with `PRIVATE_MOCK_RUNTIME_AUTH_UNAVAILABLE`.

## Fix

Bind the gateway method in the production dependency object and assert that the production factory exposes it.

## Red proof

ADO build 2804: private mock creation succeeded, then repo-sync failed at the missing adapter method. The new regression test failed with `expected undefined to be type of function` before this one-line binding.

## Validation

- `npm test`: 599 tests + 7 dispatch tests pass
- `npm run lint`, `npm run typecheck`: pass
- dist rebuilt for all three entrypoints

After this patch release, rerun ADO build 2804's pipeline on `codex/linux-runner-validation`.