### PR TITLE
fix: resolve templated private mock URLs before auth

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -136995,7 +136995,8 @@ function requireMockVisibility(mock, requested) {
   return mock;
 }
 var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_V2_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v3`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
@@ -137005,8 +137006,8 @@ var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
   "}"
 ].join("\n");
-var PRIVATE_MOCK_AUTH_SCRIPT = [
-  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+var PRIVATE_MOCK_AUTH_V2_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_V2_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
   "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
   "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
@@ -137017,8 +137018,25 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+var PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = '';",
+  "try {",
+  "  var privateMockUrl = pm.variables.replaceIn(pm.request.url.toString());",
+  "  privateMockHost = new URL(privateMockUrl).hostname;",
+  "} catch (error) {",
+  "  console.warn('Could not resolve the request URL for private mock authentication; x-api-key was not added.');",
+  "}",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
+  "}"
+].join("\n");
 function removeLegacyPrivateMockAuth(code) {
-  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
+  return [LEGACY_PRIVATE_MOCK_AUTH_SCRIPT, PRIVATE_MOCK_AUTH_V2_SCRIPT].reduce((next, script) => next.split(script).join(""), code).trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -135100,7 +135100,8 @@ function requireMockVisibility(mock, requested) {
   return mock;
 }
 var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_V2_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v3`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
@@ -135110,8 +135111,8 @@ var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
   "}"
 ].join("\n");
-var PRIVATE_MOCK_AUTH_SCRIPT = [
-  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+var PRIVATE_MOCK_AUTH_V2_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_V2_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
   "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
   "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
@@ -135122,8 +135123,25 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+var PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = '';",
+  "try {",
+  "  var privateMockUrl = pm.variables.replaceIn(pm.request.url.toString());",
+  "  privateMockHost = new URL(privateMockUrl).hostname;",
+  "} catch (error) {",
+  "  console.warn('Could not resolve the request URL for private mock authentication; x-api-key was not added.');",
+  "}",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
+  "}"
+].join("\n");
 function removeLegacyPrivateMockAuth(code) {
-  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
+  return [LEGACY_PRIVATE_MOCK_AUTH_SCRIPT, PRIVATE_MOCK_AUTH_V2_SCRIPT].reduce((next, script) => next.split(script).join(""), code).trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -137017,7 +137017,8 @@ function requireMockVisibility(mock, requested) {
   return mock;
 }
 var LEGACY_PRIVATE_MOCK_AUTH_MARKER = "postman-enterprise-automation: private-mock-auth";
-var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_V2_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+var PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v3`;
 var PRIVATE_MOCK_AUTH_VARIABLE2 = "postmanPrivateMockApiKey";
 var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
@@ -137027,8 +137028,8 @@ var LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
   "}"
 ].join("\n");
-var PRIVATE_MOCK_AUTH_SCRIPT = [
-  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+var PRIVATE_MOCK_AUTH_V2_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_V2_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
   "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
   "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
@@ -137039,8 +137040,25 @@ var PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join("\n");
+var PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE2}');`,
+  "var privateMockHost = '';",
+  "try {",
+  "  var privateMockUrl = pm.variables.replaceIn(pm.request.url.toString());",
+  "  privateMockHost = new URL(privateMockUrl).hostname;",
+  "} catch (error) {",
+  "  console.warn('Could not resolve the request URL for private mock authentication; x-api-key was not added.');",
+  "}",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE2} variable to a Postman API key with access to it, or the request returns 401.');`,
+  "}"
+].join("\n");
 function removeLegacyPrivateMockAuth(code) {
-  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join("").trim();
+  return [LEGACY_PRIVATE_MOCK_AUTH_SCRIPT, PRIVATE_MOCK_AUTH_V2_SCRIPT].reduce((next, script) => next.split(script).join(""), code).trim();
 }
 var MAX_CREATE_FLIGHTS = 256;
 var createFlights = /* @__PURE__ */ new Map();

--- a/src/lib/postman/postman-gateway-assets-client.ts
+++ b/src/lib/postman/postman-gateway-assets-client.ts
@@ -46,7 +46,8 @@ export function requirePublicMock(mock: MockRecord): MockRecord {
 }
 
 const LEGACY_PRIVATE_MOCK_AUTH_MARKER = 'postman-enterprise-automation: private-mock-auth';
-const PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+const PRIVATE_MOCK_AUTH_V2_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v2`;
+const PRIVATE_MOCK_AUTH_MARKER = `${LEGACY_PRIVATE_MOCK_AUTH_MARKER}-v3`;
 export const PRIVATE_MOCK_AUTH_VARIABLE = 'postmanPrivateMockApiKey';
 const LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   `// ${LEGACY_PRIVATE_MOCK_AUTH_MARKER}`,
