### PR TITLE
fix: execute private mock auth hooks for segmented hosts

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -136994,9 +136994,17 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
+var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "}"
+].join("\n");
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
@@ -137009,23 +137017,8 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
-function stripPrivateMockAuthBlocks(code) {
-  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
-  const lines = code.split("\n");
-  const kept = [];
-  let skipping = false;
-  for (const line of lines) {
-    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
-      skipping = true;
-      continue;
-    }
-    if (skipping) {
-      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
-      skipping = false;
-    }
-    kept.push(line);
-  }
-  return kept.join("\n").trim();
+function removeLegacyPrivateMockAuth(code) {
+  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
@@ -137626,7 +137619,7 @@ var PostmanGatewayAssetsClient = class {
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
       const existingCode = String(before?.code ?? "");
       if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const code = [removeLegacyPrivateMockAuth(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -135099,9 +135099,17 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
+var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "}"
+].join("\n");
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
@@ -135114,23 +135122,8 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
-function stripPrivateMockAuthBlocks(code) {
-  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
-  const lines = code.split("\n");
-  const kept = [];
-  let skipping = false;
-  for (const line of lines) {
-    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
-      skipping = true;
-      continue;
-    }
-    if (skipping) {
-      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
-      skipping = false;
-    }
-    kept.push(line);
-  }
-  return kept.join("\n").trim();
+function removeLegacyPrivateMockAuth(code) {
+  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
@@ -135731,7 +135724,7 @@ var PostmanGatewayAssetsClient = class {
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
       const existingCode = String(before?.code ?? "");
       if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const code = [removeLegacyPrivateMockAuth(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -137016,9 +137016,17 @@ function requireMockVisibility(mock, requested) {
   }
   return mock;
 }
-var PRIVATE_MOCK_AUTH_MARKER_PREFIX = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
+var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "}"
+].join("\n");
 var PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
@@ -137031,23 +137039,8 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
-function stripPrivateMockAuthBlocks(code) {
-  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
-  const lines = code.split("\n");
-  const kept = [];
-  let skipping = false;
-  for (const line of lines) {
-    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) {
-      skipping = true;
-      continue;
-    }
-    if (skipping) {
-      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
-      skipping = false;
-    }
-    kept.push(line);
-  }
-  return kept.join("\n").trim();
+function removeLegacyPrivateMockAuth(code) {
+  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();
@@ -137648,7 +137641,7 @@ var PostmanGatewayAssetsClient = class {
       const before = scripts.find((script) => String(script.type ?? "") === "beforeRequest");
       const existingCode = String(before?.code ?? "");
       if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
+      const code = [removeLegacyPrivateMockAuth(existingCode), PRIVATE_MOCK_AUTH_SCRIPT].filter(Boolean).join("\n");
       const nextScripts = [
         ...scripts.filter((script) => String(script.type ?? "") !== "beforeRequest"),
         { type: "beforeRequest", code, language: "text/javascript" }

--- a/src/lib/postman/postman-gateway-assets-client.ts
+++ b/src/lib/postman/postman-gateway-assets-client.ts
@@ -45,9 +45,17 @@ export function requirePublicMock(mock: MockRecord): MockRecord {
   return requireMockVisibility(mock, 'public');
 }
 
-const PRIVATE_MOCK_AUTH_MARKER_PREFIX = 'postman-enterprise-automation: private-mock-auth';
-const PRIVATE_MOCK_AUTH_MARKER = `${PRIVATE_MOCK_AUTH_MARKER_PREFIX}-v2`;
+const LEGACY_PRIVATE_MOCK_AUTH_MARKER = 'postman-enterprise-automation: private-mock-auth';
+const PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
 export const PRIVATE_MOCK_AUTH_VARIABLE = 'postmanPrivateMockApiKey';
+const LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
+  "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+  "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "}"
+].join('\n');
 const PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${PRIVATE_MOCK_AUTH_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
@@ -61,26 +69,8 @@ const PRIVATE_MOCK_AUTH_SCRIPT = [
   "}"
 ].join('\n');
 
-/**
- * Remove any previously installed generation of the managed private-mock block so an
- * upgrade replaces it instead of stacking a second copy beneath it. Author-written
- * lines around the block are preserved.
- */
-function stripPrivateMockAuthBlocks(code: string): string {
-  if (!code.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) return code.trim();
-  const lines = code.split('\n');
-  const kept: string[] = [];
-  let skipping = false;
-  for (const line of lines) {
-    if (line.includes(PRIVATE_MOCK_AUTH_MARKER_PREFIX)) { skipping = true; continue; }
-    if (skipping) {
-      // The managed block is a contiguous run of var/if/} lines ending at its closing brace.
-      if (/^\s*(?:(?:var|if)\s|\}\selse\sif\s|\}|pm\.request|console\.warn)/.test(line)) continue;
-      skipping = false;
-    }
-    kept.push(line);
-  }
-  return kept.join('\n').trim();
+function removeLegacyPrivateMockAuth(code: string): string {
+  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join('').trim();
 }
 
 const MAX_CREATE_FLIGHTS = 256;
@@ -802,7 +792,7 @@ export class PostmanGatewayAssetsClient {
       const before = scripts.find((script) => String(script.type ?? '') === 'beforeRequest');
       const existingCode = String(before?.code ?? '');
       if (existingCode.includes(PRIVATE_MOCK_AUTH_MARKER)) continue;
-      const code = [stripPrivateMockAuthBlocks(existingCode), PRIVATE_MOCK_AUTH_SCRIPT]
+      const code = [removeLegacyPrivateMockAuth(existingCode), PRIVATE_MOCK_AUTH_SCRIPT]
         .filter(Boolean)
         .join('\n');
       const nextScripts = [

--- a/tests/postman-gateway-assets-client.test.ts
+++ b/tests/postman-gateway-assets-client.test.ts
@@ -1,3 +1,5 @@
+import { runInNewContext } from 'node:vm';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { HttpError } from '../src/lib/http-error.js';
@@ -179,6 +181,35 @@ describe('PostmanGatewayAssetsClient', () => {
     expect(serialized).toContain('private-mock-auth-v2');
     expect(serialized).toContain('afterResponse');
     expect(serialized).not.toContain('pmak-');
+
+    const scripts = (patch?.body as Array<{ value: Array<{ type: string; code: string }> }>)[0].value;
+    const code = scripts.find((script) => script.type === 'beforeRequest')?.code ?? '';
+    const mockUpsert = vi.fn();
+    runInNewContext(code, {
+      pm: {
+        variables: { get: () => 'test-private-mock-key' },
+        request: {
+          url: { getHost: () => ['example', 'mock', 'pstmn', 'io'] },
+          headers: { upsert: mockUpsert }
+        }
+      }
+    });
+    expect(mockUpsert).toHaveBeenCalledWith({
+      key: 'x-api-key',
+      value: 'test-private-mock-key'
+    });
+
+    const apiUpsert = vi.fn();
+    runInNewContext(code, {
+      pm: {
+        variables: { get: () => 'test-private-mock-key' },
+        request: {
+          url: { getHost: () => ['api', 'getpostman', 'com'] },
+          headers: { upsert: apiUpsert }
+        }
+      }
+    });
+    expect(apiUpsert).not.toHaveBeenCalled();
   });
 
   it('replaces a stale private-mock hook generation instead of stacking a second copy', async () => {
@@ -191,7 +222,7 @@ describe('PostmanGatewayAssetsClient', () => {
       "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
       '}'
     ].join('\n');
-    const authorLine = "pm.environment.set('callerOwned', true);";
+    const authorLine = 'var callerOwned = true;';
 
     const requestJson = vi.fn(async (request: { method?: string; path?: string; body?: unknown }) => {
       if (request.method === 'get' && request.path?.endsWith('/items/')) {
@@ -202,7 +233,7 @@ describe('PostmanGatewayAssetsClient', () => {
           data: {
             id: 'req-1',
             scripts: [
-              { type: 'beforeRequest', code: `${authorLine}\n${legacyBlock}`, language: 'text/javascript' }
+              { type: 'beforeRequest', code: `${legacyBlock}\n${authorLine}`, language: 'text/javascript' }
             ]
           }
         };


### PR DESCRIPTION
## Summary

Private mock request hooks now normalize Postman's segmented host representation before applying the `*.mock.pstmn.io` safety guard. This lets runtime `x-api-key` injection work when `pm.request.url.getHost()` returns an array, while requests to non-mock Postman hosts remain untouched.

## What changed

- Join segmented host labels before matching the private mock domain.
- Replace the exact previously shipped hook block with the current generation without deleting caller-owned request script lines.
- Execute the generated hook in regression tests against both a private mock host and `api.getpostman.com`.
- Rebuild the committed action and CLI bundles.

## Validation

- `npm test` (609 Vitest tests and 7 dispatch monitor tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:dist:assert`
