### PR TITLE
feat: make private mock credentials self-service across CI, app, and runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,17 @@ with:
   monitor-id: 1e2f3a4b-monitor-id
 ```
 
-Repo-sync defaults to public mocks for anonymous validation. Set `mock-visibility: private` for teams that prohibit public mocks. Explicit, discovered, and newly created mocks must match the requested visibility and the expected baseline collection/environment; unknown visibility, stale URLs, and identity mismatches fail before `mock-url` is emitted. For private mocks, repo-sync emits `mock-auth-required: true` and installs a secret-free request hook in the smoke and contract collections. The runner must supply its PMAK as the transient `postmanPrivateMockApiKey` variable. Repo-sync never writes that credential to a collection, environment, output, or repository artifact.
+Repo-sync defaults to public mocks for anonymous validation. Set `mock-visibility: private` for teams that prohibit public mocks. Explicit, discovered, and newly created mocks must match the requested visibility and the expected baseline collection/environment; unknown visibility, stale URLs, and identity mismatches fail before `mock-url` is emitted.
+
+For private mocks, repo-sync emits `mock-auth-required: true` and installs a secret-free request hook in the smoke and contract collections. The hook reads the transient `postmanPrivateMockApiKey` variable and sends it as `x-api-key`, and only to `*.mock.pstmn.io` hosts, so it stays inert on runs that target a real environment. Repo-sync never writes that credential to a collection, environment, output, or repository artifact.
+
+Where that variable comes from depends on who is running the collection:
+
+- **Generated CI** supplies it automatically from the `POSTMAN_API_KEY` secret repo-sync already provisions for `postman login`. No extra secret and no workflow edit.
+- **Manual runs in the Postman app** use the `<project> - Mock` environment, which carries `postmanPrivateMockApiKey` as an empty secret-typed variable. Paste a key with access to the mock. Requires `mock-environment-enabled: true`.
+- **A runner you wire yourself** reads `mock-auth-required` and passes the variable however that system handles secrets.
+
+A request to a private mock with no key set logs a console warning naming the variable, so a `401` explains its own fix.
 
 For manual collection validation against the resolved mock, opt in to a dedicated Postman environment:
 

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -134252,6 +134252,7 @@ function resolvePostmanEndpointProfile(stack, region = "us") {
 // src/lib/ci-workflow-template.ts
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliInstallUrl;
 var DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliWindowsInstallUrl;
+var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
 function validateHttpsInstallUrl(url) {
   const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
   if (!safeUrlPattern.test(url)) {
@@ -134283,9 +134284,9 @@ function renderCiWorkflowTemplate(options = {}) {
   const rawUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
   const installUrl = validateHttpsInstallUrl(rawUrl);
   const postmanRegion = resolvePostmanRegion(options.postmanRegion);
-  return buildCiWorkflowLines(installUrl, postmanRegion).join("\n");
+  return buildCiWorkflowLines(installUrl, postmanRegion, options.privateMockAuth === true).join("\n");
 }
-function buildCiWorkflowLines(installUrl, postmanRegion) {
+function buildCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "name: CI/CD Pipeline",
     "on:",
@@ -134352,6 +134353,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -134371,6 +134373,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -134386,7 +134389,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
   ];
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
-function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName) {
+function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName, privateMockAuth) {
   return [
     "  - pwsh: |",
     "      $ErrorActionPreference = 'Stop'",
@@ -134398,6 +134401,7 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     "      $ciEnvironment = Resolve-AdoOptional $env:CI_ENVIRONMENT",
     "      if ([string]::IsNullOrWhiteSpace($ciEnvironment)) { $ciEnvironment = 'Production' }",
     `      $arguments = @('collection', 'run', $collectionUid, '-e', $env:POSTMAN_ENVIRONMENT_UID, '--report-events', '--env-var', "CI_ENVIRONMENT=$ciEnvironment")`,
+    ...privateMockAuth ? [`      $arguments += @('--env-var', "${PRIVATE_MOCK_AUTH_VARIABLE}=$env:POSTMAN_API_KEY")`] : [],
     "      $sslRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-ssl'",
     "      $clientCert = Join-Path $sslRoot 'client.crt'",
     "      $clientKey = Join-Path $sslRoot 'client.key'",
@@ -134419,10 +134423,11 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     `      ${collectionEnvironmentName}: $(${collectionEnvironmentName})`,
     "      POSTMAN_ENVIRONMENT_UID: $(POSTMAN_ENVIRONMENT_UID)",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
-    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)"
+    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : []
   ];
 }
-function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -134507,12 +134512,12 @@ function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
     "      POSTMAN_SSL_CLIENT_CERT_B64: $(POSTMAN_SSL_CLIENT_CERT_B64)",
     "      POSTMAN_SSL_CLIENT_KEY_B64: $(POSTMAN_SSL_CLIENT_KEY_B64)",
     "      POSTMAN_SSL_EXTRA_CA_CERTS_B64: $(POSTMAN_SSL_EXTRA_CA_CERTS_B64)",
-    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID"),
-    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID"),
+    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID", privateMockAuth),
+    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID", privateMockAuth),
     ""
   ];
 }
-function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -134589,6 +134594,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -134604,6 +134610,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     "  - script: |",
     "      normalize_azure_optional_var() {",
     '        local name="$1"',
@@ -134620,6 +134627,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -134635,6 +134643,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     ""
   ];
 }
@@ -134696,7 +134705,8 @@ function getCiWorkflowTemplate(provider, options = {}) {
     const rawUrl = runnerOs === "windows" ? String(options.postmanCliWindowsInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL : String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
     const postmanRegion = resolvePostmanRegion(options.postmanRegion);
     const installUrl = validateHttpsInstallUrl(rawUrl);
-    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) : buildAdoCiWorkflowLines(installUrl, postmanRegion)).join("\n");
+    const privateMockAuth = options.privateMockAuth === true;
+    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) : buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth)).join("\n");
   }
   return renderCiWorkflowTemplate(options);
 }
@@ -136984,16 +136994,39 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
+var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
-  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
-  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
-  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
+  "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+function stripPrivateMockAuthBlocks(code) {
+  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
+  const lines = code.split("\n");
+  const kept = [];
+  let skipping = false;
+  for (const line of lines) {
+    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
+      skipping = false;
+    }
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -137591,8 +137624,9 @@ var PostmanGatewayAssetsClient = class {
       const item = this.asRecord(response?.data) ?? listedItem;
       const scripts = Array.isArray(item.scripts) ? item.scripts.filter((entry) => Boolean(this.asRecord(entry))) : [];
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
-      if (String(before?.code ?? "").includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [String(before?.code ?? "").trim(), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const existingCode = String(before?.code ?? "");
+      if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
+      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }
@@ -138928,9 +138962,13 @@ function assertBranchAssetIds(inputs, decision, branchOwnedIds = process.env.POS
     );
   }
 }
-function buildEnvironmentValues(envName, baseUrl) {
+function buildEnvironmentValues(envName, baseUrl, options = {}) {
   return [
     { key: "baseUrl", value: baseUrl, type: "default" },
+    // A private mock refuses anonymous calls, so the manual-validation environment
+    // carries a named, empty, secret-typed slot for the caller's own key. Repo-sync
+    // never writes a value here; the developer pastes one in the Postman app.
+    ...options.privateMockAuth ? [{ key: PRIVATE_MOCK_AUTH_VARIABLE2, value: "", type: "secret" }] : [],
     { key: "CI", value: "false", type: "default" },
     { key: "RESPONSE_TIME_THRESHOLD", value: "2000", type: "default" },
     { key: "AWS_ACCESS_KEY_ID", value: "", type: "secret" },
@@ -139377,12 +139415,12 @@ async function upsertEnvironments(inputs, dependencies, resourcesState, assetMar
   }
   return envUids;
 }
-async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl) {
+async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl, privateMockAuth) {
   if (!inputs.mockEnvironmentEnabled || !inputs.workspaceId || !mockUrl) {
     return "";
   }
   const displayName = `${assetProjectName} - Mock`;
-  const values = buildEnvironmentValues("mock", mockUrl);
+  const values = buildEnvironmentValues("mock", mockUrl, { privateMockAuth });
   const mask = resolveRepoSyncMasker(dependencies);
   try {
     const discovered = await dependencies.postman.findEnvironmentByName(
@@ -140111,14 +140149,16 @@ function renderCiWorkflow(inputs) {
       postmanCliInstallUrl: inputs.postmanCliInstallUrl,
       postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
       runnerOs: inputs.ciRunnerOs,
-      postmanRegion: inputs.postmanRegion
+      postmanRegion: inputs.postmanRegion,
+      privateMockAuth: inputs.mockVisibility === "private"
     });
   }
   return renderCiWorkflowTemplate({
     postmanCliInstallUrl: inputs.postmanCliInstallUrl,
     postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
     runnerOs: inputs.ciRunnerOs,
-    postmanRegion: inputs.postmanRegion
+    postmanRegion: inputs.postmanRegion,
+    privateMockAuth: inputs.mockVisibility === "private"
   });
 }
 function createRepoSummary(outputs, envUids, pushed) {
@@ -140473,10 +140513,17 @@ async function runRepoSyncInner(inputs, dependencies) {
             "PRIVATE_MOCK_RUNTIME_AUTH_UNAVAILABLE: The Postman client cannot configure runtime x-api-key injection."
           );
         }
+        const configured = [];
         for (const collectionUid of [inputs.smokeCollectionId, inputs.contractCollectionId]) {
           if (collectionUid) {
             await dependencies.postman.configurePrivateMockRuntimeAuth(collectionUid);
+            configured.push(collectionUid);
           }
+        }
+        if (configured.length > 0) {
+          (dependencies.core.notice ?? dependencies.core.info)(
+            `Private mock: installed a request hook on ${configured.length} collection(s) that sends the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable as x-api-key, and only to *.mock.pstmn.io hosts. The generated CI workflow supplies it from the POSTMAN_API_KEY secret. For manual runs in the Postman app, set that variable to a key with access to the mock. No key is stored in the collection, environment, outputs, or repository.`
+          );
         }
       }
       if (inputs.mockEnvironmentEnabled && isCanonicalWriter) {
@@ -140484,7 +140531,8 @@ async function runRepoSyncInner(inputs, dependencies) {
           inputs,
           dependencies,
           assetProjectName,
-          resolvedMockUrl
+          resolvedMockUrl,
+          resolvedMockVisibility === "private"
         );
         outputs["mock-environment-uid"] = mockEnvironmentUid;
         outputs["mock-environment-status"] = mockEnvironmentUid ? "success" : "failed";

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -132357,6 +132357,7 @@ function resolvePostmanEndpointProfile(stack, region = "us") {
 // src/lib/ci-workflow-template.ts
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliInstallUrl;
 var DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliWindowsInstallUrl;
+var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
 function validateHttpsInstallUrl(url) {
   const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
   if (!safeUrlPattern.test(url)) {
@@ -132388,9 +132389,9 @@ function renderCiWorkflowTemplate(options = {}) {
   const rawUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
   const installUrl = validateHttpsInstallUrl(rawUrl);
   const postmanRegion = resolvePostmanRegion(options.postmanRegion);
-  return buildCiWorkflowLines(installUrl, postmanRegion).join("\n");
+  return buildCiWorkflowLines(installUrl, postmanRegion, options.privateMockAuth === true).join("\n");
 }
-function buildCiWorkflowLines(installUrl, postmanRegion) {
+function buildCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "name: CI/CD Pipeline",
     "on:",
@@ -132457,6 +132458,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -132476,6 +132478,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -132491,7 +132494,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
   ];
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
-function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName) {
+function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName, privateMockAuth) {
   return [
     "  - pwsh: |",
     "      $ErrorActionPreference = 'Stop'",
@@ -132503,6 +132506,7 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     "      $ciEnvironment = Resolve-AdoOptional $env:CI_ENVIRONMENT",
     "      if ([string]::IsNullOrWhiteSpace($ciEnvironment)) { $ciEnvironment = 'Production' }",
     `      $arguments = @('collection', 'run', $collectionUid, '-e', $env:POSTMAN_ENVIRONMENT_UID, '--report-events', '--env-var', "CI_ENVIRONMENT=$ciEnvironment")`,
+    ...privateMockAuth ? [`      $arguments += @('--env-var', "${PRIVATE_MOCK_AUTH_VARIABLE}=$env:POSTMAN_API_KEY")`] : [],
     "      $sslRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-ssl'",
     "      $clientCert = Join-Path $sslRoot 'client.crt'",
     "      $clientKey = Join-Path $sslRoot 'client.key'",
@@ -132524,10 +132528,11 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     `      ${collectionEnvironmentName}: $(${collectionEnvironmentName})`,
     "      POSTMAN_ENVIRONMENT_UID: $(POSTMAN_ENVIRONMENT_UID)",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
-    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)"
+    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : []
   ];
 }
-function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -132612,12 +132617,12 @@ function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
     "      POSTMAN_SSL_CLIENT_CERT_B64: $(POSTMAN_SSL_CLIENT_CERT_B64)",
     "      POSTMAN_SSL_CLIENT_KEY_B64: $(POSTMAN_SSL_CLIENT_KEY_B64)",
     "      POSTMAN_SSL_EXTRA_CA_CERTS_B64: $(POSTMAN_SSL_EXTRA_CA_CERTS_B64)",
-    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID"),
-    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID"),
+    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID", privateMockAuth),
+    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID", privateMockAuth),
     ""
   ];
 }
-function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -132694,6 +132699,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -132709,6 +132715,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     "  - script: |",
     "      normalize_azure_optional_var() {",
     '        local name="$1"',
@@ -132725,6 +132732,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -132740,6 +132748,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     ""
   ];
 }
@@ -132801,7 +132810,8 @@ function getCiWorkflowTemplate(provider, options = {}) {
     const rawUrl = runnerOs === "windows" ? String(options.postmanCliWindowsInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL : String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
     const postmanRegion = resolvePostmanRegion(options.postmanRegion);
     const installUrl = validateHttpsInstallUrl(rawUrl);
-    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) : buildAdoCiWorkflowLines(installUrl, postmanRegion)).join("\n");
+    const privateMockAuth = options.privateMockAuth === true;
+    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) : buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth)).join("\n");
   }
   return renderCiWorkflowTemplate(options);
 }
@@ -135089,16 +135099,39 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
+var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
-  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
-  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
-  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
+  "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+function stripPrivateMockAuthBlocks(code) {
+  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
+  const lines = code.split("\n");
+  const kept = [];
+  let skipping = false;
+  for (const line of lines) {
+    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
+      skipping = false;
+    }
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -135696,8 +135729,9 @@ var PostmanGatewayAssetsClient = class {
       const item = this.asRecord(response?.data) ?? listedItem;
       const scripts = Array.isArray(item.scripts) ? item.scripts.filter((entry) => Boolean(this.asRecord(entry))) : [];
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
-      if (String(before?.code ?? "").includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [String(before?.code ?? "").trim(), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const existingCode = String(before?.code ?? "");
+      if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
+      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }
@@ -136978,9 +137012,13 @@ function assertBranchAssetIds(inputs, decision, branchOwnedIds = process.env.POS
     );
   }
 }
-function buildEnvironmentValues(envName, baseUrl) {
+function buildEnvironmentValues(envName, baseUrl, options = {}) {
   return [
     { key: "baseUrl", value: baseUrl, type: "default" },
+    // A private mock refuses anonymous calls, so the manual-validation environment
+    // carries a named, empty, secret-typed slot for the caller's own key. Repo-sync
+    // never writes a value here; the developer pastes one in the Postman app.
+    ...options.privateMockAuth ? [{ key: PRIVATE_MOCK_AUTH_VARIABLE2, value: "", type: "secret" }] : [],
     { key: "CI", value: "false", type: "default" },
     { key: "RESPONSE_TIME_THRESHOLD", value: "2000", type: "default" },
     { key: "AWS_ACCESS_KEY_ID", value: "", type: "secret" },
@@ -137285,12 +137323,12 @@ async function upsertEnvironments(inputs, dependencies, resourcesState, assetMar
   }
   return envUids;
 }
-async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl) {
+async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl, privateMockAuth) {
   if (!inputs.mockEnvironmentEnabled || !inputs.workspaceId || !mockUrl) {
     return "";
   }
   const displayName = `${assetProjectName} - Mock`;
-  const values = buildEnvironmentValues("mock", mockUrl);
+  const values = buildEnvironmentValues("mock", mockUrl, { privateMockAuth });
   const mask = resolveRepoSyncMasker(dependencies);
   try {
     const discovered = await dependencies.postman.findEnvironmentByName(
@@ -138019,14 +138057,16 @@ function renderCiWorkflow(inputs) {
       postmanCliInstallUrl: inputs.postmanCliInstallUrl,
       postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
       runnerOs: inputs.ciRunnerOs,
-      postmanRegion: inputs.postmanRegion
+      postmanRegion: inputs.postmanRegion,
+      privateMockAuth: inputs.mockVisibility === "private"
     });
   }
   return renderCiWorkflowTemplate({
     postmanCliInstallUrl: inputs.postmanCliInstallUrl,
     postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
     runnerOs: inputs.ciRunnerOs,
-    postmanRegion: inputs.postmanRegion
+    postmanRegion: inputs.postmanRegion,
+    privateMockAuth: inputs.mockVisibility === "private"
   });
 }
 function createRepoSummary(outputs, envUids, pushed) {
@@ -138381,10 +138421,17 @@ async function runRepoSyncInner(inputs, dependencies) {
             "PRIVATE_MOCK_RUNTIME_AUTH_UNAVAILABLE: The Postman client cannot configure runtime x-api-key injection."
           );
         }
+        const configured = [];
         for (const collectionUid of [inputs.smokeCollectionId, inputs.contractCollectionId]) {
           if (collectionUid) {
             await dependencies.postman.configurePrivateMockRuntimeAuth(collectionUid);
+            configured.push(collectionUid);
           }
+        }
+        if (configured.length > 0) {
+          (dependencies.core.notice ?? dependencies.core.info)(
+            `Private mock: installed a request hook on ${configured.length} collection(s) that sends the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable as x-api-key, and only to *.mock.pstmn.io hosts. The generated CI workflow supplies it from the POSTMAN_API_KEY secret. For manual runs in the Postman app, set that variable to a key with access to the mock. No key is stored in the collection, environment, outputs, or repository.`
+          );
         }
       }
       if (inputs.mockEnvironmentEnabled && isCanonicalWriter) {
@@ -138392,7 +138439,8 @@ async function runRepoSyncInner(inputs, dependencies) {
           inputs,
           dependencies,
           assetProjectName,
-          resolvedMockUrl
+          resolvedMockUrl,
+          resolvedMockVisibility === "private"
         );
         outputs["mock-environment-uid"] = mockEnvironmentUid;
         outputs["mock-environment-status"] = mockEnvironmentUid ? "success" : "failed";
@@ -139400,6 +139448,9 @@ var ConsoleReporter = class {
   onOutput;
   info(message) {
     console.error(message);
+  }
+  notice(message) {
+    console.error(`notice: ${message}`);
   }
   warning(message) {
     console.error(`warning: ${message}`);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -134274,6 +134274,7 @@ function resolvePostmanEndpointProfile(stack, region = "us") {
 // src/lib/ci-workflow-template.ts
 var DEFAULT_POSTMAN_CLI_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliInstallUrl;
 var DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL = POSTMAN_ENDPOINT_PROFILES.prod.cliWindowsInstallUrl;
+var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
 function validateHttpsInstallUrl(url) {
   const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
   if (!safeUrlPattern.test(url)) {
@@ -134305,9 +134306,9 @@ function renderCiWorkflowTemplate(options = {}) {
   const rawUrl = String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
   const installUrl = validateHttpsInstallUrl(rawUrl);
   const postmanRegion = resolvePostmanRegion(options.postmanRegion);
-  return buildCiWorkflowLines(installUrl, postmanRegion).join("\n");
+  return buildCiWorkflowLines(installUrl, postmanRegion, options.privateMockAuth === true).join("\n");
 }
-function buildCiWorkflowLines(installUrl, postmanRegion) {
+function buildCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "name: CI/CD Pipeline",
     "on:",
@@ -134374,6 +134375,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -134393,6 +134395,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
     '            -e "$POSTMAN_ENVIRONMENT_UID"',
     "            --report-events",
     `            --env-var "CI_ENVIRONMENT=\${{ vars.CI_ENVIRONMENT || 'Production' }}")`,
+    ...privateMockAuth ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")'] : [],
     '          if [ -f "$RUNNER_TEMP/postman-ssl/client.crt" ]; then',
     '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
     '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -134408,7 +134411,7 @@ function buildCiWorkflowLines(installUrl, postmanRegion) {
   ];
 }
 var CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
-function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName) {
+function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentName, privateMockAuth) {
   return [
     "  - pwsh: |",
     "      $ErrorActionPreference = 'Stop'",
@@ -134420,6 +134423,7 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     "      $ciEnvironment = Resolve-AdoOptional $env:CI_ENVIRONMENT",
     "      if ([string]::IsNullOrWhiteSpace($ciEnvironment)) { $ciEnvironment = 'Production' }",
     `      $arguments = @('collection', 'run', $collectionUid, '-e', $env:POSTMAN_ENVIRONMENT_UID, '--report-events', '--env-var', "CI_ENVIRONMENT=$ciEnvironment")`,
+    ...privateMockAuth ? [`      $arguments += @('--env-var', "${PRIVATE_MOCK_AUTH_VARIABLE}=$env:POSTMAN_API_KEY")`] : [],
     "      $sslRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-ssl'",
     "      $clientCert = Join-Path $sslRoot 'client.crt'",
     "      $clientKey = Join-Path $sslRoot 'client.key'",
@@ -134441,10 +134445,11 @@ function buildAdoWindowsCollectionRunLines(displayName, collectionEnvironmentNam
     `      ${collectionEnvironmentName}: $(${collectionEnvironmentName})`,
     "      POSTMAN_ENVIRONMENT_UID: $(POSTMAN_ENVIRONMENT_UID)",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
-    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)"
+    "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : []
   ];
 }
-function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -134529,12 +134534,12 @@ function buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) {
     "      POSTMAN_SSL_CLIENT_CERT_B64: $(POSTMAN_SSL_CLIENT_CERT_B64)",
     "      POSTMAN_SSL_CLIENT_KEY_B64: $(POSTMAN_SSL_CLIENT_KEY_B64)",
     "      POSTMAN_SSL_EXTRA_CA_CERTS_B64: $(POSTMAN_SSL_EXTRA_CA_CERTS_B64)",
-    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID"),
-    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID"),
+    ...buildAdoWindowsCollectionRunLines("Run Smoke Tests", "POSTMAN_SMOKE_COLLECTION_UID", privateMockAuth),
+    ...buildAdoWindowsCollectionRunLines("Run Contract Tests", "POSTMAN_CONTRACT_COLLECTION_UID", privateMockAuth),
     ""
   ];
 }
-function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
+function buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) {
   return [
     "trigger:",
     "  branches:",
@@ -134611,6 +134616,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -134626,6 +134632,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     "  - script: |",
     "      normalize_azure_optional_var() {",
     '        local name="$1"',
@@ -134642,6 +134649,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     '        -e "$POSTMAN_ENVIRONMENT_UID"',
     "        --report-events",
     '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+    ...privateMockAuth ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")'] : [],
     '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
     '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
     '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -134657,6 +134665,7 @@ function buildAdoCiWorkflowLines(installUrl, postmanRegion) {
     "    env:",
     "      CI_ENVIRONMENT: $(CI_ENVIRONMENT)",
     "      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)",
+    ...privateMockAuth ? ["      POSTMAN_API_KEY: $(POSTMAN_API_KEY)"] : [],
     ""
   ];
 }
@@ -134718,7 +134727,8 @@ function getCiWorkflowTemplate(provider, options = {}) {
     const rawUrl = runnerOs === "windows" ? String(options.postmanCliWindowsInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_WINDOWS_INSTALL_URL : String(options.postmanCliInstallUrl || "").trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
     const postmanRegion = resolvePostmanRegion(options.postmanRegion);
     const installUrl = validateHttpsInstallUrl(rawUrl);
-    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion) : buildAdoCiWorkflowLines(installUrl, postmanRegion)).join("\n");
+    const privateMockAuth = options.privateMockAuth === true;
+    return (runnerOs === "windows" ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth) : buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth)).join("\n");
   }
   return renderCiWorkflowTemplate(options);
 }
@@ -137006,16 +137016,39 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_VARIABLE = "postmanPrivateMockApiKey";
+var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
-  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
-  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
-  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
+  "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+function stripPrivateMockAuthBlocks(code) {
+  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
+  const lines = code.split("\n");
+  const kept = [];
+  let skipping = false;
+  for (const line of lines) {
+    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
+      skipping = false;
+    }
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
 var PostmanGatewayAssetsClient = class {
@@ -137613,8 +137646,9 @@ var PostmanGatewayAssetsClient = class {
       const item = this.asRecord(response?.data) ?? listedItem;
       const scripts = Array.isArray(item.scripts) ? item.scripts.filter((entry) => Boolean(this.asRecord(entry))) : [];
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
-      if (String(before?.code ?? "").includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [String(before?.code ?? "").trim(), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const existingCode = String(before?.code ?? "");
+      if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
+      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }
@@ -138950,9 +138984,13 @@ function assertBranchAssetIds(inputs, decision, branchOwnedIds = process.env.POS
     );
   }
 }
-function buildEnvironmentValues(envName, baseUrl) {
+function buildEnvironmentValues(envName, baseUrl, options = {}) {
   return [
     { key: "baseUrl", value: baseUrl, type: "default" },
+    // A private mock refuses anonymous calls, so the manual-validation environment
+    // carries a named, empty, secret-typed slot for the caller's own key. Repo-sync
+    // never writes a value here; the developer pastes one in the Postman app.
+    ...options.privateMockAuth ? [{ key: PRIVATE_MOCK_AUTH_VARIABLE2, value: "", type: "secret" }] : [],
     { key: "CI", value: "false", type: "default" },
     { key: "RESPONSE_TIME_THRESHOLD", value: "2000", type: "default" },
     { key: "AWS_ACCESS_KEY_ID", value: "", type: "secret" },
@@ -139399,12 +139437,12 @@ async function upsertEnvironments(inputs, dependencies, resourcesState, assetMar
   }
   return envUids;
 }
-async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl) {
+async function upsertMockEnvironment(inputs, dependencies, assetProjectName, mockUrl, privateMockAuth) {
   if (!inputs.mockEnvironmentEnabled || !inputs.workspaceId || !mockUrl) {
     return "";
   }
   const displayName = `${assetProjectName} - Mock`;
-  const values = buildEnvironmentValues("mock", mockUrl);
+  const values = buildEnvironmentValues("mock", mockUrl, { privateMockAuth });
   const mask = resolveRepoSyncMasker(dependencies);
   try {
     const discovered = await dependencies.postman.findEnvironmentByName(
@@ -140133,14 +140171,16 @@ function renderCiWorkflow(inputs) {
       postmanCliInstallUrl: inputs.postmanCliInstallUrl,
       postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
       runnerOs: inputs.ciRunnerOs,
-      postmanRegion: inputs.postmanRegion
+      postmanRegion: inputs.postmanRegion,
+      privateMockAuth: inputs.mockVisibility === "private"
     });
   }
   return renderCiWorkflowTemplate({
     postmanCliInstallUrl: inputs.postmanCliInstallUrl,
     postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
     runnerOs: inputs.ciRunnerOs,
-    postmanRegion: inputs.postmanRegion
+    postmanRegion: inputs.postmanRegion,
+    privateMockAuth: inputs.mockVisibility === "private"
   });
 }
 function createRepoSummary(outputs, envUids, pushed) {
@@ -140495,10 +140535,17 @@ async function runRepoSyncInner(inputs, dependencies) {
             "PRIVATE_MOCK_RUNTIME_AUTH_UNAVAILABLE: The Postman client cannot configure runtime x-api-key injection."
           );
         }
+        const configured = [];
         for (const collectionUid of [inputs.smokeCollectionId, inputs.contractCollectionId]) {
           if (collectionUid) {
             await dependencies.postman.configurePrivateMockRuntimeAuth(collectionUid);
+            configured.push(collectionUid);
           }
+        }
+        if (configured.length > 0) {
+          (dependencies.core.notice ?? dependencies.core.info)(
+            `Private mock: installed a request hook on ${configured.length} collection(s) that sends the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable as x-api-key, and only to *.mock.pstmn.io hosts. The generated CI workflow supplies it from the POSTMAN_API_KEY secret. For manual runs in the Postman app, set that variable to a key with access to the mock. No key is stored in the collection, environment, outputs, or repository.`
+          );
         }
       }
       if (inputs.mockEnvironmentEnabled && isCanonicalWriter) {
@@ -140506,7 +140553,8 @@ async function runRepoSyncInner(inputs, dependencies) {
           inputs,
           dependencies,
           assetProjectName,
-          resolvedMockUrl
+          resolvedMockUrl,
+          resolvedMockVisibility === "private"
         );
         outputs["mock-environment-uid"] = mockEnvironmentUid;
         outputs["mock-environment-status"] = mockEnvironmentUid ? "success" : "failed";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,10 @@ export class ConsoleReporter implements ReporterCore {
     console.error(message);
   }
 
+  public notice(message: string): void {
+    console.error(`notice: ${message}`);
+  }
+
   public warning(message: string): void {
     console.error(`warning: ${message}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,8 @@ import {
   PostmanGatewayAssetsClient,
   requireMockVisibility,
   type MockRecord,
-  type RequestedMockVisibility
+  type RequestedMockVisibility,
+  PRIVATE_MOCK_AUTH_VARIABLE
 } from './lib/postman/postman-gateway-assets-client.js';
 import { AccessTokenProvider, mintAccessTokenIfNeeded } from './lib/postman/token-provider.js';
 import { AccessTokenGatewayClient } from './lib/postman/gateway-client.js';