@@ -56,8 +57,8 @@ const LEGACY_PRIVATE_MOCK_AUTH_SCRIPT = [
   "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
   "}"
 ].join('\n');
-const PRIVATE_MOCK_AUTH_SCRIPT = [
-  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+const PRIVATE_MOCK_AUTH_V2_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_V2_MARKER}`,
   `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
   "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
   "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
@@ -68,9 +69,28 @@ const PRIVATE_MOCK_AUTH_SCRIPT = [
   `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE} variable to a Postman API key with access to it, or the request returns 401.');`,
   "}"
 ].join('\n');
+const PRIVATE_MOCK_AUTH_SCRIPT = [
+  `// ${PRIVATE_MOCK_AUTH_MARKER}`,
+  `var privateMockApiKey = pm.variables.get('${PRIVATE_MOCK_AUTH_VARIABLE}');`,
+  "var privateMockHost = '';",
+  "try {",
+  "  var privateMockUrl = pm.variables.replaceIn(pm.request.url.toString());",
+  "  privateMockHost = new URL(privateMockUrl).hostname;",
+  "} catch (error) {",
+  "  console.warn('Could not resolve the request URL for private mock authentication; x-api-key was not added.');",
+  "}",
+  "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+  "if (isPrivateMockHost && privateMockApiKey) {",
+  "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+  "} else if (isPrivateMockHost) {",
+  `  console.warn('This mock server is private. Set the ${PRIVATE_MOCK_AUTH_VARIABLE} variable to a Postman API key with access to it, or the request returns 401.');`,
+  "}"
+].join('\n');
 
 function removeLegacyPrivateMockAuth(code: string): string {
-  return code.split(LEGACY_PRIVATE_MOCK_AUTH_SCRIPT).join('').trim();
+  return [LEGACY_PRIVATE_MOCK_AUTH_SCRIPT, PRIVATE_MOCK_AUTH_V2_SCRIPT]
+    .reduce((next, script) => next.split(script).join(''), code)
+    .trim();
 }
 
 const MAX_CREATE_FLIGHTS = 256;

--- a/tests/postman-gateway-assets-client.test.ts
+++ b/tests/postman-gateway-assets-client.test.ts
@@ -177,8 +177,8 @@ describe('PostmanGatewayAssetsClient', () => {
     const serialized = JSON.stringify(patch?.body);
     expect(serialized).toContain('postmanPrivateMockApiKey');
     expect(serialized).toContain('x-api-key');
-    expect(serialized).toContain("join('.')");
-    expect(serialized).toContain('private-mock-auth-v2');
+    expect(serialized).toContain('replaceIn');
+    expect(serialized).toContain('private-mock-auth-v3');
     expect(serialized).toContain('afterResponse');
     expect(serialized).not.toContain('pmak-');
 
@@ -186,10 +186,17 @@ describe('PostmanGatewayAssetsClient', () => {
     const code = scripts.find((script) => script.type === 'beforeRequest')?.code ?? '';
     const mockUpsert = vi.fn();
     runInNewContext(code, {
+      URL,
       pm: {
-        variables: { get: () => 'test-private-mock-key' },
+        variables: {
+          get: () => 'test-private-mock-key',
+          replaceIn: (value: string) => value.replace('{{baseUrl}}', 'https://example.mock.pstmn.io')
+        },
         request: {
-          url: { getHost: () => ['example', 'mock', 'pstmn', 'io'] },
+          url: {
+            getHost: () => ['{{baseUrl}}'],
+            toString: () => '{{baseUrl}}/orders'
+          },
           headers: { upsert: mockUpsert }
         }
       }
@@ -201,10 +208,17 @@ describe('PostmanGatewayAssetsClient', () => {
 
     const apiUpsert = vi.fn();
     runInNewContext(code, {
+      URL,
       pm: {
-        variables: { get: () => 'test-private-mock-key' },
+        variables: {
+          get: () => 'test-private-mock-key',
+          replaceIn: (value: string) => value.replace('{{baseUrl}}', 'https://api.getpostman.com')
+        },
         request: {
-          url: { getHost: () => ['api', 'getpostman', 'com'] },
+          url: {
+            getHost: () => ['{{baseUrl}}'],
+            toString: () => '{{baseUrl}}/collections'
+          },
           headers: { upsert: apiUpsert }
         }
       }
@@ -212,16 +226,35 @@ describe('PostmanGatewayAssetsClient', () => {
     expect(apiUpsert).not.toHaveBeenCalled();
   });
 
-  it('replaces a stale private-mock hook generation instead of stacking a second copy', async () => {
+  it.each([
+    [
+      'v1',
+      [
+        '// postman-enterprise-automation: private-mock-auth',
+        "var privateMockApiKey = pm.variables.get('postmanPrivateMockApiKey');",
+        "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
+        "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
+        "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+        '}'
+      ].join('\n')
+    ],
+    [
+      'v2',
+      [
+        '// postman-enterprise-automation: private-mock-auth-v2',
+        "var privateMockApiKey = pm.variables.get('postmanPrivateMockApiKey');",
+        "var privateMockHostValue = pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '';",
+        "var privateMockHost = Array.isArray(privateMockHostValue) ? privateMockHostValue.join('.') : String(privateMockHostValue);",
+        "var isPrivateMockHost = /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost);",
+        'if (isPrivateMockHost && privateMockApiKey) {',
+        "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
+        '} else if (isPrivateMockHost) {',
+        "  console.warn('This mock server is private. Set the postmanPrivateMockApiKey variable to a Postman API key with access to it, or the request returns 401.');",
+        '}'
+      ].join('\n')
+    ]
+  ])('replaces a stale %s private-mock hook instead of stacking a second copy', async (_version, legacyBlock) => {
     const legacyMarker = 'postman-enterprise-automation: private-mock-auth';
-    const legacyBlock = [
-      `// ${legacyMarker}`,
-      "var privateMockApiKey = pm.variables.get('postmanPrivateMockApiKey');",
-      "var privateMockHost = String(pm.request.url && pm.request.url.getHost ? pm.request.url.getHost() : '');",
-      "if (privateMockApiKey && /(^|\\.)mock\\.pstmn\\.io$/i.test(privateMockHost)) {",
-      "  pm.request.headers.upsert({ key: 'x-api-key', value: privateMockApiKey });",
-      '}'
-    ].join('\n');
     const authorLine = 'var callerOwned = true;';
 
     const requestJson = vi.fn(async (request: { method?: string; path?: string; body?: unknown }) => {
@@ -250,7 +283,7 @@ describe('PostmanGatewayAssetsClient', () => {
 
     // Exactly one managed block survives, and it is the current generation.
     expect(code.split(legacyMarker).length - 1).toBe(1);
-    expect(code).toContain('private-mock-auth-v2');
+    expect(code).toContain('private-mock-auth-v3');
     // The caller's own script is never discarded.
     expect(code).toContain(authorLine);
     // The broken String(array) form must not survive the upgrade.
@@ -269,7 +302,7 @@ describe('PostmanGatewayAssetsClient', () => {
             scripts: [
               {
                 type: 'beforeRequest',
-                code: '// postman-enterprise-automation: private-mock-auth-v2\nvar privateMockApiKey = 1;',
+                code: '// postman-enterprise-automation: private-mock-auth-v3\nvar privateMockApiKey = 1;',
                 language: 'text/javascript'
               }
             ]
@@ -300,8 +333,7 @@ describe('PostmanGatewayAssetsClient', () => {
 
     expect(code).toContain('console.warn');
     expect(code).toContain('postmanPrivateMockApiKey');
-    // Host detection must survive getHost() returning an array of labels.
-    expect(code).toContain("join('.')");
+    expect(code).toContain('replaceIn');
   });
 
   it('createEnvironment returns the owner-prefixed public uid built from the import response', async () => {


### PR DESCRIPTION
## Summary

Private mock request hooks now resolve templated request URLs before checking the destination hostname. Collections that use `{{baseUrl}}` can inject their runtime PMAK into `x-api-key`, while the strict `*.mock.pstmn.io` boundary still prevents that key from reaching non-mock hosts.

## What changed

- Resolve the full request URL with `pm.variables.replaceIn(...)` before extracting its hostname.
- Fail closed when the URL can't be resolved.
- Upgrade both previously shipped managed hook generations to v3 without deleting caller-owned request scripts.
- Execute regression coverage against an unresolved `{{baseUrl}}`, a private mock destination, and a non-mock Postman API destination.
- Rebuild the committed action and CLI bundles.

## Validation

- `npm test` (610 Vitest tests and 7 dispatch monitor tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:dist:assert`
- Disposable private-mock probe: unresolved hook returned `401`; resolved v3 candidate returned `200` both from a local collection and a cloud collection UID; non-mock control sent no `x-api-key` header
