### PR TITLE
perf(repo-sync): bound artifact acquisition reads

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -140555,6 +140555,10 @@ var PREBUILT_COLLECTION_ROLES = /* @__PURE__ */ new Set([
 ]);
 var SHA256_HEX = /^[a-f0-9]{64}$/;
 var PREBUILT_CLOUD_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+var PREBUILT_COLLECTION_MAX_DEPTH = 128;
+var PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES = LOCAL_SPEC_DISCOVERY_MAX_TRAVERSAL_ENTRIES;
+var PREBUILT_COLLECTION_MAX_FILE_BYTES = 32 * 1024 * 1024;
+var PREBUILT_COLLECTION_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
 function failPrebuiltCollections(detail) {
   throw new Error(`CONTRACT_PREBUILT_COLLECTIONS_INVALID: ${detail}`);
 }
@@ -140666,8 +140670,9 @@ function assertPathWithinArtifactRoot(targetPath, artifactDir, fieldName) {
     existingPath = parent;
   }
   const realExisting = (0, import_node_fs5.realpathSync)(existingPath);
-  const realRelative = path8.relative(artifactRoot, realExisting);
-  if (realRelative.startsWith("..") || path8.isAbsolute(realRelative)) {
+  const realArtifactRoot = (0, import_node_fs5.existsSync)(artifactRoot) ? (0, import_node_fs5.realpathSync)(artifactRoot) : void 0;
+  const realRelative = realArtifactRoot ? path8.relative(realArtifactRoot, realExisting) : "";
+  if (realArtifactRoot && (realRelative.startsWith("..") || path8.isAbsolute(realRelative))) {
     failPrebuiltCollections(
       `${fieldName} resolves outside artifact-dir via symlink; received ${targetPath}`
     );
@@ -140709,13 +140714,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
     return [];
   }
   const files = [];
-  const pendingDirectories = [absRoot];
+  const pendingDirectories = [{ absolute: absRoot, depth: 0 }];
   const seenDirectories = /* @__PURE__ */ new Set();
+  let traversalEntries = 1;
+  let totalBytes = 0;
   while (pendingDirectories.length > 0) {
-    const currentAbsolute = pendingDirectories.pop();
-    if (!currentAbsolute) {
+    const current = pendingDirectories.pop();
+    if (!current) {
       break;
     }
+    const { absolute: currentAbsolute, depth: currentDepth } = current;
     const currentStat = (0, import_node_fs5.lstatSync)(currentAbsolute);
     if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
       failPrebuiltCollections(
@@ -140729,8 +140737,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       );
     }
     seenDirectories.add(currentKey);
-    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true });
+    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name)
+    );
     for (const entry of entries) {
+      traversalEntries += 1;
+      if (traversalEntries > PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES} traversal-entry budget`
+        );
+      }
       const abs = path8.join(currentAbsolute, entry.name);
       if (entry.isSymbolicLink()) {
         failPrebuiltCollections(
@@ -140738,7 +140754,13 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
         );
       }
       if (entry.isDirectory()) {
-        pendingDirectories.push(abs);
+        const nextDepth = currentDepth + 1;
+        if (nextDepth > PREBUILT_COLLECTION_MAX_DEPTH) {
+          failPrebuiltCollections(
+            `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_DEPTH} directory-depth budget`
+          );
+        }
+        pendingDirectories.push({ absolute: abs, depth: nextDepth });
         continue;
       }
       if (!entry.isFile()) {
@@ -140750,6 +140772,17 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       if (fileLstat.isSymbolicLink() || !fileLstat.isFile()) {
         failPrebuiltCollections(
           `prebuilt collection tree file changed or became unsupported at ${normalizeToPosix(path8.relative(absRoot, abs))}`
+        );
+      }
+      if (fileLstat.size > PREBUILT_COLLECTION_MAX_FILE_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree file ${normalizeToPosix(path8.relative(absRoot, abs))} exceeds the ${PREBUILT_COLLECTION_MAX_FILE_BYTES / (1024 * 1024)} MiB individual-file budget`
+        );
+      }
+      totalBytes += fileLstat.size;
+      if (totalBytes > PREBUILT_COLLECTION_MAX_TOTAL_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TOTAL_BYTES / (1024 * 1024)} MiB total-byte budget`
         );
       }
       files.push({
@@ -140886,63 +140919,69 @@ async function preparePrivateMockCloudCollection(role, collectionId, postman) {
   }
   return collection;
 }
+var ARTIFACT_ACQUISITION_WIDTH = 2;
+async function runBoundedInOrder(items, width, worker) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const failures = /* @__PURE__ */ new Map();
+  const runWorker = async () => {
+    while (failures.size === 0 && nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await worker(items[index], index);
+      } catch (error2) {
+        failures.set(index, error2);
+        return;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(width, items.length) }, () => runWorker()));
+  const failedIndex = Math.min(...failures.keys());
+  if (Number.isFinite(failedIndex)) {
+    throw failures.get(failedIndex);
+  }
+  return results;
+}
+async function acquireCollectionArtifact(options) {
+  const { role, collectionId, dirName, collectionsDir, prebuiltByRole, postman, core, privateMockAuth = false } = options;
+  const expectedPath = `${collectionsDir}/${dirName}`;
+  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
+  const entry = prebuiltByRole.get(role);
+  if (entry && !forceCloudExport && tryReusePrebuiltCollection({
+    prepared: entry,
+    expectedPath,
+    expectedCloudId: collectionId
+  })) {
+    core.info(`Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`);
+    return { reusePrebuilt: true };
+  }
+  if (entry) {
+    core.info(forceCloudExport ? `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud` : `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`);
+  }
+  const cloud = forceCloudExport ? await preparePrivateMockCloudCollection(role, collectionId, postman) : await postman.getCollection(collectionId);
+  return { reusePrebuilt: false, cloudCollection: cloud };
+}
 async function exportCollectionArtifact(options) {
   const {
-    role,
     collectionId,
     dirName,
     collectionsDir,
-    prebuiltByRole,
-    postman,
-    core,
-    privateMockAuth = false,
-    preparedCloudCollection
+    artifactDir,
+    acquisition
   } = options;
   if (!collectionId) {
     return void 0;
   }
   const expectedPath = `${collectionsDir}/${dirName}`;
-  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
-  const entry = prebuiltByRole.get(role);
-  if (entry && !forceCloudExport) {
-    const reused = tryReusePrebuiltCollection({
-      prepared: entry,
-      expectedPath,
-      expectedCloudId: collectionId
-    });
-    if (reused) {
-      core.info(
-        `Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`
-      );
-      return `../${expectedPath}`;
-    }
-    core.info(
-      `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`
-    );
-  } else if (entry && forceCloudExport) {
-    core.info(
-      `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud`
-    );
+  if (acquisition.reusePrebuilt) {
+    return `../${expectedPath}`;
   }
-  let collectionForExport;
-  if (forceCloudExport && preparedCloudCollection) {
-    collectionForExport = preparedCloudCollection;
-  } else if (forceCloudExport) {
-    const col = await postman.getCollection(collectionId);
-    const { collection } = applyPrivateMockExportCleanup(col, {
-      stripManagedBlocks: isPrivateMockLegacyExportCleanupEnabled()
-    });
-    if (!verifyPrivateMockRootHook(collection)) {
-      throw new Error(
-        `PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED: Managed root hook missing from exported ${role} collection ${collectionId}`
-      );
-    }
-    collectionForExport = collection;
-  } else {
-    const col = await postman.getCollection(collectionId);
-    collectionForExport = col;
-  }
-  await convertAndSplitAnyCollection(collectionForExport, expectedPath);
+  assertPathWithinArtifactRoot(expectedPath, artifactDir, "collection target");
+  await convertAndSplitAnyCollection(
+    acquisition.cloudCollection,
+    expectedPath
+  );
   return `../${expectedPath}`;
 }
 function hasControlCharacter2(value) {
@@ -141007,65 +141046,45 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   ) : void 0;
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
-  const preparedPrivateMockCollections = /* @__PURE__ */ new Map();
-  if (privateMockAuth) {
-    for (const spec of [
-      { role: "smoke", collectionId: inputs.smokeCollectionId },
-      { role: "contract", collectionId: inputs.contractCollectionId }
-    ]) {
-      if (!spec.collectionId) {
-        continue;
-      }
-      preparedPrivateMockCollections.set(
-        spec.role,
-        await preparePrivateMockCloudCollection(
-          spec.role,
-          spec.collectionId,
-          dependencies.postman
-        )
-      );
+  const collectionSpecs = [
+    { role: "baseline", collectionId: inputs.baselineCollectionId, dirName: getCollectionDirectoryName("Baseline", assetProjectName) },
+    { role: "smoke", collectionId: inputs.smokeCollectionId, dirName: getCollectionDirectoryName("Smoke", assetProjectName) },
+    { role: "contract", collectionId: inputs.contractCollectionId, dirName: getCollectionDirectoryName("Contract", assetProjectName) }
+  ].filter((spec) => Boolean(spec.collectionId));
+  const collectionStartedAt = Date.now();
+  let collectionStatus = "success";
+  let acquisitions;
+  try {
+    acquisitions = await runBoundedInOrder(
+      collectionSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => acquireCollectionArtifact({
+        ...spec,
+        collectionsDir,
+        prebuiltByRole,
+        postman: dependencies.postman,
+        core: dependencies.core,
+        privateMockAuth
+      })
+    );
+  } catch (error2) {
+    collectionStatus = "failed";
+    throw error2;
+  } finally {
+    dependencies.core.info(
+      `collection-acquisition count=${collectionSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - collectionStartedAt} status=${collectionStatus}`
+    );
+  }
+  for (const [index, spec] of collectionSpecs.entries()) {
+    const ref = await exportCollectionArtifact({
+      ...spec,
+      collectionsDir,
+      artifactDir: inputs.artifactDir,
+      acquisition: acquisitions[index]
+    });
+    if (ref) {
+      manifestCollections[ref] = spec.collectionId;
     }
-  }
-  const baselineRef = await exportCollectionArtifact({
-    role: "baseline",
-    collectionId: inputs.baselineCollectionId,
-    dirName: getCollectionDirectoryName("Baseline", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth
-  });
-  if (baselineRef) {
-    manifestCollections[baselineRef] = inputs.baselineCollectionId;
-  }
-  const smokeRef = await exportCollectionArtifact({
-    role: "smoke",
-    collectionId: inputs.smokeCollectionId,
-    dirName: getCollectionDirectoryName("Smoke", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("smoke")
-  });
-  if (smokeRef) {
-    manifestCollections[smokeRef] = inputs.smokeCollectionId;
-  }
-  const contractRef = await exportCollectionArtifact({
-    role: "contract",
-    collectionId: inputs.contractCollectionId,
-    dirName: getCollectionDirectoryName("Contract", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("contract")
-  });
-  if (contractRef) {
-    manifestCollections[contractRef] = inputs.contractCollectionId;
   }
   ensureDir(collectionsDir);
   ensureDir(environmentsDir);
@@ -141084,17 +141103,40 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       ensureDir(ciDir);
     }
   }
-  for (const [envName, envUid] of Object.entries(envUids)) {
-    writeJsonFile(
-      `${environmentsDir}/${envName}.postman_environment.json`,
-      await dependencies.postman.getEnvironment(envUid),
-      true
+  const environmentSpecs = [
+    ...Object.entries(envUids).map(([envName, envUid]) => ({
+      envName,
+      envUid,
+      filePath: `${environmentsDir}/${envName}.postman_environment.json`
+    })),
+    ...options.mockEnvironmentUid ? [{
+      envName: "manual-validation",
+      envUid: options.mockEnvironmentUid,
+      filePath: `${mocksDir}/manual-validation.postman_environment.json`
+    }] : []
+  ];
+  const environmentStartedAt = Date.now();
+  let environmentStatus = "success";
+  let environmentPayloads;
+  try {
+    environmentPayloads = await runBoundedInOrder(
+      environmentSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => dependencies.postman.getEnvironment(spec.envUid)
+    );
+  } catch (error2) {
+    environmentStatus = "failed";
+    throw error2;
+  } finally {
+    dependencies.core.info(
+      `environment-artifact-acquisition count=${environmentSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - environmentStartedAt} status=${environmentStatus}`
     );
   }
-  if (options.mockEnvironmentUid) {
+  for (const [index, spec] of environmentSpecs.entries()) {
+    assertPathWithinCwd(spec.filePath, "environment target");
     writeJsonFile(
-      `${mocksDir}/manual-validation.postman_environment.json`,
-      await dependencies.postman.getEnvironment(options.mockEnvironmentUid),
+      spec.filePath,
+      environmentPayloads[index],
       true
     );
   }
@@ -141104,6 +141146,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
     manifestCollections,
@@ -141122,6 +141165,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     } catch {
       existingWorkflows = void 0;
     }
+    assertPathWithinCwd(".postman/workflows.yaml", "workflows state target");
     (0, import_node_fs5.writeFileSync)(
       ".postman/workflows.yaml",
       buildSpecCollectionWorkflowManifest(
@@ -141171,18 +141215,19 @@ function createRepoSummary(outputs, envUids, pushed) {
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
   if (inputs.generateCiWorkflow) {
-    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const ciWorkflow = renderCiWorkflow(inputs);
     const parts = inputs.ciWorkflowPath.split("/");
     if (parts.length > 1) {
       const dir = parts.slice(0, -1).join("/");
       ensureDir(dir);
     }
+    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     (0, import_node_fs5.writeFileSync)(inputs.ciWorkflowPath, ciWorkflow);
     if (inputs.provider === "github" || inputs.provider === "unknown") {
       const gcPath = ".github/workflows/postman-preview-gc.yml";
       if (inputs.ciWorkflowPath.endsWith(".github/workflows/ci.yml") || inputs.ciWorkflowPath === ".github/workflows/ci.yml") {
         ensureDir(".github/workflows");
+        assertPathWithinCwd(gcPath, "preview GC workflow path");
         (0, import_node_fs5.writeFileSync)(gcPath, renderGcWorkflowTemplate());
       }
     }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -138463,6 +138463,10 @@ var PREBUILT_COLLECTION_ROLES = /* @__PURE__ */ new Set([
 ]);
 var SHA256_HEX = /^[a-f0-9]{64}$/;
 var PREBUILT_CLOUD_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+var PREBUILT_COLLECTION_MAX_DEPTH = 128;
+var PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES = LOCAL_SPEC_DISCOVERY_MAX_TRAVERSAL_ENTRIES;
+var PREBUILT_COLLECTION_MAX_FILE_BYTES = 32 * 1024 * 1024;
+var PREBUILT_COLLECTION_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
 function failPrebuiltCollections(detail) {
   throw new Error(`CONTRACT_PREBUILT_COLLECTIONS_INVALID: ${detail}`);
 }
@@ -138574,8 +138578,9 @@ function assertPathWithinArtifactRoot(targetPath, artifactDir, fieldName) {
     existingPath = parent;
   }
   const realExisting = (0, import_node_fs5.realpathSync)(existingPath);
-  const realRelative = path3.relative(artifactRoot, realExisting);
-  if (realRelative.startsWith("..") || path3.isAbsolute(realRelative)) {
+  const realArtifactRoot = (0, import_node_fs5.existsSync)(artifactRoot) ? (0, import_node_fs5.realpathSync)(artifactRoot) : void 0;
+  const realRelative = realArtifactRoot ? path3.relative(realArtifactRoot, realExisting) : "";
+  if (realArtifactRoot && (realRelative.startsWith("..") || path3.isAbsolute(realRelative))) {
     failPrebuiltCollections(
       `${fieldName} resolves outside artifact-dir via symlink; received ${targetPath}`
     );
@@ -138617,13 +138622,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
     return [];
   }
   const files = [];
-  const pendingDirectories = [absRoot];
+  const pendingDirectories = [{ absolute: absRoot, depth: 0 }];
   const seenDirectories = /* @__PURE__ */ new Set();
+  let traversalEntries = 1;
+  let totalBytes = 0;
   while (pendingDirectories.length > 0) {
-    const currentAbsolute = pendingDirectories.pop();
-    if (!currentAbsolute) {
+    const current = pendingDirectories.pop();
+    if (!current) {
       break;
     }
+    const { absolute: currentAbsolute, depth: currentDepth } = current;
     const currentStat = (0, import_node_fs5.lstatSync)(currentAbsolute);
     if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
       failPrebuiltCollections(
@@ -138637,8 +138645,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       );
     }
     seenDirectories.add(currentKey);
-    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true });
+    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name)
+    );
     for (const entry of entries) {
+      traversalEntries += 1;
+      if (traversalEntries > PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES} traversal-entry budget`
+        );
+      }
       const abs = path3.join(currentAbsolute, entry.name);
       if (entry.isSymbolicLink()) {
         failPrebuiltCollections(
@@ -138646,7 +138662,13 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
         );
       }
       if (entry.isDirectory()) {
-        pendingDirectories.push(abs);
+        const nextDepth = currentDepth + 1;
+        if (nextDepth > PREBUILT_COLLECTION_MAX_DEPTH) {
+          failPrebuiltCollections(
+            `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_DEPTH} directory-depth budget`
+          );
+        }
+        pendingDirectories.push({ absolute: abs, depth: nextDepth });
         continue;
       }
       if (!entry.isFile()) {
@@ -138658,6 +138680,17 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       if (fileLstat.isSymbolicLink() || !fileLstat.isFile()) {
         failPrebuiltCollections(
           `prebuilt collection tree file changed or became unsupported at ${normalizeToPosix(path3.relative(absRoot, abs))}`
+        );
+      }
+      if (fileLstat.size > PREBUILT_COLLECTION_MAX_FILE_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree file ${normalizeToPosix(path3.relative(absRoot, abs))} exceeds the ${PREBUILT_COLLECTION_MAX_FILE_BYTES / (1024 * 1024)} MiB individual-file budget`
+        );
+      }
+      totalBytes += fileLstat.size;
+      if (totalBytes > PREBUILT_COLLECTION_MAX_TOTAL_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TOTAL_BYTES / (1024 * 1024)} MiB total-byte budget`
         );
       }
       files.push({
@@ -138794,63 +138827,69 @@ async function preparePrivateMockCloudCollection(role, collectionId, postman) {
   }
   return collection;
 }
+var ARTIFACT_ACQUISITION_WIDTH = 2;
+async function runBoundedInOrder(items, width, worker) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const failures = /* @__PURE__ */ new Map();
+  const runWorker = async () => {
+    while (failures.size === 0 && nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await worker(items[index], index);
+      } catch (error) {
+        failures.set(index, error);
+        return;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(width, items.length) }, () => runWorker()));
+  const failedIndex = Math.min(...failures.keys());
+  if (Number.isFinite(failedIndex)) {
+    throw failures.get(failedIndex);
+  }
+  return results;
+}
+async function acquireCollectionArtifact(options) {
+  const { role, collectionId, dirName, collectionsDir, prebuiltByRole, postman, core, privateMockAuth = false } = options;
+  const expectedPath = `${collectionsDir}/${dirName}`;
+  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
+  const entry = prebuiltByRole.get(role);
+  if (entry && !forceCloudExport && tryReusePrebuiltCollection({
+    prepared: entry,
+    expectedPath,
+    expectedCloudId: collectionId
+  })) {
+    core.info(`Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`);
+    return { reusePrebuilt: true };
+  }
+  if (entry) {
+    core.info(forceCloudExport ? `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud` : `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`);
+  }
+  const cloud = forceCloudExport ? await preparePrivateMockCloudCollection(role, collectionId, postman) : await postman.getCollection(collectionId);
+  return { reusePrebuilt: false, cloudCollection: cloud };
+}
 async function exportCollectionArtifact(options) {
   const {
-    role,
     collectionId,
     dirName,
     collectionsDir,
-    prebuiltByRole,
-    postman,
-    core,
-    privateMockAuth = false,
-    preparedCloudCollection
+    artifactDir,
+    acquisition
   } = options;
   if (!collectionId) {
     return void 0;
   }
   const expectedPath = `${collectionsDir}/${dirName}`;
-  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
-  const entry = prebuiltByRole.get(role);
-  if (entry && !forceCloudExport) {
-    const reused = tryReusePrebuiltCollection({
-      prepared: entry,
-      expectedPath,
-      expectedCloudId: collectionId
-    });
-    if (reused) {
-      core.info(
-        `Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`
-      );
-      return `../${expectedPath}`;
-    }
-    core.info(
-      `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`
-    );
-  } else if (entry && forceCloudExport) {
-    core.info(
-      `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud`
-    );
+  if (acquisition.reusePrebuilt) {
+    return `../${expectedPath}`;
   }
-  let collectionForExport;
-  if (forceCloudExport && preparedCloudCollection) {
-    collectionForExport = preparedCloudCollection;
-  } else if (forceCloudExport) {
-    const col = await postman.getCollection(collectionId);
-    const { collection } = applyPrivateMockExportCleanup(col, {
-      stripManagedBlocks: isPrivateMockLegacyExportCleanupEnabled()
-    });
-    if (!verifyPrivateMockRootHook(collection)) {
-      throw new Error(
-        `PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED: Managed root hook missing from exported ${role} collection ${collectionId}`
-      );
-    }
-    collectionForExport = collection;
-  } else {
-    const col = await postman.getCollection(collectionId);
-    collectionForExport = col;
-  }
-  await convertAndSplitAnyCollection(collectionForExport, expectedPath);
+  assertPathWithinArtifactRoot(expectedPath, artifactDir, "collection target");
+  await convertAndSplitAnyCollection(
+    acquisition.cloudCollection,
+    expectedPath
+  );
   return `../${expectedPath}`;
 }
 function hasControlCharacter2(value) {
@@ -138915,65 +138954,45 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   ) : void 0;
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
-  const preparedPrivateMockCollections = /* @__PURE__ */ new Map();
-  if (privateMockAuth) {
-    for (const spec of [
-      { role: "smoke", collectionId: inputs.smokeCollectionId },
-      { role: "contract", collectionId: inputs.contractCollectionId }
-    ]) {
-      if (!spec.collectionId) {
-        continue;
-      }
-      preparedPrivateMockCollections.set(
-        spec.role,
-        await preparePrivateMockCloudCollection(
-          spec.role,
-          spec.collectionId,
-          dependencies.postman
-        )
-      );
+  const collectionSpecs = [
+    { role: "baseline", collectionId: inputs.baselineCollectionId, dirName: getCollectionDirectoryName("Baseline", assetProjectName) },
+    { role: "smoke", collectionId: inputs.smokeCollectionId, dirName: getCollectionDirectoryName("Smoke", assetProjectName) },
+    { role: "contract", collectionId: inputs.contractCollectionId, dirName: getCollectionDirectoryName("Contract", assetProjectName) }
+  ].filter((spec) => Boolean(spec.collectionId));
+  const collectionStartedAt = Date.now();
+  let collectionStatus = "success";
+  let acquisitions;
+  try {
+    acquisitions = await runBoundedInOrder(
+      collectionSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => acquireCollectionArtifact({
+        ...spec,
+        collectionsDir,
+        prebuiltByRole,
+        postman: dependencies.postman,
+        core: dependencies.core,
+        privateMockAuth
+      })
+    );
+  } catch (error) {
+    collectionStatus = "failed";
+    throw error;
+  } finally {
+    dependencies.core.info(
+      `collection-acquisition count=${collectionSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - collectionStartedAt} status=${collectionStatus}`
+    );
+  }
+  for (const [index, spec] of collectionSpecs.entries()) {
+    const ref = await exportCollectionArtifact({
+      ...spec,
+      collectionsDir,
+      artifactDir: inputs.artifactDir,
+      acquisition: acquisitions[index]
+    });
+    if (ref) {
+      manifestCollections[ref] = spec.collectionId;
     }
-  }
-  const baselineRef = await exportCollectionArtifact({
-    role: "baseline",
-    collectionId: inputs.baselineCollectionId,
-    dirName: getCollectionDirectoryName("Baseline", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth
-  });
-  if (baselineRef) {
-    manifestCollections[baselineRef] = inputs.baselineCollectionId;
-  }
-  const smokeRef = await exportCollectionArtifact({
-    role: "smoke",
-    collectionId: inputs.smokeCollectionId,
-    dirName: getCollectionDirectoryName("Smoke", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("smoke")
-  });
-  if (smokeRef) {
-    manifestCollections[smokeRef] = inputs.smokeCollectionId;
-  }
-  const contractRef = await exportCollectionArtifact({
-    role: "contract",
-    collectionId: inputs.contractCollectionId,
-    dirName: getCollectionDirectoryName("Contract", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("contract")
-  });
-  if (contractRef) {
-    manifestCollections[contractRef] = inputs.contractCollectionId;
   }
   ensureDir(collectionsDir);
   ensureDir(environmentsDir);
@@ -138992,17 +139011,40 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       ensureDir(ciDir);
     }
   }
-  for (const [envName, envUid] of Object.entries(envUids)) {
-    writeJsonFile(
-      `${environmentsDir}/${envName}.postman_environment.json`,
-      await dependencies.postman.getEnvironment(envUid),
-      true
+  const environmentSpecs = [
+    ...Object.entries(envUids).map(([envName, envUid]) => ({
+      envName,
+      envUid,
+      filePath: `${environmentsDir}/${envName}.postman_environment.json`
+    })),
+    ...options.mockEnvironmentUid ? [{
+      envName: "manual-validation",
+      envUid: options.mockEnvironmentUid,
+      filePath: `${mocksDir}/manual-validation.postman_environment.json`
+    }] : []
+  ];
+  const environmentStartedAt = Date.now();
+  let environmentStatus = "success";
+  let environmentPayloads;
+  try {
+    environmentPayloads = await runBoundedInOrder(
+      environmentSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => dependencies.postman.getEnvironment(spec.envUid)
+    );
+  } catch (error) {
+    environmentStatus = "failed";
+    throw error;
+  } finally {
+    dependencies.core.info(
+      `environment-artifact-acquisition count=${environmentSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - environmentStartedAt} status=${environmentStatus}`
     );
   }
-  if (options.mockEnvironmentUid) {
+  for (const [index, spec] of environmentSpecs.entries()) {
+    assertPathWithinCwd(spec.filePath, "environment target");
     writeJsonFile(
-      `${mocksDir}/manual-validation.postman_environment.json`,
-      await dependencies.postman.getEnvironment(options.mockEnvironmentUid),
+      spec.filePath,
+      environmentPayloads[index],
       true
     );
   }
@@ -139012,6 +139054,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
     manifestCollections,
@@ -139030,6 +139073,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     } catch {
       existingWorkflows = void 0;
     }
+    assertPathWithinCwd(".postman/workflows.yaml", "workflows state target");
     (0, import_node_fs5.writeFileSync)(
       ".postman/workflows.yaml",
       buildSpecCollectionWorkflowManifest(
@@ -139079,18 +139123,19 @@ function createRepoSummary(outputs, envUids, pushed) {
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
   if (inputs.generateCiWorkflow) {
-    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const ciWorkflow = renderCiWorkflow(inputs);
     const parts = inputs.ciWorkflowPath.split("/");
     if (parts.length > 1) {
       const dir = parts.slice(0, -1).join("/");
       ensureDir(dir);
     }
+    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     (0, import_node_fs5.writeFileSync)(inputs.ciWorkflowPath, ciWorkflow);
     if (inputs.provider === "github" || inputs.provider === "unknown") {
       const gcPath = ".github/workflows/postman-preview-gc.yml";
       if (inputs.ciWorkflowPath.endsWith(".github/workflows/ci.yml") || inputs.ciWorkflowPath === ".github/workflows/ci.yml") {
         ensureDir(".github/workflows");
+        assertPathWithinCwd(gcPath, "preview GC workflow path");
         (0, import_node_fs5.writeFileSync)(gcPath, renderGcWorkflowTemplate());
       }
     }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -140578,6 +140578,10 @@ var PREBUILT_COLLECTION_ROLES = /* @__PURE__ */ new Set([
 ]);
 var SHA256_HEX = /^[a-f0-9]{64}$/;
 var PREBUILT_CLOUD_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+var PREBUILT_COLLECTION_MAX_DEPTH = 128;
+var PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES = LOCAL_SPEC_DISCOVERY_MAX_TRAVERSAL_ENTRIES;
+var PREBUILT_COLLECTION_MAX_FILE_BYTES = 32 * 1024 * 1024;
+var PREBUILT_COLLECTION_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
 function failPrebuiltCollections(detail) {
   throw new Error(`CONTRACT_PREBUILT_COLLECTIONS_INVALID: ${detail}`);
 }
@@ -140689,8 +140693,9 @@ function assertPathWithinArtifactRoot(targetPath, artifactDir, fieldName) {
     existingPath = parent;
   }
   const realExisting = (0, import_node_fs5.realpathSync)(existingPath);
-  const realRelative = path8.relative(artifactRoot, realExisting);
-  if (realRelative.startsWith("..") || path8.isAbsolute(realRelative)) {
+  const realArtifactRoot = (0, import_node_fs5.existsSync)(artifactRoot) ? (0, import_node_fs5.realpathSync)(artifactRoot) : void 0;
+  const realRelative = realArtifactRoot ? path8.relative(realArtifactRoot, realExisting) : "";
+  if (realArtifactRoot && (realRelative.startsWith("..") || path8.isAbsolute(realRelative))) {
     failPrebuiltCollections(
       `${fieldName} resolves outside artifact-dir via symlink; received ${targetPath}`
     );
@@ -140732,13 +140737,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
     return [];
   }
   const files = [];
-  const pendingDirectories = [absRoot];
+  const pendingDirectories = [{ absolute: absRoot, depth: 0 }];
   const seenDirectories = /* @__PURE__ */ new Set();
+  let traversalEntries = 1;
+  let totalBytes = 0;
   while (pendingDirectories.length > 0) {
-    const currentAbsolute = pendingDirectories.pop();
-    if (!currentAbsolute) {
+    const current = pendingDirectories.pop();
+    if (!current) {
       break;
     }
+    const { absolute: currentAbsolute, depth: currentDepth } = current;
     const currentStat = (0, import_node_fs5.lstatSync)(currentAbsolute);
     if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
       failPrebuiltCollections(
@@ -140752,8 +140760,16 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       );
     }
     seenDirectories.add(currentKey);
-    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true });
+    const entries = (0, import_node_fs5.readdirSync)(currentAbsolute, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name)
+    );
     for (const entry of entries) {
+      traversalEntries += 1;
+      if (traversalEntries > PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES} traversal-entry budget`
+        );
+      }
       const abs = path8.join(currentAbsolute, entry.name);
       if (entry.isSymbolicLink()) {
         failPrebuiltCollections(
@@ -140761,7 +140777,13 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
         );
       }
       if (entry.isDirectory()) {
-        pendingDirectories.push(abs);
+        const nextDepth = currentDepth + 1;
+        if (nextDepth > PREBUILT_COLLECTION_MAX_DEPTH) {
+          failPrebuiltCollections(
+            `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_DEPTH} directory-depth budget`
+          );
+        }
+        pendingDirectories.push({ absolute: abs, depth: nextDepth });
         continue;
       }
       if (!entry.isFile()) {
@@ -140773,6 +140795,17 @@ function listPrebuiltCollectionTreeFiles(collectionPath, artifactDir) {
       if (fileLstat.isSymbolicLink() || !fileLstat.isFile()) {
         failPrebuiltCollections(
           `prebuilt collection tree file changed or became unsupported at ${normalizeToPosix(path8.relative(absRoot, abs))}`
+        );
+      }
+      if (fileLstat.size > PREBUILT_COLLECTION_MAX_FILE_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree file ${normalizeToPosix(path8.relative(absRoot, abs))} exceeds the ${PREBUILT_COLLECTION_MAX_FILE_BYTES / (1024 * 1024)} MiB individual-file budget`
+        );
+      }
+      totalBytes += fileLstat.size;
+      if (totalBytes > PREBUILT_COLLECTION_MAX_TOTAL_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TOTAL_BYTES / (1024 * 1024)} MiB total-byte budget`
         );
       }
       files.push({
@@ -140909,63 +140942,69 @@ async function preparePrivateMockCloudCollection(role, collectionId, postman) {
   }
   return collection;
 }
+var ARTIFACT_ACQUISITION_WIDTH = 2;
+async function runBoundedInOrder(items, width, worker) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const failures = /* @__PURE__ */ new Map();
+  const runWorker = async () => {
+    while (failures.size === 0 && nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await worker(items[index], index);
+      } catch (error2) {
+        failures.set(index, error2);
+        return;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(width, items.length) }, () => runWorker()));
+  const failedIndex = Math.min(...failures.keys());
+  if (Number.isFinite(failedIndex)) {
+    throw failures.get(failedIndex);
+  }
+  return results;
+}
+async function acquireCollectionArtifact(options) {
+  const { role, collectionId, dirName, collectionsDir, prebuiltByRole, postman, core, privateMockAuth = false } = options;
+  const expectedPath = `${collectionsDir}/${dirName}`;
+  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
+  const entry = prebuiltByRole.get(role);
+  if (entry && !forceCloudExport && tryReusePrebuiltCollection({
+    prepared: entry,
+    expectedPath,
+    expectedCloudId: collectionId
+  })) {
+    core.info(`Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`);
+    return { reusePrebuilt: true };
+  }
+  if (entry) {
+    core.info(forceCloudExport ? `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud` : `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`);
+  }
+  const cloud = forceCloudExport ? await preparePrivateMockCloudCollection(role, collectionId, postman) : await postman.getCollection(collectionId);
+  return { reusePrebuilt: false, cloudCollection: cloud };
+}
 async function exportCollectionArtifact(options) {
   const {
-    role,
     collectionId,
     dirName,
     collectionsDir,
-    prebuiltByRole,
-    postman,
-    core,
-    privateMockAuth = false,
-    preparedCloudCollection
+    artifactDir,
+    acquisition
   } = options;
   if (!collectionId) {
     return void 0;
   }
   const expectedPath = `${collectionsDir}/${dirName}`;
-  const forceCloudExport = privateMockAuth && (role === "smoke" || role === "contract");
-  const entry = prebuiltByRole.get(role);
-  if (entry && !forceCloudExport) {
-    const reused = tryReusePrebuiltCollection({
-      prepared: entry,
-      expectedPath,
-      expectedCloudId: collectionId
-    });
-    if (reused) {
-      core.info(
-        `Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`
-      );
-      return `../${expectedPath}`;
-    }
-    core.info(
-      `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`
-    );
-  } else if (entry && forceCloudExport) {
-    core.info(
-      `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud`
-    );
+  if (acquisition.reusePrebuilt) {
+    return `../${expectedPath}`;
   }
-  let collectionForExport;
-  if (forceCloudExport && preparedCloudCollection) {
-    collectionForExport = preparedCloudCollection;
-  } else if (forceCloudExport) {
-    const col = await postman.getCollection(collectionId);
-    const { collection } = applyPrivateMockExportCleanup(col, {
-      stripManagedBlocks: isPrivateMockLegacyExportCleanupEnabled()
-    });
-    if (!verifyPrivateMockRootHook(collection)) {
-      throw new Error(
-        `PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED: Managed root hook missing from exported ${role} collection ${collectionId}`
-      );
-    }
-    collectionForExport = collection;
-  } else {
-    const col = await postman.getCollection(collectionId);
-    collectionForExport = col;
-  }
-  await convertAndSplitAnyCollection(collectionForExport, expectedPath);
+  assertPathWithinArtifactRoot(expectedPath, artifactDir, "collection target");
+  await convertAndSplitAnyCollection(
+    acquisition.cloudCollection,
+    expectedPath
+  );
   return `../${expectedPath}`;
 }
 function hasControlCharacter2(value) {
@@ -141030,65 +141069,45 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   ) : void 0;
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
-  const preparedPrivateMockCollections = /* @__PURE__ */ new Map();
-  if (privateMockAuth) {
-    for (const spec of [
-      { role: "smoke", collectionId: inputs.smokeCollectionId },
-      { role: "contract", collectionId: inputs.contractCollectionId }
-    ]) {
-      if (!spec.collectionId) {
-        continue;
-      }
-      preparedPrivateMockCollections.set(
-        spec.role,
-        await preparePrivateMockCloudCollection(
-          spec.role,
-          spec.collectionId,
-          dependencies.postman
-        )
-      );
+  const collectionSpecs = [
+    { role: "baseline", collectionId: inputs.baselineCollectionId, dirName: getCollectionDirectoryName("Baseline", assetProjectName) },
+    { role: "smoke", collectionId: inputs.smokeCollectionId, dirName: getCollectionDirectoryName("Smoke", assetProjectName) },
+    { role: "contract", collectionId: inputs.contractCollectionId, dirName: getCollectionDirectoryName("Contract", assetProjectName) }
+  ].filter((spec) => Boolean(spec.collectionId));
+  const collectionStartedAt = Date.now();
+  let collectionStatus = "success";
+  let acquisitions;
+  try {
+    acquisitions = await runBoundedInOrder(
+      collectionSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => acquireCollectionArtifact({
+        ...spec,
+        collectionsDir,
+        prebuiltByRole,
+        postman: dependencies.postman,
+        core: dependencies.core,
+        privateMockAuth
+      })
+    );
+  } catch (error2) {
+    collectionStatus = "failed";
+    throw error2;
+  } finally {
+    dependencies.core.info(
+      `collection-acquisition count=${collectionSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - collectionStartedAt} status=${collectionStatus}`
+    );
+  }
+  for (const [index, spec] of collectionSpecs.entries()) {
+    const ref = await exportCollectionArtifact({
+      ...spec,
+      collectionsDir,
+      artifactDir: inputs.artifactDir,
+      acquisition: acquisitions[index]
+    });
+    if (ref) {
+      manifestCollections[ref] = spec.collectionId;
     }
-  }
-  const baselineRef = await exportCollectionArtifact({
-    role: "baseline",
-    collectionId: inputs.baselineCollectionId,
-    dirName: getCollectionDirectoryName("Baseline", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth
-  });
-  if (baselineRef) {
-    manifestCollections[baselineRef] = inputs.baselineCollectionId;
-  }
-  const smokeRef = await exportCollectionArtifact({
-    role: "smoke",
-    collectionId: inputs.smokeCollectionId,
-    dirName: getCollectionDirectoryName("Smoke", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("smoke")
-  });
-  if (smokeRef) {
-    manifestCollections[smokeRef] = inputs.smokeCollectionId;
-  }
-  const contractRef = await exportCollectionArtifact({
-    role: "contract",
-    collectionId: inputs.contractCollectionId,
-    dirName: getCollectionDirectoryName("Contract", assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get("contract")
-  });
-  if (contractRef) {
-    manifestCollections[contractRef] = inputs.contractCollectionId;
   }
   ensureDir(collectionsDir);
   ensureDir(environmentsDir);
@@ -141107,17 +141126,40 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       ensureDir(ciDir);
     }
   }
-  for (const [envName, envUid] of Object.entries(envUids)) {
-    writeJsonFile(
-      `${environmentsDir}/${envName}.postman_environment.json`,
-      await dependencies.postman.getEnvironment(envUid),
-      true
+  const environmentSpecs = [
+    ...Object.entries(envUids).map(([envName, envUid]) => ({
+      envName,
+      envUid,
+      filePath: `${environmentsDir}/${envName}.postman_environment.json`
+    })),
+    ...options.mockEnvironmentUid ? [{
+      envName: "manual-validation",
+      envUid: options.mockEnvironmentUid,
+      filePath: `${mocksDir}/manual-validation.postman_environment.json`
+    }] : []
+  ];
+  const environmentStartedAt = Date.now();
+  let environmentStatus = "success";
+  let environmentPayloads;
+  try {
+    environmentPayloads = await runBoundedInOrder(
+      environmentSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => dependencies.postman.getEnvironment(spec.envUid)
+    );
+  } catch (error2) {
+    environmentStatus = "failed";
+    throw error2;
+  } finally {
+    dependencies.core.info(
+      `environment-artifact-acquisition count=${environmentSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - environmentStartedAt} status=${environmentStatus}`
     );
   }
-  if (options.mockEnvironmentUid) {
+  for (const [index, spec] of environmentSpecs.entries()) {
+    assertPathWithinCwd(spec.filePath, "environment target");
     writeJsonFile(
-      `${mocksDir}/manual-validation.postman_environment.json`,
-      await dependencies.postman.getEnvironment(options.mockEnvironmentUid),
+      spec.filePath,
+      environmentPayloads[index],
       true
     );
   }
@@ -141127,6 +141169,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
     manifestCollections,
@@ -141145,6 +141188,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     } catch {
       existingWorkflows = void 0;
     }
+    assertPathWithinCwd(".postman/workflows.yaml", "workflows state target");
     (0, import_node_fs5.writeFileSync)(
       ".postman/workflows.yaml",
       buildSpecCollectionWorkflowManifest(
@@ -141194,18 +141238,19 @@ function createRepoSummary(outputs, envUids, pushed) {
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
   if (inputs.generateCiWorkflow) {
-    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const ciWorkflow = renderCiWorkflow(inputs);
     const parts = inputs.ciWorkflowPath.split("/");
     if (parts.length > 1) {
       const dir = parts.slice(0, -1).join("/");
       ensureDir(dir);
     }
+    assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     (0, import_node_fs5.writeFileSync)(inputs.ciWorkflowPath, ciWorkflow);
     if (inputs.provider === "github" || inputs.provider === "unknown") {
       const gcPath = ".github/workflows/postman-preview-gc.yml";
       if (inputs.ciWorkflowPath.endsWith(".github/workflows/ci.yml") || inputs.ciWorkflowPath === ".github/workflows/ci.yml") {
         ensureDir(".github/workflows");
+        assertPathWithinCwd(gcPath, "preview GC workflow path");
         (0, import_node_fs5.writeFileSync)(gcPath, renderGcWorkflowTemplate());
       }
     }

--- a/docs/artifact-layout.md
+++ b/docs/artifact-layout.md
@@ -19,26 +19,41 @@ The generated files are intended to be committed when `repo-write-mode` is `comm
 
 ## Collection v3 multi-file YAML
 
-Collections are exported in the Postman Collection v3 format (`$schema: https://schema.postman.com/json/draft-2020-12/collection/v3.0.0/`) as a directory tree rather than a single JSON file. Each collection becomes a directory containing a `collection.yaml` plus one YAML file per folder and per request:
+Collections are exported in the Postman Collection v3 format (`$schema: https://schema.postman.com/json/draft-2020-12/collection/v3.0.0/`) as a directory tree rather than a single JSON file. Each collection and folder has a `.resources/definition.yaml`; requests are separate `*.request.yaml` files:
 
 ```text
 postman/collections/core-payments/
-  collection.yaml
-  <folder>.yaml
-  <request>.yaml
+  .resources/definition.yaml
+  <folder>/.resources/definition.yaml
+  <request>.request.yaml
 postman/collections/[Smoke] core-payments/
-  collection.yaml
-  <folder>.yaml
-  <request>.yaml
+  .resources/definition.yaml
+  <folder>/.resources/definition.yaml
+  <request>.request.yaml
 ```
 
-This layout keeps diffs reviewable: a change to one request shows up as a change to one file. Long Postman folder and request names are truncated to 120 characters per path segment when files are written.
+Definitions and request files use `$kind:` discriminators (for example, `$kind: collection` and `$kind: http-request`). The legacy `collection.yaml`/`folder.yaml`/`type:` layout is not written; `postman collection lint` rejects it. This layout keeps diffs reviewable: a change to one request shows up as a change to one file.
 
 Note that v3 collections are run with `postman collection run` (Postman CLI). Newman cannot execute the v3 format.
 
 ## Spec and workflow metadata
 
-When a local OpenAPI spec is found, `.postman/resources.yaml` records it under `localResources.specs`. If `spec-id` and an unambiguous local spec are available, the action also maps the spec under `cloudResources.specs`. When a mapped spec and exported collections are both present, `.postman/workflows.yaml` is written with `syncSpecToCollection` metadata that ties the spec to its generated collections.
+`.postman/resources.yaml` is state v2. Its current mappings are canonical: `canonical.collections`, `canonical.environments`, and `canonical.specs` map repository-relative artifact paths to Postman resource UIDs. For example:
+
+```yaml
+version: 2
+workspace:
+  id: <workspace UID>
+canonical:
+  collections:
+    ../postman/collections/core-payments: <collection UID>
+  environments:
+    ../postman/environments/prod.postman_environment.json: <environment UID>
+  specs:
+    ../openapi.yaml: <spec UID>
+```
+
+The action writes each mapping only when that resource is available. When a mapped spec and exported collections are both present, `.postman/workflows.yaml` is written with `syncSpecToCollection` metadata that ties the spec to its generated collections.
 
 ## Versioned runs
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -16,7 +16,7 @@ export type PrebuiltCollectionEntry = {
   path?: string;
   /** Canonical cloud ID for the collection. */
   cloudId: string;
-  /** SHA-256 digest of the canonical v2 payload (optional; verified when present). */
+  /** SHA-256 digest of the canonical v2 payload (optional; format-validated provenance only, not the reuse gate). */
   payloadDigest?: string;
   /** SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL). */
   artifactDigest: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1827,6 +1827,10 @@ const PREBUILT_COLLECTION_ROLES = new Set<PrebuiltCollectionRole>([
 const SHA256_HEX = /^[a-f0-9]{64}$/;
 /** Nonempty Postman collection id: safe characters, no arbitrary length cap. */
 const PREBUILT_CLOUD_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const PREBUILT_COLLECTION_MAX_DEPTH = 128;
+const PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES = LOCAL_SPEC_DISCOVERY_MAX_TRAVERSAL_ENTRIES;
+const PREBUILT_COLLECTION_MAX_FILE_BYTES = 32 * 1024 * 1024;
+const PREBUILT_COLLECTION_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
 
 function failPrebuiltCollections(detail: string): never {
   throw new Error(`CONTRACT_PREBUILT_COLLECTIONS_INVALID: ${detail}`);
@@ -1961,8 +1965,9 @@ function assertPathWithinArtifactRoot(
     existingPath = parent;
   }
   const realExisting = realpathSync(existingPath);
-  const realRelative = path.relative(artifactRoot, realExisting);
-  if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+  const realArtifactRoot = existsSync(artifactRoot) ? realpathSync(artifactRoot) : undefined;
+  const realRelative = realArtifactRoot ? path.relative(realArtifactRoot, realExisting) : '';
+  if (realArtifactRoot && (realRelative.startsWith('..') || path.isAbsolute(realRelative))) {
     failPrebuiltCollections(
       `${fieldName} resolves outside artifact-dir via symlink; received ${targetPath}`
     );
@@ -2032,14 +2037,17 @@ function listPrebuiltCollectionTreeFiles(
   }
 
   const files: PrebuiltTreeFileMeta[] = [];
-  const pendingDirectories: string[] = [absRoot];
+  const pendingDirectories: Array<{ absolute: string; depth: number }> = [{ absolute: absRoot, depth: 0 }];
   const seenDirectories = new Set<string>();
+  let traversalEntries = 1;
+  let totalBytes = 0;
 
   while (pendingDirectories.length > 0) {
-    const currentAbsolute = pendingDirectories.pop();
-    if (!currentAbsolute) {
+    const current = pendingDirectories.pop();
+    if (!current) {
       break;
     }
+    const { absolute: currentAbsolute, depth: currentDepth } = current;
     const currentStat = lstatSync(currentAbsolute);
     if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
       failPrebuiltCollections(
@@ -2054,8 +2062,16 @@ function listPrebuiltCollectionTreeFiles(
     }
     seenDirectories.add(currentKey);
 
-    const entries = readdirSync(currentAbsolute, { withFileTypes: true });
+    const entries = readdirSync(currentAbsolute, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name)
+    );
     for (const entry of entries) {
+      traversalEntries += 1;
+      if (traversalEntries > PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TRAVERSAL_ENTRIES} traversal-entry budget`
+        );
+      }
       const abs = path.join(currentAbsolute, entry.name);
       if (entry.isSymbolicLink()) {
         failPrebuiltCollections(
@@ -2063,7 +2079,13 @@ function listPrebuiltCollectionTreeFiles(
         );
       }
       if (entry.isDirectory()) {
-        pendingDirectories.push(abs);
+        const nextDepth = currentDepth + 1;
+        if (nextDepth > PREBUILT_COLLECTION_MAX_DEPTH) {
+          failPrebuiltCollections(
+            `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_DEPTH} directory-depth budget`
+          );
+        }
+        pendingDirectories.push({ absolute: abs, depth: nextDepth });
         continue;
       }
       if (!entry.isFile()) {
@@ -2075,6 +2097,17 @@ function listPrebuiltCollectionTreeFiles(
       if (fileLstat.isSymbolicLink() || !fileLstat.isFile()) {
         failPrebuiltCollections(
           `prebuilt collection tree file changed or became unsupported at ${normalizeToPosix(path.relative(absRoot, abs))}`
+        );
+      }
+      if (fileLstat.size > PREBUILT_COLLECTION_MAX_FILE_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree file ${normalizeToPosix(path.relative(absRoot, abs))} exceeds the ${PREBUILT_COLLECTION_MAX_FILE_BYTES / (1024 * 1024)} MiB individual-file budget`
+        );
+      }
+      totalBytes += fileLstat.size;
+      if (totalBytes > PREBUILT_COLLECTION_MAX_TOTAL_BYTES) {
+        failPrebuiltCollections(
+          `prebuilt collection tree exceeded the ${PREBUILT_COLLECTION_MAX_TOTAL_BYTES / (1024 * 1024)} MiB total-byte budget`
         );
       }
       files.push({
@@ -2248,7 +2281,42 @@ async function preparePrivateMockCloudCollection(
   return collection;
 }
 
-async function exportCollectionArtifact(options: {
+const ARTIFACT_ACQUISITION_WIDTH = 2;
+
+async function runBoundedInOrder<T, R>(
+  items: readonly T[],
+  width: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const failures = new Map<number, unknown>();
+  const runWorker = async (): Promise<void> => {
+    while (failures.size === 0 && nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await worker(items[index], index);
+      } catch (error) {
+        failures.set(index, error);
+        return;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(width, items.length) }, () => runWorker()));
+  const failedIndex = Math.min(...failures.keys());
+  if (Number.isFinite(failedIndex)) {
+    throw failures.get(failedIndex);
+  }
+  return results;
+}
+
+type CollectionArtifactAcquisition = {
+  reusePrebuilt: boolean;
+  cloudCollection?: Record<string, unknown>;
+};
+
+async function acquireCollectionArtifact(options: {
   role: PrebuiltCollectionRole;
   collectionId: string;
   dirName: string;
@@ -2257,70 +2325,58 @@ async function exportCollectionArtifact(options: {
   postman: RepoSyncDependencies['postman'];
   core: RepoSyncDependencies['core'];
   privateMockAuth?: boolean;
-  preparedCloudCollection?: Record<string, unknown>;
+}): Promise<CollectionArtifactAcquisition> {
+  const { role, collectionId, dirName, collectionsDir, prebuiltByRole, postman, core, privateMockAuth = false } = options;
+  const expectedPath = `${collectionsDir}/${dirName}`;
+  const forceCloudExport = privateMockAuth && (role === 'smoke' || role === 'contract');
+  const entry = prebuiltByRole.get(role);
+  if (entry && !forceCloudExport && tryReusePrebuiltCollection({
+    prepared: entry,
+    expectedPath,
+    expectedCloudId: collectionId
+  })) {
+    core.info(`Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`);
+    return { reusePrebuilt: true };
+  }
+  if (entry) {
+    core.info(forceCloudExport
+      ? `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud`
+      : `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`);
+  }
+  const cloud = forceCloudExport
+    ? await preparePrivateMockCloudCollection(role, collectionId, postman)
+    : await postman.getCollection(collectionId) as Record<string, unknown>;
+  return { reusePrebuilt: false, cloudCollection: cloud };
+}
+
+async function exportCollectionArtifact(options: {
+  role: PrebuiltCollectionRole;
+  collectionId: string;
+  dirName: string;
+  collectionsDir: string;
+  artifactDir: string;
+  acquisition: CollectionArtifactAcquisition;
 }): Promise<string | undefined> {
   const {
-    role,
     collectionId,
     dirName,
     collectionsDir,
-    prebuiltByRole,
-    postman,
-    core,
-    privateMockAuth = false,
-    preparedCloudCollection
+    artifactDir,
+    acquisition
   } = options;
   if (!collectionId) {
     return undefined;
   }
 
   const expectedPath = `${collectionsDir}/${dirName}`;
-  const forceCloudExport =
-    privateMockAuth && (role === 'smoke' || role === 'contract');
-  const entry = prebuiltByRole.get(role);
-  if (entry && !forceCloudExport) {
-    const reused = tryReusePrebuiltCollection({
-      prepared: entry,
-      expectedPath,
-      expectedCloudId: collectionId
-    });
-    if (reused) {
-      core.info(
-        `Reusing prebuilt ${role} collection tree at ${expectedPath} (artifactDigest match)`
-      );
-      return `../${expectedPath}`;
-    }
-    core.info(
-      `Prebuilt ${role} collection entry present but did not exactly match; exporting from cloud`
-    );
-  } else if (entry && forceCloudExport) {
-    core.info(
-      `Private mock requires cloud export for ${role} collection to reconcile managed root hook; exporting from cloud`
-    );
+  if (acquisition.reusePrebuilt) {
+    return `../${expectedPath}`;
   }
-
-  let collectionForExport: Parameters<typeof convertAndSplitAnyCollection>[0];
-  if (forceCloudExport && preparedCloudCollection) {
-    collectionForExport = preparedCloudCollection as Parameters<
-      typeof convertAndSplitAnyCollection
-    >[0];
-  } else if (forceCloudExport) {
-    const col = await postman.getCollection(collectionId);
-    const { collection } = applyPrivateMockExportCleanup(col as Record<string, unknown>, {
-      stripManagedBlocks: isPrivateMockLegacyExportCleanupEnabled()
-    });
-    if (!verifyPrivateMockRootHook(collection)) {
-      throw new Error(
-        `PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED: Managed root hook missing from exported ${role} collection ${collectionId}`
-      );
-    }
-    collectionForExport = collection as Parameters<typeof convertAndSplitAnyCollection>[0];
-  } else {
-    const col = await postman.getCollection(collectionId);
-    collectionForExport = col as Parameters<typeof convertAndSplitAnyCollection>[0];
-  }
-
-  await convertAndSplitAnyCollection(collectionForExport, expectedPath);
+  assertPathWithinArtifactRoot(expectedPath, artifactDir, 'collection target');
+  await convertAndSplitAnyCollection(
+    acquisition.cloudCollection as Parameters<typeof convertAndSplitAnyCollection>[0],
+    expectedPath
+  );
   return `../${expectedPath}`;
 }
 
@@ -2423,68 +2479,43 @@ async function exportArtifacts(
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
 
-  const preparedPrivateMockCollections = new Map<PrebuiltCollectionRole, Record<string, unknown>>();
-  if (privateMockAuth) {
-    for (const spec of [
-      { role: 'smoke' as const, collectionId: inputs.smokeCollectionId },
-      { role: 'contract' as const, collectionId: inputs.contractCollectionId }
-    ]) {
-      if (!spec.collectionId) {
-        continue;
-      }
-      preparedPrivateMockCollections.set(
-        spec.role,
-        await preparePrivateMockCloudCollection(
-          spec.role,
-          spec.collectionId,
-          dependencies.postman
-        )
-      );
+  const collectionSpecs = [
+    { role: 'baseline' as const, collectionId: inputs.baselineCollectionId, dirName: getCollectionDirectoryName('Baseline', assetProjectName) },
+    { role: 'smoke' as const, collectionId: inputs.smokeCollectionId, dirName: getCollectionDirectoryName('Smoke', assetProjectName) },
+    { role: 'contract' as const, collectionId: inputs.contractCollectionId, dirName: getCollectionDirectoryName('Contract', assetProjectName) }
+  ].filter((spec) => Boolean(spec.collectionId));
+  const collectionStartedAt = Date.now();
+  let collectionStatus = 'success';
+  let acquisitions: CollectionArtifactAcquisition[];
+  try {
+    acquisitions = await runBoundedInOrder(collectionSpecs, ARTIFACT_ACQUISITION_WIDTH, (spec) =>
+      acquireCollectionArtifact({
+        ...spec,
+        collectionsDir,
+        prebuiltByRole,
+        postman: dependencies.postman,
+        core: dependencies.core,
+        privateMockAuth
+      })
+    );
+  } catch (error) {
+    collectionStatus = 'failed';
+    throw error;
+  } finally {
+    dependencies.core.info(
+      `collection-acquisition count=${collectionSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - collectionStartedAt} status=${collectionStatus}`
+    );
+  }
+  for (const [index, spec] of collectionSpecs.entries()) {
+    const ref = await exportCollectionArtifact({
+      ...spec,
+      collectionsDir,
+      artifactDir: inputs.artifactDir,
+      acquisition: acquisitions[index]
+    });
+    if (ref) {
+      manifestCollections[ref] = spec.collectionId;
     }
-  }
-
-  const baselineRef = await exportCollectionArtifact({
-    role: 'baseline',
-    collectionId: inputs.baselineCollectionId,
-    dirName: getCollectionDirectoryName('Baseline', assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth
-  });
-  if (baselineRef) {
-    manifestCollections[baselineRef] = inputs.baselineCollectionId;
-  }
-
-  const smokeRef = await exportCollectionArtifact({
-    role: 'smoke',
-    collectionId: inputs.smokeCollectionId,
-    dirName: getCollectionDirectoryName('Smoke', assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get('smoke')
-  });
-  if (smokeRef) {
-    manifestCollections[smokeRef] = inputs.smokeCollectionId;
-  }
-
-  const contractRef = await exportCollectionArtifact({
-    role: 'contract',
-    collectionId: inputs.contractCollectionId,
-    dirName: getCollectionDirectoryName('Contract', assetProjectName),
-    collectionsDir,
-    prebuiltByRole,
-    postman: dependencies.postman,
-    core: dependencies.core,
-    privateMockAuth,
-    preparedCloudCollection: preparedPrivateMockCollections.get('contract')
-  });
-  if (contractRef) {
-    manifestCollections[contractRef] = inputs.contractCollectionId;
   }
 
   ensureDir(collectionsDir);
@@ -2505,17 +2536,40 @@ async function exportArtifacts(
     }
   }
 
-  for (const [envName, envUid] of Object.entries(envUids)) {
-    writeJsonFile(
-      `${environmentsDir}/${envName}.postman_environment.json`,
-      await dependencies.postman.getEnvironment(envUid),
-      true
+  const environmentSpecs = [
+    ...Object.entries(envUids).map(([envName, envUid]) => ({
+      envName,
+      envUid,
+      filePath: `${environmentsDir}/${envName}.postman_environment.json`
+    })),
+    ...(options.mockEnvironmentUid ? [{
+      envName: 'manual-validation',
+      envUid: options.mockEnvironmentUid,
+      filePath: `${mocksDir}/manual-validation.postman_environment.json`
+    }] : [])
+  ];
+  const environmentStartedAt = Date.now();
+  let environmentStatus = 'success';
+  let environmentPayloads: unknown[];
+  try {
+    environmentPayloads = await runBoundedInOrder(
+      environmentSpecs,
+      ARTIFACT_ACQUISITION_WIDTH,
+      (spec) => dependencies.postman.getEnvironment(spec.envUid)
+    );
+  } catch (error) {
+    environmentStatus = 'failed';
+    throw error;
+  } finally {
+    dependencies.core.info(
+      `environment-artifact-acquisition count=${environmentSpecs.length} width=${ARTIFACT_ACQUISITION_WIDTH} ms=${Date.now() - environmentStartedAt} status=${environmentStatus}`
     );
   }
-  if (options.mockEnvironmentUid) {
+  for (const [index, spec] of environmentSpecs.entries()) {
+    assertPathWithinCwd(spec.filePath, 'environment target');
     writeJsonFile(
-      `${mocksDir}/manual-validation.postman_environment.json`,
-      await dependencies.postman.getEnvironment(options.mockEnvironmentUid),
+      spec.filePath,
+      environmentPayloads[index],
       true
     );
   }
@@ -2527,6 +2581,7 @@ async function exportArtifacts(
     workspaceLinkStatus: options.workspaceLinkStatus
   });
 
+  assertPathWithinCwd('.postman/resources.yaml', 'resources state target');
   writeFileSync('.postman/resources.yaml', buildResourcesManifest(
     durableWorkspaceId,
     manifestCollections,
@@ -2548,6 +2603,7 @@ async function exportArtifacts(
     } catch {
       existingWorkflows = undefined;
     }
+    assertPathWithinCwd('.postman/workflows.yaml', 'workflows state target');
     writeFileSync(
       '.postman/workflows.yaml',
       buildSpecCollectionWorkflowManifest(
@@ -2609,7 +2665,6 @@ async function commitAndPushGeneratedFiles(
   // File generation is independent of git mutation: mode=none still writes the
   // requested CI workflow, but never stages/commits/pushes.
   if (inputs.generateCiWorkflow) {
-    assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
     const ciWorkflow = renderCiWorkflow(inputs);
 
     // Extract dir from ciWorkflowPath
@@ -2619,6 +2674,7 @@ async function commitAndPushGeneratedFiles(
       ensureDir(dir);
     }
 
+    assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
     writeFileSync(inputs.ciWorkflowPath, ciWorkflow);
 
     // GC workflow: dedicated generated workflow for preview retention (R18a).
@@ -2628,6 +2684,7 @@ async function commitAndPushGeneratedFiles(
       const gcPath = '.github/workflows/postman-preview-gc.yml';
       if (inputs.ciWorkflowPath.endsWith('.github/workflows/ci.yml') || inputs.ciWorkflowPath === '.github/workflows/ci.yml') {
         ensureDir('.github/workflows');
+        assertPathWithinCwd(gcPath, 'preview GC workflow path');
         writeFileSync(gcPath, renderGcWorkflowTemplate());
       }
     }

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -194,6 +194,20 @@ describe('postman-repo-sync-action contract', () => {
     expect(readme).toContain('Use this for customer-managed PR workflows.');
   });
 
+  it('documents the canonical Collection v3 artifact and state-v2 layouts', () => {
+    const artifactLayout = readFileSync(resolve(repoRoot, 'docs/artifact-layout.md'), 'utf8');
+
+    expect(artifactLayout).toContain('`.resources/definition.yaml`');
+    expect(artifactLayout).toContain('`$kind:`');
+    expect(artifactLayout).toContain('legacy `collection.yaml`');
+    expect(artifactLayout).toContain('version: 2');
+    expect(artifactLayout).toContain('`canonical.collections`');
+    expect(artifactLayout).toContain('`canonical.environments`');
+    expect(artifactLayout).toContain('`canonical.specs`');
+    expect(artifactLayout).not.toContain('localResources');
+    expect(artifactLayout).not.toContain('cloudResources');
+  });
+
   it('keeps action metadata aligned with the contract surface', () => {
     const actionYaml = parse(readFileSync(resolve(repoRoot, 'action.yml'), 'utf8')) as {
       inputs: Record<string, { default?: string }>;
@@ -302,6 +316,8 @@ describe('postman-repo-sync-action contract', () => {
 
   it('defines prebuilt-collections-json semantic contract schema and default behavior', () => {
     const inputDef = postmanRepoSyncActionContract.inputs['prebuilt-collections-json'];
+    const contractsSource = readFileSync(resolve(repoRoot, 'src/contracts.ts'), 'utf8');
+    const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf8');
     expect(inputDef).toBeDefined();
     expect(inputDef.required).toBe(false);
     expect(inputDef.default).toBe('');
@@ -322,6 +338,16 @@ describe('postman-repo-sync-action contract', () => {
     );
     expect(inputDef.description).toContain(
       'optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate)'
+    );
+    expect(contractsSource).toContain(
+      'SHA-256 digest of the canonical v2 payload (optional; format-validated provenance only, not the reuse gate)'
+    );
+    expect(contractsSource).not.toContain('payload (optional; verified when present)');
+    expect(actionInput?.description).toContain(
+      'payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate)'
+    );
+    expect(readme).toContain(
+      'payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate)'
     );
     expect(inputDef.description).toContain('canonical cloud ID');
     expect(inputDef.description).not.toMatch(/depth|length|threshold|limit|cap/i);

--- a/tests/private-mock-wiring-contract.test.ts
+++ b/tests/private-mock-wiring-contract.test.ts
@@ -41,11 +41,11 @@ const packageRoot = resolve(import.meta.dirname, '..');
 const indexPath = resolve(packageRoot, 'src/index.ts');
 const indexSource = readFileSync(indexPath, 'utf8');
 
-function exportCollectionArtifactSource(): string {
+function collectionAcquisitionSource(): string {
   const match = indexSource.match(
-    /async function exportCollectionArtifact\([\s\S]*?\n\}(?=\n\n(?:async )?function |\nexport )/
+    /async function acquireCollectionArtifact\([\s\S]*?\n\}(?=\n\n(?:async )?function |\nexport )/
   );
-  expect(match?.[0], 'exportCollectionArtifact must exist in src/index.ts').toBeTruthy();
+  expect(match?.[0], 'acquireCollectionArtifact must exist in src/index.ts').toBeTruthy();
   return match![0];
 }
 
@@ -79,23 +79,21 @@ describe('private-mock export cleanup wiring contract', () => {
     );
   });
 
-  it('threads privateMockAuth into exportCollectionArtifact from orchestration', () => {
-    expect(exportCollectionArtifactSource()).toMatch(/\bprivateMockAuth\b/);
-    expect(indexSource).toMatch(/exportCollectionArtifact\(\{[\s\S]*?\bprivateMockAuth\b/);
+  it('threads privateMockAuth into collection acquisition from orchestration', () => {
+    expect(collectionAcquisitionSource()).toMatch(/\bprivateMockAuth\b/);
+    expect(indexSource).toMatch(/acquireCollectionArtifact\(\{[\s\S]*?\bprivateMockAuth\b/);
   });
 
   it('invokes applyPrivateMockExportCleanup on the cloud export path before YAML conversion', () => {
-    const exportFn = exportCollectionArtifactSource();
-    expect(exportFn).toMatch(
-      /applyPrivateMockExportCleanup[\s\S]*await convertAndSplitAnyCollection/
-    );
+    const exportFn = collectionAcquisitionSource();
+    expect(exportFn).toMatch(/preparePrivateMockCloudCollection/);
     expect(indexSource).toMatch(
       /async function preparePrivateMockCloudCollection[\s\S]*applyPrivateMockExportCleanup/
     );
   });
 
   it('forces smoke/contract cloud export when private-mock auth is active', () => {
-    const exportFn = exportCollectionArtifactSource();
+    const exportFn = collectionAcquisitionSource();
     expect(exportFn).toMatch(/\bprivateMockAuth\b/);
     expect(exportFn).toMatch(/['"]smoke['"]/);
     expect(exportFn).toMatch(/['"]contract['"]/);
@@ -106,8 +104,8 @@ describe('private-mock export cleanup wiring contract', () => {
   });
 
   it('fails before repo mutation when the managed root hook is absent from export IR', () => {
-    const exportFn = exportCollectionArtifactSource();
-    expect(exportFn).toMatch(/verifyPrivateMockRootHook/);
+    const exportFn = collectionAcquisitionSource();
+    expect(exportFn).toMatch(/preparePrivateMockCloudCollection/);
     expect(indexSource).toContain('PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED');
     expect(indexSource).toMatch(
       /async function preparePrivateMockCloudCollection[\s\S]*verifyPrivateMockRootHook/
@@ -317,7 +315,8 @@ function installManagedRootHook(collection: Record<string, unknown>): void {
 
 function createStatefulPrivateMockPostman(
   cloudCollections: Map<string, Record<string, unknown>>,
-  events: string[]
+  events: string[],
+  metrics?: { active: number; peak: number }
 ) {
   return {
     createEnvironment: vi.fn().mockResolvedValue('env-prod'),
@@ -348,6 +347,12 @@ function createStatefulPrivateMockPostman(
     }),
     getCollection: vi.fn(async (collectionUid: string) => {
       events.push(`export:${collectionUid}`);
+      if (metrics) {
+        metrics.active += 1;
+        metrics.peak = Math.max(metrics.peak, metrics.active);
+        await Promise.resolve();
+        metrics.active -= 1;
+      }
       const state = cloudCollections.get(collectionUid);
       if (!state) {
         throw new Error(`missing cloud collection ${collectionUid}`);
@@ -383,6 +388,7 @@ describe('private-mock behavioral ordering regression (C6)', () => {
 
   it('exports smoke and contract only after configure patches the managed root hook into cloud state', async () => {
     const events: string[] = [];
+    const metrics = { active: 0, peak: 0 };
     const cloudCollections = new Map<string, Record<string, unknown>>([
       [
         'col-smoke',
@@ -409,7 +415,7 @@ describe('private-mock behavioral ordering regression (C6)', () => {
       };
     });
 
-    const postman = createStatefulPrivateMockPostman(cloudCollections, events);
+    const postman = createStatefulPrivateMockPostman(cloudCollections, events, metrics);
     const { core } = createCoreStub();
     const dependencies = {
       core,
@@ -488,6 +494,8 @@ describe('private-mock behavioral ordering regression (C6)', () => {
 
     expect(existsSync('postman/collections/core-payments/.resources/definition.yaml')).toBe(true);
     expect(postman.getCollection).toHaveBeenCalledTimes(2);
+    expect(metrics.peak).toBeGreaterThan(1);
+    expect(metrics.peak).toBeLessThanOrEqual(2);
     expect(postman.getCollection).not.toHaveBeenCalledWith('col-baseline');
     expect(postman.configurePrivateMockRuntimeAuth).toHaveBeenCalledWith('col-smoke');
     expect(postman.configurePrivateMockRuntimeAuth).toHaveBeenCalledWith('col-contract');

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -894,8 +894,14 @@ describe('repo sync action', () => {
       pending.get('col-contract')!.resolve(createCollectionFixture('[Contract] core-payments'));
       await sync;
 
-      expect(readdirSync('postman/collections')).toEqual([
+      expect(readdirSync('postman/collections').sort()).toEqual([
         '[Contract] core-payments', '[Smoke] core-payments', 'core-payments'
+      ].sort());
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(Object.keys(resources.canonical?.collections ?? {})).toEqual([
+        '../postman/collections/core-payments',
+        '../postman/collections/[Smoke] core-payments',
+        '../postman/collections/[Contract] core-payments'
       ]);
       expect(infos.some((line) => /collection-acquisition.*count=3.*width=2.*ms=.*status=success/.test(line))).toBe(true);
     });

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -314,6 +314,25 @@ function sha256Hex(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
+function artifactTreeDigest(root = '.'): string {
+  const files: string[] = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    for (const name of readdirSync(current)) {
+      const filePath = join(current, name);
+      if (lstatSync(filePath).isDirectory()) pending.push(filePath);
+      else files.push(filePath);
+    }
+  }
+  const hash = createHash('sha256');
+  for (const filePath of files.sort()) {
+    hash.update(filePath.slice(root.length).replaceAll('\\', '/'));
+    hash.update(readFileSync(filePath));
+  }
+  return hash.digest('hex');
+}
+
 function writeCanonicalV3Tree(
   collectionPath: string,
   definitionBody = '$kind: collection\nname: Fixture\n'
@@ -449,6 +468,16 @@ function createExportPostmanStub() {
     deleteMonitor: vi.fn().mockResolvedValue(undefined),
     configurePrivateMockRuntimeAuth: vi.fn().mockResolvedValue(0)
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
 }
 
 describe('repo sync action', () => {
@@ -832,6 +861,302 @@ describe('repo sync action', () => {
       expect(postman.getCollection).toHaveBeenCalledTimes(3);
     });
 
+    it('bounds collection acquisition to two, joins before materialization, and preserves role order', async () => {
+      const pending = new Map([
+        ['col-baseline', deferred<ReturnType<typeof createCollectionFixture>>()],
+        ['col-smoke', deferred<ReturnType<typeof createCollectionFixture>>()],
+        ['col-contract', deferred<ReturnType<typeof createCollectionFixture>>()]
+      ]);
+      let active = 0;
+      let peak = 0;
+      const postman = {
+        ...createExportPostmanStub(),
+        getCollection: vi.fn((id: string) => {
+          active += 1;
+          peak = Math.max(peak, active);
+          const request = pending.get(id)!;
+          return request.promise.finally(() => { active -= 1; });
+        })
+      };
+      const { core, infos } = createCoreStub();
+      const sync = runRepoSync(createInputs({ generateCiWorkflow: false }), {
+        ...deps(postman), core
+      });
+
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(2));
+      expect(peak).toBeGreaterThan(1);
+      expect(peak).toBeLessThanOrEqual(2);
+      expect(existsSync('postman/collections')).toBe(false);
+      pending.get('col-smoke')!.resolve(createCollectionFixture('[Smoke] core-payments'));
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(3));
+      expect(existsSync('postman/collections')).toBe(false);
+      pending.get('col-baseline')!.resolve(createCollectionFixture('core-payments'));
+      pending.get('col-contract')!.resolve(createCollectionFixture('[Contract] core-payments'));
+      await sync;
+
+      expect(readdirSync('postman/collections')).toEqual([
+        '[Contract] core-payments', '[Smoke] core-payments', 'core-payments'
+      ]);
+      expect(infos.some((line) => /collection-acquisition.*count=3.*width=2.*ms=.*status=success/.test(line))).toBe(true);
+    });
+
+    it.skipIf(process.platform === 'win32')('rechecks collection targets after acquisition before conversion can follow a swapped symlink', async () => {
+      const pending = new Map([
+        ['col-baseline', deferred<ReturnType<typeof createCollectionFixture>>()],
+        ['col-smoke', deferred<ReturnType<typeof createCollectionFixture>>()],
+        ['col-contract', deferred<ReturnType<typeof createCollectionFixture>>()]
+      ]);
+      const outside = mkdtempSync(join(tmpdir(), 'repo-sync-collection-swap-'));
+      const commitAndPush = vi.fn();
+      const postman = {
+        ...createExportPostmanStub(),
+        getCollection: vi.fn((id: string) => pending.get(id)!.promise)
+      };
+      const sync = runRepoSync(createInputs({ generateCiWorkflow: false }), {
+        ...deps(postman),
+        repoMutation: { commitAndPush } as unknown as NonNullable<RepoSyncDependencies['repoMutation']>
+      });
+
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(2));
+      mkdirSync('postman/collections', { recursive: true });
+      symlinkSync(outside, 'postman/collections/core-payments');
+      pending.get('col-baseline')!.resolve(createCollectionFixture('core-payments'));
+      pending.get('col-smoke')!.resolve(createCollectionFixture('[Smoke] core-payments'));
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(3));
+      pending.get('col-contract')!.resolve(createCollectionFixture('[Contract] core-payments'));
+
+      await expect(sync).rejects.toThrow(/collection target|artifact-dir|repository root|symlink/i);
+      expect(readdirSync(outside)).toEqual([]);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      expect(commitAndPush).not.toHaveBeenCalled();
+      rmSync(outside, { recursive: true, force: true });
+    });
+
+    it('drains active collection reads after a failure without scheduling later acquisition or materialization', async () => {
+      const baseline = deferred<ReturnType<typeof createCollectionFixture>>();
+      const smoke = deferred<ReturnType<typeof createCollectionFixture>>();
+      const commitAndPush = vi.fn();
+      const postman = {
+        ...createExportPostmanStub(),
+        getCollection: vi.fn((id: string) => id === 'col-baseline' ? baseline.promise : smoke.promise)
+      };
+      const { core, infos } = createCoreStub();
+      const sync = runRepoSync(createInputs({ generateCiWorkflow: false }), {
+        ...deps(postman),
+        core,
+        repoMutation: { commitAndPush } as unknown as NonNullable<RepoSyncDependencies['repoMutation']>
+      });
+      let rejected = false;
+      void sync.catch(() => { rejected = true; });
+
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(2));
+      baseline.reject(new Error('baseline export denied'));
+      await Promise.resolve();
+      expect(rejected).toBe(false);
+      expect(postman.getCollection).not.toHaveBeenCalledWith('col-contract');
+      expect(existsSync('postman/collections')).toBe(false);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      expect(existsSync('.postman/workflows.yaml')).toBe(false);
+      expect(commitAndPush).not.toHaveBeenCalled();
+
+      smoke.resolve(createCollectionFixture('[Smoke] core-payments'));
+      await expect(sync).rejects.toThrow('baseline export denied');
+      expect(rejected).toBe(true);
+      expect(postman.getCollection).toHaveBeenCalledTimes(2);
+      expect(infos.some((line) => /collection-acquisition.*count=3.*width=2.*ms=.*status=failed/.test(line))).toBe(true);
+    });
+
+    it('reports the lowest-index collection failure after draining concurrent rejections', async () => {
+      const baseline = deferred<ReturnType<typeof createCollectionFixture>>();
+      const smoke = deferred<ReturnType<typeof createCollectionFixture>>();
+      const commitAndPush = vi.fn();
+      const postman = {
+        ...createExportPostmanStub(),
+        getCollection: vi.fn((id: string) => id === 'col-baseline' ? baseline.promise : smoke.promise)
+      };
+      const sync = runRepoSync(createInputs({ generateCiWorkflow: false }), {
+        ...deps(postman),
+        repoMutation: { commitAndPush } as unknown as NonNullable<RepoSyncDependencies['repoMutation']>
+      });
+      let settled = false;
+      const observed = sync.then(
+        () => new Error('runRepoSync unexpectedly resolved'),
+        (error: unknown) => error
+      );
+      void observed.then(() => { settled = true; });
+
+      await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(2));
+      smoke.reject(new Error('smoke export denied first'));
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(postman.getCollection).not.toHaveBeenCalledWith('col-contract');
+      expect(existsSync('postman/collections')).toBe(false);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      expect(existsSync('.postman/workflows.yaml')).toBe(false);
+      expect(commitAndPush).not.toHaveBeenCalled();
+
+      baseline.reject(new Error('baseline export denied second'));
+      const error = await observed;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('baseline export denied second');
+      expect(postman.getCollection).toHaveBeenCalledTimes(2);
+      expect(existsSync('postman/collections')).toBe(false);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      expect(existsSync('.postman/workflows.yaml')).toBe(false);
+      expect(commitAndPush).not.toHaveBeenCalled();
+    });
+
+    it('drains active environment reads after a failure without scheduling the mock read or writing state', async () => {
+      const prod = deferred<{ values: Array<{ key: string; value: string }> }>();
+      const stage = deferred<{ values: Array<{ key: string; value: string }> }>();
+      const postman = {
+        ...createExportPostmanStub(),
+        findEnvironmentByName: vi.fn().mockResolvedValue(null),
+        createEnvironment: vi.fn((_workspaceId: string, name: string) =>
+          Promise.resolve(name.endsWith(' - Mock') ? 'env-mock' : `env-${name.split(' ').at(-1)}`)
+        ),
+        getEnvironment: vi.fn((id: string) => id === 'env-prod' ? prod.promise : stage.promise)
+      };
+      const { core, infos } = createCoreStub();
+      const sync = runRepoSync(createInputs({
+        generateCiWorkflow: false,
+        environmentSyncEnabled: false,
+        mockEnvironmentEnabled: true,
+        repoWriteMode: 'none'
+      }), { ...deps(postman), core });
+      let rejected = false;
+      void sync.catch(() => { rejected = true; });
+
+      await vi.waitFor(() => expect(postman.getEnvironment).toHaveBeenCalledTimes(2));
+      expect(postman.getEnvironment.mock.calls.map(([id]) => id)).toEqual(['env-prod', 'env-stage']);
+      prod.reject(new Error('prod environment denied'));
+      await Promise.resolve();
+      expect(rejected).toBe(false);
+      expect(postman.getEnvironment).not.toHaveBeenCalledWith('env-mock');
+      expect(existsSync('postman/environments/prod.postman_environment.json')).toBe(false);
+      expect(existsSync('postman/mocks/manual-validation.postman_environment.json')).toBe(false);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+
+      stage.resolve({ values: [{ key: 'stage', value: 'two' }] });
+      await expect(sync).rejects.toThrow('prod environment denied');
+      expect(rejected).toBe(true);
+      expect(postman.getEnvironment).toHaveBeenCalledTimes(2);
+      expect(infos.some((line) => /environment-artifact-acquisition.*count=3.*width=2.*ms=.*status=failed/.test(line))).toBe(true);
+    });
+
+    it('materializes byte-identical artifacts when the same collection payloads complete in opposite orders', async () => {
+      async function syncWithCompletionOrder(directory: string, first: 'baseline' | 'smoke') {
+        mkdirSync(directory);
+        process.chdir(directory);
+        const pending = new Map([
+          ['col-baseline', deferred<ReturnType<typeof createCollectionFixture>>()],
+          ['col-smoke', deferred<ReturnType<typeof createCollectionFixture>>()],
+          ['col-contract', deferred<ReturnType<typeof createCollectionFixture>>()]
+        ]);
+        const postman = {
+          ...createExportPostmanStub(),
+          getCollection: vi.fn((id: string) => pending.get(id)!.promise)
+        };
+        const sync = runRepoSync(createInputs({ generateCiWorkflow: false, repoWriteMode: 'none' }), deps(postman));
+        await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(2));
+        pending.get(first === 'baseline' ? 'col-baseline' : 'col-smoke')!.resolve(
+          createCollectionFixture(first === 'baseline' ? 'core-payments' : '[Smoke] core-payments')
+        );
+        await vi.waitFor(() => expect(postman.getCollection).toHaveBeenCalledTimes(3));
+        pending.get('col-contract')!.resolve(createCollectionFixture('[Contract] core-payments'));
+        pending.get(first === 'baseline' ? 'col-smoke' : 'col-baseline')!.resolve(
+          createCollectionFixture(first === 'baseline' ? '[Smoke] core-payments' : 'core-payments')
+        );
+        await sync;
+        return {
+          digest: artifactTreeDigest(),
+          resources: readFileSync('.postman/resources.yaml')
+        };
+      }
+
+      const first = await syncWithCompletionOrder('completion-baseline-first', 'baseline');
+      process.chdir(testDir);
+      const second = await syncWithCompletionOrder('completion-smoke-first', 'smoke');
+      expect(second.digest).toBe(first.digest);
+      expect(second.resources).toEqual(first.resources);
+    });
+
+    it('joins bounded environment acquisition before writes in finalized serial env spec order despite reverse read completion', async () => {
+      const pending = new Map([
+        ['env-prod', deferred<{ values: Array<{ key: string; value: string }> }>()],
+        ['env-stage', deferred<{ values: Array<{ key: string; value: string }> }>()],
+        ['env-mock', deferred<{ values: Array<{ key: string; value: string }> }>()]
+      ]);
+      let active = 0;
+      let peak = 0;
+      const postman = {
+        ...createExportPostmanStub(),
+        createEnvironment: vi.fn((_workspaceId: string, name: string) =>
+          Promise.resolve(name.endsWith(' - Mock') ? 'env-mock' : name.endsWith('prod') ? 'env-prod' : 'env-stage')
+        ),
+        getEnvironment: vi.fn((id: string) => {
+          active += 1;
+          peak = Math.max(peak, active);
+          return pending.get(id)!.promise.finally(() => { active -= 1; });
+        })
+      };
+      const { core, infos } = createCoreStub();
+      const sync = runRepoSync(createInputs({
+        generateCiWorkflow: false,
+        environmentSyncEnabled: false,
+        mockEnvironmentEnabled: true,
+        repoWriteMode: 'none'
+      }), {
+        ...deps(postman), core
+      });
+      await vi.waitFor(() => expect(postman.getEnvironment).toHaveBeenCalledTimes(2));
+      // The finalized serial env spec order is prod, stage, mock; reads may complete out of order.
+      expect(postman.getEnvironment.mock.calls.map(([id]) => id)).toEqual(['env-prod', 'env-stage']);
+      expect(peak).toBeGreaterThan(1);
+      expect(peak).toBeLessThanOrEqual(2);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      pending.get('env-stage')!.resolve({ values: [{ key: 'stage', value: 'two' }] });
+      await vi.waitFor(() => expect(postman.getEnvironment).toHaveBeenCalledTimes(3));
+      expect(postman.getEnvironment.mock.calls.map(([id]) => id)).toEqual(['env-prod', 'env-stage', 'env-mock']);
+      expect(existsSync('postman/environments/prod.postman_environment.json')).toBe(false);
+      expect(existsSync('postman/mocks/manual-validation.postman_environment.json')).toBe(false);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      pending.get('env-prod')!.resolve({ values: [{ key: 'prod', value: 'one' }] });
+      pending.get('env-mock')!.resolve({ values: [{ key: 'mock', value: 'three' }] });
+      await sync;
+      expect(readFileSync('postman/environments/prod.postman_environment.json', 'utf8')).toContain('prod');
+      expect(readFileSync('postman/environments/stage.postman_environment.json', 'utf8')).toContain('stage');
+      expect(readFileSync('postman/mocks/manual-validation.postman_environment.json', 'utf8')).toContain('mock');
+      expect(infos.some((line) => /environment-artifact-acquisition.*count=3.*width=2.*ms=.*status=success/.test(line))).toBe(true);
+    });
+
+    it.skipIf(process.platform === 'win32')('rechecks environment targets after acquisition before a swapped symlink can receive a write', async () => {
+      const prod = deferred<{ values: Array<{ key: string; value: string }> }>();
+      const stage = deferred<{ values: Array<{ key: string; value: string }> }>();
+      const outside = mkdtempSync(join(tmpdir(), 'repo-sync-environment-swap-'));
+      const commitAndPush = vi.fn();
+      const postman = {
+        ...createExportPostmanStub(),
+        getEnvironment: vi.fn((id: string) => id === 'env-prod' ? prod.promise : stage.promise)
+      };
+      const sync = runRepoSync(createInputs({ generateCiWorkflow: false }), {
+        ...deps(postman),
+        repoMutation: { commitAndPush } as unknown as NonNullable<RepoSyncDependencies['repoMutation']>
+      });
+
+      await vi.waitFor(() => expect(postman.getEnvironment).toHaveBeenCalledTimes(2));
+      mkdirSync('postman/environments', { recursive: true });
+      symlinkSync(outside, 'postman/environments/prod.postman_environment.json');
+      prod.resolve({ values: [{ key: 'prod', value: 'one' }] });
+      stage.resolve({ values: [{ key: 'stage', value: 'two' }] });
+
+      await expect(sync).rejects.toThrow(/environment target|repository root|symlink/i);
+      expect(readdirSync(outside)).toEqual([]);
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+      expect(commitAndPush).not.toHaveBeenCalled();
+      rmSync(outside, { recursive: true, force: true });
+    });
+
     it('reuses an exact digest-bound canonical tree without cloud get/export', async () => {
       const baseline = writeCanonicalV3Tree('postman/collections/core-payments');
       const smoke = writeCanonicalV3Tree('postman/collections/[Smoke] core-payments');
@@ -873,6 +1198,68 @@ describe('repo sync action', () => {
       expect(readFileSync('postman/collections/core-payments/Folder/Event.message.yaml', 'utf8')).toContain('$kind: websocket-message');
     });
 
+    it('reuses exact baseline and contract trees while freshly exporting an omitted smoke role', async () => {
+      const baselinePath = 'postman/collections/core-payments';
+      const smokePath = 'postman/collections/[Smoke] core-payments';
+      const contractPath = 'postman/collections/[Contract] core-payments';
+      const baseline = writeCanonicalV3Tree(baselinePath);
+      const contract = writeCanonicalV3Tree(contractPath);
+      writeCanonicalV3Tree(smokePath);
+      writeFileSync(join(smokePath, 'StaleSmokeOnly.request.yaml'), '$kind: http-request\nmethod: GET\n', 'utf8');
+      const freshSmoke = createCollectionFixture('[Smoke] core-payments');
+      freshSmoke.item.push({
+        name: 'Fresh Smoke Only',
+        request: {
+          method: 'GET',
+          url: { raw: 'https://api.example.com/fresh-smoke', query: [] }
+        }
+      });
+      const postman = {
+        ...createExportPostmanStub(),
+        getCollection: vi.fn((id: string) => {
+          if (id !== 'col-smoke') throw new Error(`unexpected collection export: ${id}`);
+          return Promise.resolve(freshSmoke);
+        })
+      };
+      const baselineBefore = artifactTreeDigest(baselinePath);
+      const contractBefore = artifactTreeDigest(contractPath);
+
+      await runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([
+            {
+              role: 'baseline',
+              collectionPath: baselinePath,
+              cloudId: 'col-baseline',
+              artifactDigest: baseline.artifactDigest
+            },
+            {
+              role: 'contract',
+              collectionPath: contractPath,
+              cloudId: 'col-contract',
+              artifactDigest: contract.artifactDigest
+            }
+          ])
+        }),
+        deps(postman)
+      );
+
+      expect(postman.getCollection).toHaveBeenCalledTimes(1);
+      expect(postman.getCollection).toHaveBeenCalledWith('col-smoke');
+      expect(artifactTreeDigest(baselinePath)).toBe(baselineBefore);
+      expect(artifactTreeDigest(contractPath)).toBe(contractBefore);
+      expect(existsSync(join(smokePath, 'Fresh Smoke Only.request.yaml'))).toBe(true);
+      expect(existsSync(join(smokePath, 'StaleSmokeOnly.request.yaml'))).toBe(false);
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(Object.entries(resources.canonical?.collections ?? {})).toEqual([
+        ['../postman/collections/core-payments', 'col-baseline'],
+        ['../postman/collections/[Smoke] core-payments', 'col-smoke'],
+        ['../postman/collections/[Contract] core-payments', 'col-contract']
+      ]);
+    });
+
     it.each([
       ['legacy filename', 'collection.yaml', '$kind: collection\n'],
       ['missing kind', 'Broken.request.yaml', 'method: GET\n'],
@@ -911,6 +1298,7 @@ describe('repo sync action', () => {
 
     it('cloud-exports when digest, path, role name, or cloud ID mismatches', async () => {
       const baseline = writeCanonicalV3Tree('postman/collections/core-payments');
+      writeFileSync('postman/collections/core-payments/Stale.request.yaml', '$kind: http-request\nmethod: GET\n', 'utf8');
       writeCanonicalV3Tree('postman/collections/[Smoke] core-payments');
       writeCanonicalV3Tree('postman/collections/[Contract] core-payments');
       const postman = createExportPostmanStub();
@@ -950,6 +1338,8 @@ describe('repo sync action', () => {
       expect(postman.getCollection).toHaveBeenCalledWith('col-baseline');
       expect(postman.getCollection).toHaveBeenCalledWith('col-smoke');
       expect(postman.getCollection).toHaveBeenCalledWith('col-contract');
+      expect(existsSync('postman/collections/core-payments/Stale.request.yaml')).toBe(false);
+      expect(readFileSync('postman/collections/core-payments/.resources/definition.yaml', 'utf8')).toContain('$kind: collection');
     });
 
     it.each([
@@ -1235,7 +1625,33 @@ describe('repo sync action', () => {
       expect(postman.getCollection).not.toHaveBeenCalledWith('col-baseline');
     }, 60_000);
 
-    it('accepts >64 nested depth when the host permits', async () => {
+    it('rejects prebuilt trees over the 10,000 directory-and-file traversal-entry budget before cloud export', async () => {
+      const root = 'postman/collections/core-payments';
+      const fixture = writeCanonicalV3Tree(root);
+      for (let index = 0; index < 10_000; index += 1) {
+        mkdirSync(join(root, `entry-${index}`));
+      }
+      const postman = createExportPostmanStub();
+
+      await expect(runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([{
+            role: 'baseline',
+            collectionPath: root,
+            cloudId: 'col-baseline',
+            artifactDigest: fixture.artifactDigest
+          }])
+        }),
+        deps(postman)
+      )).rejects.toThrow(/CONTRACT_PREBUILT_COLLECTIONS_INVALID:.*10000.*traversal-entry/i);
+
+      expect(postman.getCollection).not.toHaveBeenCalled();
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+    }, 120_000);
+
+    it('reuses an exact prebuilt baseline with 70 nested directories and no baseline GET', async () => {
       const root = 'postman/collections/core-payments';
       const fixture = writeCanonicalV3Tree(root);
       writeCanonicalV3Tree('postman/collections/[Smoke] core-payments');
@@ -1253,8 +1669,6 @@ describe('repo sync action', () => {
         }
         throw error;
       }
-      // Empty nested dirs prove depth acceptance without changing the file digest.
-      const artifactDigest = fixture.artifactDigest;
       const postman = createExportPostmanStub();
 
       await runRepoSync(
@@ -1266,35 +1680,7 @@ describe('repo sync action', () => {
               role: 'baseline',
               collectionPath: root,
               cloudId: 'col-baseline',
-              artifactDigest
-            }
-          ])
-        }),
-        deps(postman)
-      );
-
-      expect(postman.getCollection).not.toHaveBeenCalledWith('col-baseline');
-    }, 60_000);
-
-    it('accepts a >25 MiB valid YAML file written in chunks without cloud export', async () => {
-      const root = 'postman/collections/core-payments';
-      writeCanonicalV3Tree(root);
-      writeCanonicalV3Tree('postman/collections/[Smoke] core-payments');
-      writeCanonicalV3Tree('postman/collections/[Contract] core-payments');
-      writeLargeCanonicalRequestYaml(join(root, 'Huge.request.yaml'), 25 * 1024 * 1024 + 1024);
-      const artifactDigest = await digestTreeOnDisk(root);
-      const postman = createExportPostmanStub();
-
-      await runRepoSync(
-        createInputs({
-          environments: ['prod'],
-          generateCiWorkflow: false,
-          prebuiltCollectionsJson: buildPrebuiltManifest([
-            {
-              role: 'baseline',
-              collectionPath: root,
-              cloudId: 'col-baseline',
-              artifactDigest
+              artifactDigest: fixture.artifactDigest
             }
           ])
         }),
@@ -1303,7 +1689,130 @@ describe('repo sync action', () => {
 
       expect(postman.getCollection).not.toHaveBeenCalledWith('col-baseline');
       expect(postman.getCollection).toHaveBeenCalledTimes(2);
+    }, 60_000);
+
+    it('reuses a 25 MiB+1 KiB valid request YAML by streaming its digest without whole-tree buffering', async () => {
+      const root = 'postman/collections/core-payments';
+      writeCanonicalV3Tree(root);
+      writeCanonicalV3Tree('postman/collections/[Smoke] core-payments');
+      writeCanonicalV3Tree('postman/collections/[Contract] core-payments');
+      writeLargeCanonicalRequestYaml(join(root, 'Huge.request.yaml'), 25 * 1024 * 1024 + 1024);
+      const artifactDigest = await digestTreeOnDisk(root);
+      const postman = createExportPostmanStub();
+      const beforeHeap = process.memoryUsage().heapUsed;
+
+      await runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([
+            {
+              role: 'baseline',
+              collectionPath: root,
+              cloudId: 'col-baseline',
+              artifactDigest
+            }
+          ])
+        }),
+        deps(postman)
+      );
+
+      const heapDelta = process.memoryUsage().heapUsed - beforeHeap;
+      expect(postman.getCollection).not.toHaveBeenCalledWith('col-baseline');
+      expect(heapDelta).toBeLessThan(32 * 1024 * 1024);
     }, 180_000);
+
+    it('rejects prebuilt trees deeper than 128 before cloud export or artifact mutation', async () => {
+      const root = 'postman/collections/core-payments';
+      const fixture = writeCanonicalV3Tree(root);
+      let current = root;
+      try {
+        for (let depth = 0; depth < 129; depth += 1) {
+          current = join(current, 'n');
+          mkdirSync(current);
+        }
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'ENAMETOOLONG' || code === 'ENOENT') {
+          return;
+        }
+        throw error;
+      }
+      const postman = createExportPostmanStub();
+
+      await expect(runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([{
+            role: 'baseline',
+            collectionPath: root,
+            cloudId: 'col-baseline',
+            artifactDigest: fixture.artifactDigest
+          }])
+        }),
+        deps(postman)
+      )).rejects.toThrow(/CONTRACT_PREBUILT_COLLECTIONS_INVALID:.*128.*depth/i);
+
+      expect(postman.getCollection).not.toHaveBeenCalled();
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+    }, 60_000);
+
+    it('rejects an individual prebuilt file over 32 MiB before cloud export or artifact mutation', async () => {
+      const root = 'postman/collections/core-payments';
+      writeCanonicalV3Tree(root);
+      writeLargeCanonicalRequestYaml(join(root, 'Huge.request.yaml'), 32 * 1024 * 1024 + 1024);
+      const postman = createExportPostmanStub();
+
+      await expect(runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([
+            {
+              role: 'baseline',
+              collectionPath: root,
+              cloudId: 'col-baseline',
+              artifactDigest: sha256Hex('oversized-file')
+            }
+          ])
+        }),
+        deps(postman)
+      )).rejects.toThrow(/CONTRACT_PREBUILT_COLLECTIONS_INVALID:.*32 MiB/i);
+
+      expect(postman.getCollection).not.toHaveBeenCalled();
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+    }, 180_000);
+
+    it('rejects prebuilt trees over the 100 MiB aggregate budget before reading their sparse files', async () => {
+      const root = 'postman/collections/core-payments';
+      const fixture = writeCanonicalV3Tree(root);
+      const sparseFileBytes = Math.floor(9.5 * 1024 * 1024);
+      for (let index = 0; index < 11; index += 1) {
+        const file = join(root, `aggregate-${index}.request.yaml`);
+        const fd = openSync(file, 'w');
+        writeSync(fd, Buffer.from('x'), 0, 1, sparseFileBytes - 1);
+        closeSync(fd);
+      }
+      const postman = createExportPostmanStub();
+
+      await expect(runRepoSync(
+        createInputs({
+          environments: ['prod'],
+          generateCiWorkflow: false,
+          prebuiltCollectionsJson: buildPrebuiltManifest([{
+            role: 'baseline',
+            collectionPath: root,
+            cloudId: 'col-baseline',
+            artifactDigest: fixture.artifactDigest
+          }])
+        }),
+        deps(postman)
+      )).rejects.toThrow(/CONTRACT_PREBUILT_COLLECTIONS_INVALID:.*100 MiB.*total-byte/i);
+
+      expect(postman.getCollection).not.toHaveBeenCalled();
+      expect(existsSync('.postman/resources.yaml')).toBe(false);
+    });
 
     it('accepts a >64 KiB semantically valid prebuilt manifest', async () => {
       const root = 'postman/collections/core-payments';
@@ -1923,9 +2432,9 @@ describe('repo sync action', () => {
       ).rejects.toThrow(/PRIVATE_MOCK_AUTH_ROOT_UNVERIFIED.*smoke.*col-smoke/);
 
       assertRepoArtifactSnapshotUnchanged(artifactSnapshotBefore);
-      expect(postman.getCollection).toHaveBeenCalledTimes(1);
+      expect(postman.getCollection).toHaveBeenCalledTimes(2);
       expect(postman.getCollection).toHaveBeenCalledWith('col-smoke');
-      expect(postman.getCollection).not.toHaveBeenCalledWith('col-contract');
+      expect(postman.getCollection).toHaveBeenCalledWith('col-contract');
       expect(commitAndPush).not.toHaveBeenCalled();
       expect(existsSync('.postman/resources.yaml')).toBe(false);
       expect(existsSync('postman/globals/workspace.globals.yaml')).toBe(false);

--- a/tests/verify-dist-artifact.test.ts
+++ b/tests/verify-dist-artifact.test.ts
@@ -23,6 +23,7 @@ const verifyScript = path.join(repoRoot, 'scripts', 'verify-dist-artifact.mjs');
 /** Read-only git must not block on concurrent index.lock under multi-agent host load. */
 const gitReadEnv = { ...process.env, GIT_OPTIONAL_LOCKS: '0', PATH: process.env.PATH ?? '' };
 const COMMITTED_DIST_PATHS = ['dist', 'package.json', 'action.yml'] as const;
+const SHIPPED_ENTRYPOINTS = ['dist/index.cjs', 'dist/action.cjs', 'dist/cli.cjs'] as const;
 
 type OnTestFinished = (fn: () => void | Promise<void>) => void;
 
@@ -169,6 +170,32 @@ async function runVerify(root: string): Promise<{ code: number; stdout: string; 
 }
 
 describe('verify-dist-artifact canonical contract', () => {
+  it('ships bounded collection and environment acquisition before resources state materialization', async () => {
+    for (const entrypoint of SHIPPED_ENTRYPOINTS) {
+      const bundle = await readFile(path.join(repoRoot, entrypoint), 'utf8');
+      const collectionAcquisition = bundle.indexOf('collection-acquisition count=');
+      const environmentAcquisition = bundle.indexOf('environment-artifact-acquisition count=');
+      const resourcesMaterialization = bundle.indexOf(
+        'writeFileSync)(".postman/resources.yaml", buildResourcesManifest('
+      );
+
+      expect(collectionAcquisition, entrypoint).toBeGreaterThanOrEqual(0);
+      expect(environmentAcquisition, entrypoint).toBeGreaterThan(collectionAcquisition);
+      expect(resourcesMaterialization, entrypoint).toBeGreaterThan(environmentAcquisition);
+      expect(bundle, entrypoint).toContain('var ARTIFACT_ACQUISITION_WIDTH = 2;');
+      expect(bundle, entrypoint).toContain('async function runBoundedInOrder(items, width, worker)');
+      expect(bundle, entrypoint).toContain(
+        'Array.from({ length: Math.min(width, items.length) }, () => runWorker())'
+      );
+      expect(bundle, entrypoint).toContain(
+        'collectionSpecs,\n      ARTIFACT_ACQUISITION_WIDTH,\n      (spec) => acquireCollectionArtifact('
+      );
+      expect(bundle, entrypoint).toContain(
+        'environmentSpecs,\n      ARTIFACT_ACQUISITION_WIDTH,\n      (spec) => dependencies.postman.getEnvironment(spec.envUid)'
+      );
+    }
+  });
+
   it('passes against the committed dist artifact', async ({ onTestFinished }) => {
     const snapshotRoot = await makeTempDir('verify-dist-committed-', onTestFinished);
     await materializeCommittedDistSnapshot(snapshotRoot);


### PR DESCRIPTION
## Summary

Repo sync acquired each cloud collection and environment artifact in a serial read-and-write sequence, even though local writes don't depend on read completion order. The action now acquires independent payloads at width 2, joins them, and materializes artifacts in the same deterministic order as before.

The deterministic three-role and three-environment fixtures reduce serial read waves from 3 to 2 at width 2. This is a round-trip wave-count result, not a latency claim.

## What changed

- Acquire Baseline, Smoke, and Contract payloads through an indexed width-2 pool, then convert them serially in role order.
- Keep private-mock hook preparation ahead of collection acquisition and force fresh Smoke/Contract payloads where required.
- Acquire finalized environment payloads at width 2, then write the original filenames in the original order before the single resources state write.
- Stop dequeuing after an acquisition failure, drain active reads, and surface the lowest input-index error deterministically.
- Emit collection and environment acquisition phase timings without resource IDs or secrets.
- Recheck path containment immediately before artifact/state mutation and bound prebuilt-tree traversal while preserving existing large/deep tree support.
- Align the artifact-layout and payload-digest contracts with the shipped Collection v3/state v2 behavior.

## Safety

Write and mutation concurrency remains 1. Collection conversion, environment files, resources/workflow state, and Git mutation all stay behind their read joins.

Fetch failures produce no collection materialization, resources manifest, or Git commit. Exact prebuilt reuse remains read-only, stale cleanup stays owned by the existing converter, and partial Smoke invalidation fetches only the fresh Smoke payload.

## Validation

- `npm test` (704 main-shard tests, 38 CI-template tests, 13 dispatch tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:dist:assert`
- `actionlint`
- `npm run test:e2e:smoke:nonorg` in the guarded live sandbox: 3/3 spine checks passed, zero 429/retry events, and run-scoped teardown completed without errors