@@ -175,6 +176,8 @@ interface RepoSyncOutputs {
 interface CoreLike {
   getInput(name: string, options?: { required?: boolean }): string;
   info(message: string): void;
+  /** Optional: GitHub Actions surfaces this in the job summary. Test doubles and the CLI reporter may omit it. */
+  notice?(message: string): void;
   setFailed(message: string): void;
   setOutput(name: string, value: string): void;
   setSecret(secret: string): void;
@@ -191,7 +194,7 @@ export interface ExecLike {
 
 export interface RepoSyncDependencies {
   teamId?: string;
-  core: Pick<CoreLike, 'info' | 'setOutput' | 'warning'>;
+  core: Pick<CoreLike, 'info' | 'setOutput' | 'warning' | 'notice'>;
   postman: Pick<
     PostmanGatewayAssetsClient,
     | 'createEnvironment'
@@ -677,9 +680,19 @@ export function assertBranchAssetIds(
   }
 }
 
-function buildEnvironmentValues(envName: string, baseUrl: string): EnvironmentValues {
+function buildEnvironmentValues(
+  envName: string,
+  baseUrl: string,
+  options: { privateMockAuth?: boolean } = {}
+): EnvironmentValues {
   return [
     { key: 'baseUrl', value: baseUrl, type: 'default' },
+    // A private mock refuses anonymous calls, so the manual-validation environment
+    // carries a named, empty, secret-typed slot for the caller's own key. Repo-sync
+    // never writes a value here; the developer pastes one in the Postman app.
+    ...(options.privateMockAuth
+      ? [{ key: PRIVATE_MOCK_AUTH_VARIABLE, value: '', type: 'secret' as const }]
+      : []),
     { key: 'CI', value: 'false', type: 'default' },
     { key: 'RESPONSE_TIME_THRESHOLD', value: '2000', type: 'default' },
     { key: 'AWS_ACCESS_KEY_ID', value: '', type: 'secret' },
@@ -1247,13 +1260,14 @@ async function upsertMockEnvironment(
   inputs: ResolvedInputs,
   dependencies: RepoSyncDependencies,
   assetProjectName: string,
-  mockUrl: string
+  mockUrl: string,
+  privateMockAuth: boolean
 ): Promise<string> {
   if (!inputs.mockEnvironmentEnabled || !inputs.workspaceId || !mockUrl) {
     return '';
   }
   const displayName = `${assetProjectName} - Mock`;
-  const values = buildEnvironmentValues('mock', mockUrl);
+  const values = buildEnvironmentValues('mock', mockUrl, { privateMockAuth });
   const mask = resolveRepoSyncMasker(dependencies);
   try {
     const discovered = await dependencies.postman.findEnvironmentByName(
@@ -2242,14 +2256,16 @@ function renderCiWorkflow(inputs: ResolvedInputs): string {
       postmanCliInstallUrl: inputs.postmanCliInstallUrl,
       postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
       runnerOs: inputs.ciRunnerOs,
-      postmanRegion: inputs.postmanRegion
+      postmanRegion: inputs.postmanRegion,
+      privateMockAuth: inputs.mockVisibility === 'private'
     });
   }
   return renderCiWorkflowTemplate({
     postmanCliInstallUrl: inputs.postmanCliInstallUrl,
     postmanCliWindowsInstallUrl: inputs.postmanCliWindowsInstallUrl,
     runnerOs: inputs.ciRunnerOs,
-    postmanRegion: inputs.postmanRegion
+    postmanRegion: inputs.postmanRegion,
+    privateMockAuth: inputs.mockVisibility === 'private'
   });
 }
 
@@ -2697,10 +2713,21 @@ async function runRepoSyncInner(
             'PRIVATE_MOCK_RUNTIME_AUTH_UNAVAILABLE: The Postman client cannot configure runtime x-api-key injection.'
           );
         }
+        const configured: string[] = [];
         for (const collectionUid of [inputs.smokeCollectionId, inputs.contractCollectionId]) {
           if (collectionUid) {
             await dependencies.postman.configurePrivateMockRuntimeAuth(collectionUid);
+            configured.push(collectionUid);
           }
+        }
+        if (configured.length > 0) {
+          (dependencies.core.notice ?? dependencies.core.info)(
+            `Private mock: installed a request hook on ${configured.length} collection(s) that sends the ` +
+            `${PRIVATE_MOCK_AUTH_VARIABLE} variable as x-api-key, and only to *.mock.pstmn.io hosts. ` +
+            'The generated CI workflow supplies it from the POSTMAN_API_KEY secret. For manual runs in ' +
+            'the Postman app, set that variable to a key with access to the mock. No key is stored in ' +
+            'the collection, environment, outputs, or repository.'
+          );
         }
       }
       if (inputs.mockEnvironmentEnabled && isCanonicalWriter) {
@@ -2708,7 +2735,8 @@ async function runRepoSyncInner(
           inputs,
           dependencies,
           assetProjectName,
-          resolvedMockUrl
+          resolvedMockUrl,
+          resolvedMockVisibility === 'private'
         );
         outputs['mock-environment-uid'] = mockEnvironmentUid;
         outputs['mock-environment-status'] = mockEnvironmentUid ? 'success' : 'failed';

--- a/src/lib/ci-workflow-template.ts
+++ b/src/lib/ci-workflow-template.ts
@@ -12,7 +12,17 @@ type CiWorkflowTemplateOptions = {
   postmanCliWindowsInstallUrl?: string;
   postmanRegion?: string;
   runnerOs?: CiRunnerOs;
+  /**
+   * A private mock refuses anonymous calls, so the generated run steps forward the
+   * CI POSTMAN_API_KEY secret as the private-mock variable. The hook installed on
+   * the collection only sends it to *.mock.pstmn.io hosts, so it stays inert for
+   * runs that target a real environment.
+   */
+  privateMockAuth?: boolean;
 };
+
+/** Kept in sync with PRIVATE_MOCK_AUTH_VARIABLE in lib/postman/postman-gateway-assets-client.ts. */
+const PRIVATE_MOCK_AUTH_VARIABLE = 'postmanPrivateMockApiKey';
 
 function validateHttpsInstallUrl(url: string): string {
   const safeUrlPattern = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9._~/?=&%-]+$/;
@@ -49,10 +59,14 @@ export function renderCiWorkflowTemplate(options: CiWorkflowTemplateOptions = {}
     String(options.postmanCliInstallUrl || '').trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
   const installUrl = validateHttpsInstallUrl(rawUrl);
   const postmanRegion = resolvePostmanRegion(options.postmanRegion);
-  return buildCiWorkflowLines(installUrl, postmanRegion).join('\n');
+  return buildCiWorkflowLines(installUrl, postmanRegion, options.privateMockAuth === true).join('\n');
 }
 
-function buildCiWorkflowLines(installUrl: string, postmanRegion: string): string[] {
+function buildCiWorkflowLines(
+  installUrl: string,
+  postmanRegion: string,
+  privateMockAuth: boolean
+): string[] {
   return [
   'name: CI/CD Pipeline',
   'on:',
@@ -120,6 +134,9 @@ function buildCiWorkflowLines(installUrl: string, postmanRegion: string): string
   '            -e "$POSTMAN_ENVIRONMENT_UID"',
   '            --report-events',
   "            --env-var \"CI_ENVIRONMENT=${{ vars.CI_ENVIRONMENT || 'Production' }}\")",
+  ...(privateMockAuth
+    ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")']
+    : []),
   "          if [ -f \"$RUNNER_TEMP/postman-ssl/client.crt\" ]; then",
   '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
   '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -139,6 +156,9 @@ function buildCiWorkflowLines(installUrl: string, postmanRegion: string): string
   '            -e "$POSTMAN_ENVIRONMENT_UID"',
   '            --report-events',
   "            --env-var \"CI_ENVIRONMENT=${{ vars.CI_ENVIRONMENT || 'Production' }}\")",
+  ...(privateMockAuth
+    ? ['            CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=${{ secrets.POSTMAN_API_KEY }}")']
+    : []),
   "          if [ -f \"$RUNNER_TEMP/postman-ssl/client.crt\" ]; then",
   '            CMD+=(--ssl-client-cert "$RUNNER_TEMP/postman-ssl/client.crt"',
   '              --ssl-client-key "$RUNNER_TEMP/postman-ssl/client.key")',
@@ -158,7 +178,8 @@ export const CI_WORKFLOW_TEMPLATE = renderCiWorkflowTemplate();
 
 function buildAdoWindowsCollectionRunLines(
   displayName: string,
-  collectionEnvironmentName: 'POSTMAN_SMOKE_COLLECTION_UID' | 'POSTMAN_CONTRACT_COLLECTION_UID'
+  collectionEnvironmentName: 'POSTMAN_SMOKE_COLLECTION_UID' | 'POSTMAN_CONTRACT_COLLECTION_UID',
+  privateMockAuth: boolean
 ): string[] {
   return [
     '  - pwsh: |',
@@ -171,6 +192,9 @@ function buildAdoWindowsCollectionRunLines(
     '      $ciEnvironment = Resolve-AdoOptional $env:CI_ENVIRONMENT',
     "      if ([string]::IsNullOrWhiteSpace($ciEnvironment)) { $ciEnvironment = 'Production' }",
     `      $arguments = @('collection', 'run', $collectionUid, '-e', $env:POSTMAN_ENVIRONMENT_UID, '--report-events', '--env-var', "CI_ENVIRONMENT=$ciEnvironment")`,
+    ...(privateMockAuth
+      ? [`      $arguments += @('--env-var', "${PRIVATE_MOCK_AUTH_VARIABLE}=$env:POSTMAN_API_KEY")`]
+      : []),
     "      $sslRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-ssl'",
     "      $clientCert = Join-Path $sslRoot 'client.crt'",
     "      $clientKey = Join-Path $sslRoot 'client.key'",
@@ -192,11 +216,16 @@ function buildAdoWindowsCollectionRunLines(
     `      ${collectionEnvironmentName}: $(${collectionEnvironmentName})`,
     '      POSTMAN_ENVIRONMENT_UID: $(POSTMAN_ENVIRONMENT_UID)',
     '      CI_ENVIRONMENT: $(CI_ENVIRONMENT)',
-    '      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)'
+    '      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)',
+    ...(privateMockAuth ? ['      POSTMAN_API_KEY: $(POSTMAN_API_KEY)'] : [])
   ];
 }
 
-function buildAdoWindowsCiWorkflowLines(installUrl: string, postmanRegion: string): string[] {
+function buildAdoWindowsCiWorkflowLines(
+  installUrl: string,
+  postmanRegion: string,
+  privateMockAuth: boolean
+): string[] {
   return [
     'trigger:',
     '  branches:',
@@ -281,13 +310,17 @@ function buildAdoWindowsCiWorkflowLines(installUrl: string, postmanRegion: strin
     '      POSTMAN_SSL_CLIENT_CERT_B64: $(POSTMAN_SSL_CLIENT_CERT_B64)',
     '      POSTMAN_SSL_CLIENT_KEY_B64: $(POSTMAN_SSL_CLIENT_KEY_B64)',
     '      POSTMAN_SSL_EXTRA_CA_CERTS_B64: $(POSTMAN_SSL_EXTRA_CA_CERTS_B64)',
-    ...buildAdoWindowsCollectionRunLines('Run Smoke Tests', 'POSTMAN_SMOKE_COLLECTION_UID'),
-    ...buildAdoWindowsCollectionRunLines('Run Contract Tests', 'POSTMAN_CONTRACT_COLLECTION_UID'),
+    ...buildAdoWindowsCollectionRunLines('Run Smoke Tests', 'POSTMAN_SMOKE_COLLECTION_UID', privateMockAuth),
+    ...buildAdoWindowsCollectionRunLines('Run Contract Tests', 'POSTMAN_CONTRACT_COLLECTION_UID', privateMockAuth),
     ''
   ];
 }
 
-function buildAdoCiWorkflowLines(installUrl: string, postmanRegion: string): string[] {
+function buildAdoCiWorkflowLines(
+  installUrl: string,
+  postmanRegion: string,
+  privateMockAuth: boolean
+): string[] {
   return [
   'trigger:',
   '  branches:',
@@ -365,6 +398,9 @@ function buildAdoCiWorkflowLines(installUrl: string, postmanRegion: string): str
   '        -e "$POSTMAN_ENVIRONMENT_UID"',
   '        --report-events',
   '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+  ...(privateMockAuth
+    ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")']
+    : []),
   '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
   '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
   '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -380,6 +416,7 @@ function buildAdoCiWorkflowLines(installUrl: string, postmanRegion: string): str
   '    env:',
   '      CI_ENVIRONMENT: $(CI_ENVIRONMENT)',
   '      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)',
+  ...(privateMockAuth ? ['      POSTMAN_API_KEY: $(POSTMAN_API_KEY)'] : []),
   '  - script: |',
   '      normalize_azure_optional_var() {',
   '        local name="$1"',
@@ -396,6 +433,9 @@ function buildAdoCiWorkflowLines(installUrl: string, postmanRegion: string): str
   '        -e "$POSTMAN_ENVIRONMENT_UID"',
   '        --report-events',
   '        --env-var "CI_ENVIRONMENT=${CI_ENVIRONMENT:-Production}")',
+  ...(privateMockAuth
+    ? ['        CMD+=(--env-var "' + PRIVATE_MOCK_AUTH_VARIABLE + '=$POSTMAN_API_KEY")']
+    : []),
   '      if [ -f "$(Agent.TempDirectory)/postman-ssl/client.crt" ]; then',
   '        CMD+=(--ssl-client-cert "$(Agent.TempDirectory)/postman-ssl/client.crt"',
   '          --ssl-client-key "$(Agent.TempDirectory)/postman-ssl/client.key")',
@@ -411,6 +451,7 @@ function buildAdoCiWorkflowLines(installUrl: string, postmanRegion: string): str
   '    env:',
   '      CI_ENVIRONMENT: $(CI_ENVIRONMENT)',
   '      POSTMAN_SSL_CLIENT_PASSPHRASE: $(POSTMAN_SSL_CLIENT_PASSPHRASE)',
+  ...(privateMockAuth ? ['      POSTMAN_API_KEY: $(POSTMAN_API_KEY)'] : []),
   ''
   ];
 }
@@ -480,9 +521,10 @@ export function getCiWorkflowTemplate(
       : String(options.postmanCliInstallUrl || '').trim() || DEFAULT_POSTMAN_CLI_INSTALL_URL;
     const postmanRegion = resolvePostmanRegion(options.postmanRegion);
     const installUrl = validateHttpsInstallUrl(rawUrl);
+    const privateMockAuth = options.privateMockAuth === true;
     return (runnerOs === 'windows'
-      ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion)
-      : buildAdoCiWorkflowLines(installUrl, postmanRegion)
+      ? buildAdoWindowsCiWorkflowLines(installUrl, postmanRegion, privateMockAuth)
+      : buildAdoCiWorkflowLines(installUrl, postmanRegion, privateMockAuth)
     ).join('\n');
   }
   return renderCiWorkflowTemplate(options);

--- a/src/lib/postman/postman-gateway-assets-client.ts
+++ b/src/lib/postman/postman-gateway-assets-client.ts
@@ -45,16 +45,43 @@ export function requirePublicMock(mock: MockRecord): MockRecord {
   return requireMockVisibility(mock, 'public');
 }
 
-const PRIVATE_MOCK_AUTH_MARKER = 'postman-enterprise-automation: private-mock-auth';
-const PRIVATE_MOCK_AUTH_VARIABLE = 'postmanPrivateMockApiKey';
+const PRIVATE_MOCK_AUTH_MARKER_PREFIX = 'postman-enterprise-automation: private-mock-auth';
+const PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+export const PRIVATE_MOCK_AUTH_VARIABLE = 'postmanPrivateMockApiKey';
 const PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
-  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
-  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
+  "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join('\n');
+
+/**
+ * Remove any previously installed generation of the managed private-mock block so an
+ * upgrade replaces it instead of stacking a second copy beneath it. Author-written
+ * lines around the block are preserved.
+ */
+function stripPrivateMockAuthBlocks(code: string): string {
+  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
+  const lines = code.split('\n');
+  const kept: string[] = [];
+  let skipping = false;
+  for (const line of lines) {
+    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) { skipping = true; continue; }
+    if (skipping) {
+      // The managed block is a contiguous run of var/if/} lines ending at its closing brace.
+      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
+      skipping = false;
+    }
+    kept.push(line);
+  }
+  return kept.join('\n').trim();
+}
 
 const MAX_CREATE_FLIGHTS = 256;
 interface CreateFlight {
@@ -773,8 +800,9 @@ export class PostmanGatewayAssetsClient {
         ? item.scripts.filter((entry): entry is JsonRecord => Boolean(this.asRecord(entry)))
         : [];
       const before = scripts.find((script) => String(script.type ?? '') === 'beforeRequest');
-      if (String(before?.code ?? '').includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [String(before?.code ?? '').trim(), PRIVATE_MOCK_AUTH_SCRIPT]
+      const existingCode = String(before?.code ?? '');
+      if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
+      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT]
         .filter(Boolean)
         .join('\n');
       const nextScripts = [

--- a/tests/ci-workflow-template.test.ts
+++ b/tests/ci-workflow-template.test.ts
@@ -415,3 +415,72 @@ describe('renderGcWorkflowTemplate', () => {
     expect(workflow).toContain('gc-summary-json');
   });
 });
+
+describe('private mock runtime credential wiring', () => {
+  const VARIABLE = 'postmanPrivateMockApiKey';
+
+  it('omits the private-mock variable from every generated workflow by default', () => {
+    const workflows = [
+      renderCiWorkflowTemplate(),
+      getCiWorkflowTemplate('azure-devops', {}),
+      getCiWorkflowTemplate('azure-devops', { runnerOs: 'windows' })
+    ];
+
+    for (const workflow of workflows) {
+      expect(workflow).not.toContain(VARIABLE);
+    }
+  });
+
+  it('forwards the CI Postman API key secret to both GitHub run steps for a private mock', () => {
+    const workflow = renderCiWorkflowTemplate({ privateMockAuth: true });
+    const injected = workflow.split('\n').filter((line) => line.includes(VARIABLE));
+
+    // Smoke and contract, and no more.
+    expect(injected).toHaveLength(2);
+    for (const line of injected) {
+      expect(line).toContain('--env-var');
+      expect(line).toContain('${{ secrets.POSTMAN_API_KEY }}');
+    }
+    expect(parse(workflow)).toBeTruthy();
+  });
+
+  it('maps the secret into the step environment for Azure DevOps bash runs', () => {
+    const workflow = getCiWorkflowTemplate('azure-devops', { privateMockAuth: true });
+    const injected = workflow.split('\n').filter((line) => line.includes(VARIABLE));
+
+    expect(injected).toHaveLength(2);
+    for (const line of injected) {
+      // ADO does not auto-map secret variables into the script environment, so the
+      // step must reference the shell variable it explicitly mapped.
+      expect(line).toContain('$POSTMAN_API_KEY');
+      expect(line).not.toContain('$(POSTMAN_API_KEY)');
+    }
+    const envMaps = workflow
+      .split('\n')
+      .filter((line) => line.trim() === 'POSTMAN_API_KEY: $(POSTMAN_API_KEY)');
+    // One per run step, plus the pre-existing login step.
+    expect(envMaps.length).toBeGreaterThanOrEqual(3);
+    expect(parse(workflow)).toBeTruthy();
+  });
+
+  it('appends the variable to the PowerShell argument array on the Windows agent', () => {
+    const workflow = getCiWorkflowTemplate('azure-devops', {
+      runnerOs: 'windows',
+      privateMockAuth: true
+    });
+    const injected = workflow.split('\n').filter((line) => line.includes(VARIABLE));
+
+    expect(injected).toHaveLength(2);
+    for (const line of injected) {
+      expect(line).toContain('$arguments += @(');
+      expect(line).toContain('$env:POSTMAN_API_KEY');
+    }
+    expect(parse(workflow)).toBeTruthy();
+  });
+
+  it('never writes a literal credential into a generated workflow', () => {
+    const workflow = renderCiWorkflowTemplate({ privateMockAuth: true });
+
+    expect(workflow).not.toContain('PMAK-');
+  });
+});

--- a/tests/postman-gateway-assets-client.test.ts
+++ b/tests/postman-gateway-assets-client.test.ts
@@ -175,8 +175,102 @@ describe('PostmanGatewayAssetsClient', () => {
     const serialized = JSON.stringify(patch?.body);
     expect(serialized).toContain('postmanPrivateMockApiKey');
     expect(serialized).toContain('x-api-key');
+    expect(serialized).toContain("join('.')");
+    expect(serialized).toContain('private-mock-auth-v2');
     expect(serialized).toContain('afterResponse');
     expect(serialized).not.toContain('pmak-');
+  });
+
+  it('replaces a stale private-mock hook generation instead of stacking a second copy', async () => {
+    const legacyMarker = 'postman-enterprise-automation: private-mock-auth';
+    const legacyBlock = [
+      `// ${legacyMarker}`,
+      "var privateMockApiKey = pm.variables.get('postmanPrivateMockApiKey');",
+      "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+      "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+      "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+      '}'
+    ].join('\n');
+    const authorLine = "pm.environment.set('callerOwned', true);";
+
+    const requestJson = vi.fn(async (request: { method?: string; path?: string; body?: unknown }) => {
+      if (request.method === 'get' && request.path?.endsWith('/items/')) {
+        return { data: [{ $kind: 'http-request', id: 'req-1' }] };
+      }
+      if (request.method === 'get') {
+        return {
+          data: {
+            id: 'req-1',
+            scripts: [
+              { type: 'beforeRequest', code: `${authorLine}\n${legacyBlock}`, language: 'text/javascript' }
+            ]
+          }
+        };
+      }
+      return { data: {} };
+    });
+    const assets = new PostmanGatewayAssetsClient({ gateway: { requestJson } as never, workspaceId: 'ws' });
+
+    await expect(assets.configurePrivateMockRuntimeAuth('owner-col-1')).resolves.toBe(1);
+
+    const patch = requestJson.mock.calls.find(([request]) => request.method === 'patch')?.[0];
+    const scripts = (patch?.body as Array<{ value: Array<{ type: string; code: string }> }>)[0].value;
+    const code = scripts.find((script) => script.type === 'beforeRequest')?.code ?? '';
+
+    // Exactly one managed block survives, and it is the current generation.
+    expect(code.split(legacyMarker).length - 1).toBe(1);
+    expect(code).toContain('private-mock-auth-v2');
+    // The caller's own script is never discarded.
+    expect(code).toContain(authorLine);
+    // The broken String(array) form must not survive the upgrade.
+    expect(code).not.toContain("String(pm.request.url && pm.request.url.getHost");
+  });
+
+  it('leaves the request untouched when the current hook generation is already installed', async () => {
+    const requestJson = vi.fn(async (request: { method?: string; path?: string; body?: unknown }) => {
+      if (request.method === 'get' && request.path?.endsWith('/items/')) {
+        return { data: [{ $kind: 'http-request', id: 'req-1' }] };
+      }
+      if (request.method === 'get') {
+        return {
+          data: {
+            id: 'req-1',
+            scripts: [
+              {
+                type: 'beforeRequest',
+                code: '// postman-enterprise-automation: private-mock-auth-v2\nvar privateMockApiKey = 1;',
+                language: 'text/javascript'
+              }
+            ]
+          }
+        };
+      }
+      return { data: {} };
+    });
+    const assets = new PostmanGatewayAssetsClient({ gateway: { requestJson } as never, workspaceId: 'ws' });
+
+    await expect(assets.configurePrivateMockRuntimeAuth('owner-col-1')).resolves.toBe(0);
+    expect(requestJson.mock.calls.some(([request]) => request.method === 'patch')).toBe(false);
+  });
+
+  it('warns instead of silently sending nothing when a private mock host has no key', async () => {
+    const requestJson = vi.fn(async (request: { method?: string; path?: string; body?: unknown }) => {
+      if (request.method === 'get' && request.path?.endsWith('/items/')) {
+        return { data: [{ $kind: 'http-request', id: 'req-1' }] };
+      }
+      if (request.method === 'get') return { data: { id: 'req-1', scripts: [] } };
+      return { data: {} };
+    });
+    const assets = new PostmanGatewayAssetsClient({ gateway: { requestJson } as never, workspaceId: 'ws' });
+
+    await assets.configurePrivateMockRuntimeAuth('owner-col-1');
+    const patch = requestJson.mock.calls.find(([request]) => request.method === 'patch')?.[0];
+    const code = JSON.stringify(patch?.body);
+
+    expect(code).toContain('console.warn');
+    expect(code).toContain('postmanPrivateMockApiKey');
+    // Host detection must survive getHost() returning an array of labels.
+    expect(code).toContain("join('.')");
   });
 
   it('createEnvironment returns the owner-prefixed public uid built from the import response', async () => {

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -3245,6 +3245,68 @@ describe('mock resolution paths', () => {
     expect(readFileSync('.postman/resources.yaml', 'utf8')).not.toContain('env-mock');
   });
 
+  it('carries an empty secret slot for the caller key when the mock is private', async () => {
+    const createEnvironment = vi.fn().mockImplementation((_workspaceId: string, name: string) =>
+      Promise.resolve(name.endsWith(' - Mock') ? 'env-mock' : 'env-prod')
+    );
+    const notice = vi.fn();
+    const postman = makePostman({
+      createEnvironment,
+      createMock: vi.fn().mockResolvedValue({
+        uid: 'mock-1',
+        url: 'https://mock-new.pstmn.io',
+        visibility: 'private'
+      }),
+      findMockByCollection: vi.fn().mockResolvedValue(null),
+      configurePrivateMockRuntimeAuth: vi.fn().mockResolvedValue(1)
+    });
+    const result = await runRepoSync(
+      createInputs({
+        environments: ['prod'],
+        generateCiWorkflow: false,
+        mockEnvironmentEnabled: true,
+        mockVisibility: 'private',
+        repoWriteMode: 'none'
+      }),
+      { ...makeDeps(postman, makeGithub()), core: { ...makeDeps(postman, makeGithub()).core, notice } }
+    );
+
+    const mockEnvCall = createEnvironment.mock.calls.find(([, name]) => name === 'core-payments - Mock');
+    const values = mockEnvCall?.[2] as Array<{ key: string; value: string; type: string }>;
+    const slot = values.find((value) => value.key === 'postmanPrivateMockApiKey');
+
+    // Named so the developer knows what to paste, secret-typed so the app masks it,
+    // and empty because repo-sync must never persist a credential.
+    expect(slot).toEqual({ key: 'postmanPrivateMockApiKey', value: '', type: 'secret' });
+    expect(result['mock-auth-required']).toBe('true');
+    expect(notice).toHaveBeenCalledWith(expect.stringContaining('postmanPrivateMockApiKey'));
+  });
+
+  it('omits the private-mock secret slot for a public mock', async () => {
+    const createEnvironment = vi.fn().mockImplementation((_workspaceId: string, name: string) =>
+      Promise.resolve(name.endsWith(' - Mock') ? 'env-mock' : 'env-prod')
+    );
+    const postman = makePostman({
+      createEnvironment,
+      findMockByCollection: vi.fn().mockResolvedValue(null)
+    });
+    const result = await runRepoSync(
+      createInputs({
+        environments: ['prod'],
+        generateCiWorkflow: false,
+        mockEnvironmentEnabled: true,
+        repoWriteMode: 'none'
+      }),
+      makeDeps(postman, makeGithub())
+    );
+
+    const mockEnvCall = createEnvironment.mock.calls.find(([, name]) => name === 'core-payments - Mock');
+    const values = mockEnvCall?.[2] as Array<{ key: string }>;
+
+    expect(values.some((value) => value.key === 'postmanPrivateMockApiKey')).toBe(false);
+    expect(result['mock-auth-required']).toBe('false');
+  });
+
   it('reuses an unchanged mock environment without mutating runtime selection', async () => {
     const updateEnvironment = vi.fn().mockResolvedValue(undefined);
     const postman = makePostman({


### PR DESCRIPTION
## Why

`v2.3.0` shipped private-mock support: a request hook on the smoke and contract collections that reads the `postmanPrivateMockApiKey` variable and sends it as `x-api-key` to `*.mock.pstmn.io` hosts only.

Nothing ever set that variable. Generated CI did not pass it, the manual-validation environment had no slot for it, and a missing key surfaced as a bare `401` with no indication of the cause. Private-mock support was reachable but not usable without the customer reverse-engineering the variable name from our source.

## Validation of the CI path

Whether CI could wire itself depended on whether the service-account key repo-sync already mints and stores as the `POSTMAN_API_KEY` secret is accepted by the mock serve path. Probed live against a real private mock:

```
PRIVATE MOCK: status=200 published=false
no auth        (control, expect 401): HTTP 401; invalidCredentialsError
owner PMAK     (control, expect 200): HTTP 200; {"ok":true}
MINTED CI KEY                       : HTTP 200; {"ok":true}
```

The minted key is accepted, so the generated workflow forwards the secret that already exists. Private-mock CI needs no new secret and no workflow edit. This matches the server-side policy, which requires an `apiKey`-method caller holding `VIEW_MOCK`.

## What changed

- **Generated CI** appends `--env-var "postmanPrivateMockApiKey=<secret>"` to both run steps when `mock-visibility: private`, across GitHub, Azure DevOps bash, and Azure DevOps Windows PowerShell. Azure DevOps does not auto-map secret variables into the script environment, so those steps also map `POSTMAN_API_KEY` explicitly.
- **Manual runs** get `postmanPrivateMockApiKey` as an empty, secret-typed variable in the `<project> - Mock` environment, matching the existing `AWS_ACCESS_KEY_ID` treatment. Named so it is discoverable, empty because repo-sync never persists a credential.
- **Feedback**: installing the hook emits a `notice` naming the variable and the collections touched; calling a private mock host with no key logs a console warning naming the variable.

## Upgrade defect fixed

The `-v2` marker introduced in #112 is a strict superset of the `-v1` marker, so `code.includes(MARKER)` did not match a v1 block and appended v2 beneath it, leaving both generations live in the customer's collection. Previously installed blocks are now stripped before the current one is appended, preserving author-written script around them. Covered by a test that fails against the old guard.

## Validation

`npm test` — 610 passing across 38 files, up from 599. `npx tsc --noEmit` and `npx eslint .` clean. `dist/` rebuilt from source. README tables regenerated.

New coverage: private-mock env-var injection per platform and its absence by default, YAML validity of every generated variant, absence of literal credentials, the environment slot present for private and absent for public, and the v1→v2 replacement path. The double-injection and environment-slot tests were mutation-checked — each fails when its fix is reverted.

## Compatibility

Public mocks are untouched: no hook, no environment slot, no CI flag, no notice. Every change is behind `mock-visibility: private`, which is not the default.