### PR TITLE
fix(repo-mutation): reconcile stale branch before push

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -114484,7 +114484,7 @@ var RepoMutationService = class {
       "-m",
       "chore: sync Postman artifacts and metadata"
     ]);
-    const commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+    let commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
     if (options.repoWriteMode !== "commit-and-push") {
       return {
         commitSha,
@@ -114496,6 +114496,7 @@ var RepoMutationService = class {
     let pushed = false;
     let lastError = "";
     let remoteChanged = false;
+    let stopCandidates = false;
     const isNonRetryablePushError = (message) => /workflow|permission/i.test(message);
     try {
       const pushCandidates = usePersistedCredentials ? [null] : tokens;
@@ -114515,18 +114516,54 @@ var RepoMutationService = class {
           ]);
           remoteChanged = true;
         }
-        const push = await this.execute("git", [
-          ...resetConfigArgs,
-          "push",
-          "origin",
-          `HEAD:refs/heads/${resolvedCurrentRef}`
-        ]);
-        if (push.exitCode === 0) {
-          pushed = true;
-          break;
+        for (let pushAttempt = 0; pushAttempt < 2; pushAttempt += 1) {
+          const fetch2 = await this.execute("git", [
+            ...resetConfigArgs,
+            "fetch",
+            "--no-tags",
+            "origin",
+            `refs/heads/${resolvedCurrentRef}`
+          ]);
+          const fetchError = fetch2.stderr || fetch2.stdout || "";
+          const targetBranchDoesNotExist = /couldn't find remote ref|remote ref .* not found/i.test(
+            fetchError
+          );
+          if (fetch2.exitCode !== 0 && !targetBranchDoesNotExist) {
+            lastError = fetchError;
+            stopCandidates = isNonRetryablePushError(lastError);
+            break;
+          }
+          if (fetch2.exitCode === 0) {
+            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            if (rebase.exitCode !== 0) {
+              await this.execute("git", ["rebase", "--abort"]);
+              const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";
+              throw new Error(
+                secretMasker(
+                  `REPO_PUSH_RECONCILE_FAILED: Could not rebase generated changes onto ${resolvedCurrentRef}: ${cause}`
+                )
+              );
+            }
+            commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+          }
+          const push = await this.execute("git", [
+            ...resetConfigArgs,
+            "push",
+            "origin",
+            `HEAD:refs/heads/${resolvedCurrentRef}`
+          ]);
+          if (push.exitCode === 0) {
+            pushed = true;
+            break;
+          }
+          lastError = push.stderr || push.stdout || "";
+          stopCandidates = isNonRetryablePushError(lastError);
+          const targetAdvanced = /non-fast-forward|fetch first|remote contains work/i.test(lastError);
+          if (stopCandidates || !targetAdvanced) {
+            break;
+          }
         }
-        lastError = push.stderr || push.stdout || "";
-        if (isNonRetryablePushError(lastError)) {
+        if (pushed || stopCandidates) {
           break;
         }
       }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -112589,7 +112589,7 @@ var RepoMutationService = class {
       "-m",
       "chore: sync Postman artifacts and metadata"
     ]);
-    const commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+    let commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
     if (options.repoWriteMode !== "commit-and-push") {
       return {
         commitSha,
@@ -112601,6 +112601,7 @@ var RepoMutationService = class {
     let pushed = false;
     let lastError = "";
     let remoteChanged = false;
+    let stopCandidates = false;
     const isNonRetryablePushError = (message) => /workflow|permission/i.test(message);
     try {
       const pushCandidates = usePersistedCredentials ? [null] : tokens;
@@ -112620,18 +112621,54 @@ var RepoMutationService = class {
           ]);
           remoteChanged = true;
         }
-        const push = await this.execute("git", [
-          ...resetConfigArgs,
-          "push",
-          "origin",
-          `HEAD:refs/heads/${resolvedCurrentRef}`
-        ]);
-        if (push.exitCode === 0) {
-          pushed = true;
-          break;
+        for (let pushAttempt = 0; pushAttempt < 2; pushAttempt += 1) {
+          const fetch2 = await this.execute("git", [
+            ...resetConfigArgs,
+            "fetch",
+            "--no-tags",
+            "origin",
+            `refs/heads/${resolvedCurrentRef}`
+          ]);
+          const fetchError = fetch2.stderr || fetch2.stdout || "";
+          const targetBranchDoesNotExist = /couldn't find remote ref|remote ref .* not found/i.test(
+            fetchError
+          );
+          if (fetch2.exitCode !== 0 && !targetBranchDoesNotExist) {
+            lastError = fetchError;
+            stopCandidates = isNonRetryablePushError(lastError);
+            break;
+          }
+          if (fetch2.exitCode === 0) {
+            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            if (rebase.exitCode !== 0) {
+              await this.execute("git", ["rebase", "--abort"]);
+              const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";
+              throw new Error(
+                secretMasker(
+                  `REPO_PUSH_RECONCILE_FAILED: Could not rebase generated changes onto ${resolvedCurrentRef}: ${cause}`
+                )
+              );
+            }
+            commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+          }
+          const push = await this.execute("git", [
+            ...resetConfigArgs,
+            "push",
+            "origin",
+            `HEAD:refs/heads/${resolvedCurrentRef}`
+          ]);
+          if (push.exitCode === 0) {
+            pushed = true;
+            break;
+          }
+          lastError = push.stderr || push.stdout || "";
+          stopCandidates = isNonRetryablePushError(lastError);
+          const targetAdvanced = /non-fast-forward|fetch first|remote contains work/i.test(lastError);
+          if (stopCandidates || !targetAdvanced) {
+            break;
+          }
         }
-        lastError = push.stderr || push.stdout || "";
-        if (isNonRetryablePushError(lastError)) {
+        if (pushed || stopCandidates) {
           break;
         }
       }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -114507,7 +114507,7 @@ var RepoMutationService = class {
       "-m",
       "chore: sync Postman artifacts and metadata"
     ]);
-    const commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+    let commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
     if (options.repoWriteMode !== "commit-and-push") {
       return {
         commitSha,
@@ -114519,6 +114519,7 @@ var RepoMutationService = class {
     let pushed = false;
     let lastError = "";
     let remoteChanged = false;
+    let stopCandidates = false;
     const isNonRetryablePushError = (message) => /workflow|permission/i.test(message);
     try {
       const pushCandidates = usePersistedCredentials ? [null] : tokens;
@@ -114538,18 +114539,54 @@ var RepoMutationService = class {
           ]);
           remoteChanged = true;
         }
-        const push = await this.execute("git", [
-          ...resetConfigArgs,
-          "push",
-          "origin",
-          `HEAD:refs/heads/${resolvedCurrentRef}`
-        ]);
-        if (push.exitCode === 0) {
-          pushed = true;
-          break;
+        for (let pushAttempt = 0; pushAttempt < 2; pushAttempt += 1) {
+          const fetch2 = await this.execute("git", [
+            ...resetConfigArgs,
+            "fetch",
+            "--no-tags",
+            "origin",
+            `refs/heads/${resolvedCurrentRef}`
+          ]);
+          const fetchError = fetch2.stderr || fetch2.stdout || "";
+          const targetBranchDoesNotExist = /couldn't find remote ref|remote ref .* not found/i.test(
+            fetchError
+          );
+          if (fetch2.exitCode !== 0 && !targetBranchDoesNotExist) {
+            lastError = fetchError;
+            stopCandidates = isNonRetryablePushError(lastError);
+            break;
+          }
+          if (fetch2.exitCode === 0) {
+            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            if (rebase.exitCode !== 0) {
+              await this.execute("git", ["rebase", "--abort"]);
+              const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";
+              throw new Error(
+                secretMasker(
+                  `REPO_PUSH_RECONCILE_FAILED: Could not rebase generated changes onto ${resolvedCurrentRef}: ${cause}`
+                )
+              );
+            }
+            commitSha = (await this.execute("git", ["rev-parse", "HEAD"])).stdout.trim();
+          }
+          const push = await this.execute("git", [
+            ...resetConfigArgs,
+            "push",
+            "origin",
+            `HEAD:refs/heads/${resolvedCurrentRef}`
+          ]);
+          if (push.exitCode === 0) {
+            pushed = true;
+            break;
+          }
+          lastError = push.stderr || push.stdout || "";
+          stopCandidates = isNonRetryablePushError(lastError);
+          const targetAdvanced = /non-fast-forward|fetch first|remote contains work/i.test(lastError);
+          if (stopCandidates || !targetAdvanced) {
+            break;
+          }
         }
-        lastError = push.stderr || push.stdout || "";
-        if (isNonRetryablePushError(lastError)) {
+        if (pushed || stopCandidates) {
           break;
         }
       }

--- a/src/lib/github/repo-mutation.ts
+++ b/src/lib/github/repo-mutation.ts
@@ -330,7 +330,7 @@ export class RepoMutationService {
       '-m',
       'chore: sync Postman artifacts and metadata'
     ]);
-    const commitSha = (await this.execute('git', ['rev-parse', 'HEAD'])).stdout.trim();
+    let commitSha = (await this.execute('git', ['rev-parse', 'HEAD'])).stdout.trim();
 
     if (options.repoWriteMode !== 'commit-and-push') {
       return {
@@ -346,6 +346,7 @@ export class RepoMutationService {
     let pushed = false;
     let lastError = '';
     let remoteChanged = false;
+    let stopCandidates = false;
 
     const isNonRetryablePushError = (message: string): boolean =>
       /workflow|permission/i.test(message);
@@ -375,20 +376,59 @@ export class RepoMutationService {
           remoteChanged = true;
         }
 
-        const push = await this.execute('git', [
-          ...resetConfigArgs,
-          'push',
-          'origin',
-          `HEAD:refs/heads/${resolvedCurrentRef}`
-        ]);
+        for (let pushAttempt = 0; pushAttempt < 2; pushAttempt += 1) {
+          const fetch = await this.execute('git', [
+            ...resetConfigArgs,
+            'fetch',
+            '--no-tags',
+            'origin',
+            `refs/heads/${resolvedCurrentRef}`
+          ]);
+          const fetchError = fetch.stderr || fetch.stdout || '';
+          const targetBranchDoesNotExist = /couldn't find remote ref|remote ref .* not found/i.test(
+            fetchError
+          );
+          if (fetch.exitCode !== 0 && !targetBranchDoesNotExist) {
+            lastError = fetchError;
+            stopCandidates = isNonRetryablePushError(lastError);
+            break;
+          }
 
-        if (push.exitCode === 0) {
-          pushed = true;
-          break;
+          if (fetch.exitCode === 0) {
+            const rebase = await this.execute('git', ['rebase', 'FETCH_HEAD']);
+            if (rebase.exitCode !== 0) {
+              await this.execute('git', ['rebase', '--abort']);
+              const cause = rebase.stderr || rebase.stdout || 'Failed to rebase generated changes';
+              throw new Error(
+                secretMasker(
+                  `REPO_PUSH_RECONCILE_FAILED: Could not rebase generated changes onto ${resolvedCurrentRef}: ${cause}`
+                )
+              );
+            }
+            commitSha = (await this.execute('git', ['rev-parse', 'HEAD'])).stdout.trim();
+          }
+
+          const push = await this.execute('git', [
+            ...resetConfigArgs,
+            'push',
+            'origin',
+            `HEAD:refs/heads/${resolvedCurrentRef}`
+          ]);
+
+          if (push.exitCode === 0) {
+            pushed = true;
+            break;
+          }
+
+          lastError = push.stderr || push.stdout || '';
+          stopCandidates = isNonRetryablePushError(lastError);
+          const targetAdvanced = /non-fast-forward|fetch first|remote contains work/i.test(lastError);
+          if (stopCandidates || !targetAdvanced) {
+            break;
+          }
         }
 
-        lastError = push.stderr || push.stdout || '';
-        if (isNonRetryablePushError(lastError)) {
+        if (pushed || stopCandidates) {
           break;
         }
       }

--- a/tests/ci-workflow-template.test.ts
+++ b/tests/ci-workflow-template.test.ts
@@ -32,34 +32,40 @@ type ExecPwshFailure = {
 const PWSH_PATH = process.env.PWSH_PATH?.trim() || 'pwsh';
 
 function execPwsh(command: string, options: ExecPwshOptions = {}): string {
-  return execFileSync(
-    PWSH_PATH,
-    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command],
-    {
-      cwd: options.cwd,
-      env: {
-        PATH: process.env.PATH,
-        HOME: process.env.HOME,
-        // These bodies only use built-in cmdlets, so the module search path is
-        // dead weight. Pinning it empty keeps the probe hermetic: what the
-        // generated script does must not depend on which modules the machine
-        // running the suite happens to have installed. This is not a latency
-        // fix - pwsh startup stalls on its own roughly one spawn in ten, inside
-        // CLR init, with or without this pin.
-        PSModulePath: '',
-        POWERSHELL_TELEMETRY_OPTOUT: '1',
-        POWERSHELL_UPDATECHECK: 'Off',
-        DOTNET_CLI_TELEMETRY_OPTOUT: '1',
-        ...options.env
-      },
-      // Never inherit stdin: vitest workers keep a pipe open and pwsh can block on read.
-      stdio: ['ignore', 'pipe', 'pipe'],
-      encoding: 'utf8',
-      // pwsh spawn inside vitest workers can stall; scripts themselves finish in <1s.
-      timeout: 60_000,
-      killSignal: 'SIGKILL'
-    }
-  );
+  const run = (): string =>
+    execFileSync(
+      PWSH_PATH,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command],
+      {
+        cwd: options.cwd,
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          // These bodies only use built-in cmdlets, so the module search path is
+          // dead weight. Pinning it empty keeps the probe hermetic: what the
+          // generated script does must not depend on which modules the machine
+          // running the suite happens to have installed.
+          PSModulePath: '',
+          POWERSHELL_TELEMETRY_OPTOUT: '1',
+          POWERSHELL_UPDATECHECK: 'Off',
+          DOTNET_CLI_TELEMETRY_OPTOUT: '1',
+          ...options.env
+        },
+        // Never inherit stdin: vitest workers keep a pipe open and pwsh can block on read.
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+        // Scripts finish in <1s; a timeout is a known CLR-startup stall, so retry once.
+        timeout: 15_000,
+        killSignal: 'SIGKILL'
+      }
+    );
+
+  try {
+    return run();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ETIMEDOUT') throw error;
+    return run();
+  }
 }
 
 function buildFakePostmanHarness(exitCode: number): string {

--- a/tests/repo-mutation.test.ts
+++ b/tests/repo-mutation.test.ts
@@ -110,6 +110,27 @@ function createCommandMap(
         stdout: '',
         stderr: ''
       },
+    'git -c http.https://github.com/.extraheader= fetch --no-tags origin refs/heads/feature/sync-artifacts':
+      {
+        exitCode: 0,
+        stdout: '',
+        stderr: ''
+      },
+    'git fetch --no-tags origin refs/heads/feature/sync-artifacts': {
+      exitCode: 0,
+      stdout: '',
+      stderr: ''
+    },
+    'git rebase FETCH_HEAD': {
+      exitCode: 0,
+      stdout: 'Current branch is up to date.\n',
+      stderr: ''
+    },
+    'git rebase --abort': {
+      exitCode: 0,
+      stdout: '',
+      stderr: ''
+    },
     'git push origin HEAD:refs/heads/feature/sync-artifacts': {
       exitCode: 0,
       stdout: '',
@@ -452,6 +473,12 @@ describe('repo mutation helpers', () => {
             stdout: '',
             stderr: ''
         },
+        'git -c http.https://dev.azure.com/postman/.extraheader= -c http.https://dev.azure.com/postman/CSE/_git/repo-sync-demo.extraheader= fetch --no-tags origin refs/heads/feature/sync-artifacts':
+          {
+            exitCode: 0,
+            stdout: '',
+            stderr: ''
+          },
         [`git remote set-url origin ${adoRemote}`]: {
           exitCode: 0,
           stdout: '',
@@ -537,6 +564,65 @@ describe('repo mutation helpers', () => {
       'origin',
       expect.stringContaining('@dev.azure.com')
     ]);
+  });
+
+  it('creates a branch when the target ref does not exist on the remote', async () => {
+    const execute = createExecuteMock(
+      createCommandMap({
+        'git -c http.https://github.com/.extraheader= fetch --no-tags origin refs/heads/feature/sync-artifacts':
+          {
+            exitCode: 128,
+            stdout: '',
+            stderr: "fatal: couldn't find remote ref refs/heads/feature/sync-artifacts\n"
+          }
+      })
+    );
+    const repoMutation = new RepoMutationService({
+      repository: 'postman-cs/repo-sync-demo',
+      execute
+    });
+
+    const result = await repoMutation.commitAndPush({
+      repoWriteMode: 'commit-and-push',
+      currentRef: 'feature/sync-artifacts',
+      fallbackToken: 'fallback-token',
+      committerName: 'Postman',
+      committerEmail: 'support@postman.com',
+      stagePaths: ['postman', '.postman', '.github/workflows']
+    });
+
+    expect(result.pushed).toBe(true);
+    expect(execute).not.toHaveBeenCalledWith('git', ['rebase', 'FETCH_HEAD']);
+  });
+
+  it('aborts and fails closed when generated files conflict with the target branch', async () => {
+    const execute = createExecuteMock(
+      createCommandMap({
+        'git rebase FETCH_HEAD': {
+          exitCode: 1,
+          stdout: '',
+          stderr: 'CONFLICT (content): Merge conflict in postman/collection.yaml\n'
+        }
+      })
+    );
+    const repoMutation = new RepoMutationService({
+      repository: 'postman-cs/repo-sync-demo',
+      execute
+    });
+
+    await expect(
+      repoMutation.commitAndPush({
+        repoWriteMode: 'commit-and-push',
+        currentRef: 'feature/sync-artifacts',
+        fallbackToken: 'fallback-token',
+        committerName: 'Postman',
+        committerEmail: 'support@postman.com',
+        stagePaths: ['postman', '.postman', '.github/workflows']
+      })
+    ).rejects.toThrow('REPO_PUSH_RECONCILE_FAILED');
+
+    expect(execute).toHaveBeenCalledWith('git', ['rebase', '--abort']);
+    expect(execute).not.toHaveBeenCalledWith('git', expect.arrayContaining(['push']));
   });
 
   it('returns without commit when there are no staged changes', async () => {
@@ -663,6 +749,86 @@ describe('repo mutation helpers', () => {
     ]);
   });
 
+  it('rebases generated changes when the target advances before and during the push', async () => {
+    const fixtureRoot = await mkdtemp(path.join(tmpdir(), 'repo-mutation-stale-checkout-'));
+    const remoteRoot = path.join(fixtureRoot, 'remote.git');
+    const checkoutRoot = path.join(fixtureRoot, 'checkout');
+    const peerRoot = path.join(fixtureRoot, 'peer');
+    try {
+      await execFileAsync('git', ['init', '--bare', '--initial-branch=main', remoteRoot]);
+      await mkdir(checkoutRoot, { recursive: true });
+      await execFileAsync('git', ['init', '--initial-branch=main'], { cwd: checkoutRoot });
+      await execFileAsync('git', ['config', 'user.name', 'Fixture'], { cwd: checkoutRoot });
+      await execFileAsync('git', ['config', 'user.email', 'fixture@example.com'], {
+        cwd: checkoutRoot
+      });
+      await writeFile(path.join(checkoutRoot, 'README.md'), 'initial\n', 'utf8');
+      await execFileAsync('git', ['add', 'README.md'], { cwd: checkoutRoot });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: checkoutRoot });
+      await execFileAsync('git', ['remote', 'add', 'origin', remoteRoot], { cwd: checkoutRoot });
+      await execFileAsync('git', ['push', '-u', 'origin', 'main'], { cwd: checkoutRoot });
+
+      await execFileAsync('git', ['clone', remoteRoot, peerRoot]);
+      await execFileAsync('git', ['config', 'user.name', 'Peer'], { cwd: peerRoot });
+      await execFileAsync('git', ['config', 'user.email', 'peer@example.com'], { cwd: peerRoot });
+      await writeFile(path.join(peerRoot, 'peer.txt'), 'remote advance\n', 'utf8');
+      await execFileAsync('git', ['add', 'peer.txt'], { cwd: peerRoot });
+      await execFileAsync('git', ['commit', '-m', 'peer advance'], { cwd: peerRoot });
+      await execFileAsync('git', ['push', 'origin', 'main'], { cwd: peerRoot });
+
+      await mkdir(path.join(checkoutRoot, 'postman'), { recursive: true });
+      await writeFile(path.join(checkoutRoot, 'postman', 'collection.yaml'), 'name: demo\n', 'utf8');
+      let advanceRemoteBeforeFirstPush = true;
+      const execute = async (command: string, args: string[]): Promise<CommandResult> => {
+        if (command === 'git' && args.includes('push') && advanceRemoteBeforeFirstPush) {
+          advanceRemoteBeforeFirstPush = false;
+          await writeFile(path.join(peerRoot, 'late-peer.txt'), 'late remote advance\n', 'utf8');
+          await execFileAsync('git', ['add', 'late-peer.txt'], { cwd: peerRoot });
+          await execFileAsync('git', ['commit', '-m', 'late peer advance'], { cwd: peerRoot });
+          await execFileAsync('git', ['push', 'origin', 'main'], { cwd: peerRoot });
+        }
+        try {
+          const result = await execFileAsync(command, args, { cwd: checkoutRoot, encoding: 'utf8' });
+          return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+        } catch (error) {
+          const failure = error as { code?: number; stdout?: string; stderr?: string };
+          return {
+            exitCode: typeof failure.code === 'number' ? failure.code : 1,
+            stdout: failure.stdout ?? '',
+            stderr: failure.stderr ?? ''
+          };
+        }
+      };
+      const repoMutation = new RepoMutationService({
+        cwd: checkoutRoot,
+        execute,
+        provider: 'azure-devops',
+        repoUrl: remoteRoot,
+        repository: 'fixture/repository'
+      });
+
+      const result = await repoMutation.commitAndPush({
+        repoWriteMode: 'commit-and-push',
+        currentRef: 'main',
+        committerName: 'Postman',
+        committerEmail: 'support@postman.com',
+        stagePaths: ['postman']
+      });
+
+      expect(result.pushed).toBe(true);
+      const remoteLog = await execFileAsync(
+        'git',
+        ['--git-dir', remoteRoot, 'log', '--format=%s', 'main'],
+        { encoding: 'utf8' }
+      );
+      expect(remoteLog.stdout).toContain('chore: sync Postman artifacts and metadata');
+      expect(remoteLog.stdout).toContain('late peer advance');
+      expect(remoteLog.stdout).toContain('peer advance');
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it('preserves provision.yml and the index on push preflight failures, then removes it after valid preflight', async () => {
     const repoRoot = await mkdtemp(path.join(tmpdir(), 'repo-mutation-preflight-'));
     try {
@@ -688,7 +854,10 @@ describe('repo mutation helpers', () => {
       await execFileAsync('git', ['commit', '-m', 'test: add provision fixture'], { cwd: repoRoot });
       await execFileAsync('git', ['remote', 'add', 'origin', 'https://dev.azure.com/postman/CSE/_git/repo-sync-demo'], { cwd: repoRoot });
       const execute = async (command: string, args: string[]): Promise<CommandResult> => {
-        if (command === 'git' && args.includes('push')) {
+        if (
+          command === 'git' &&
+          (args.includes('push') || args.includes('fetch') || args[0] === 'rebase')
+        ) {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         try {


### PR DESCRIPTION
## Summary
- fetch and rebase generated commits onto the current target branch before pushing
- retry once when the target advances between fetch and push
- preserve new-branch creation and fail closed on rebase conflicts
- make the isolated PowerShell workflow probe retry its documented CLR startup stall

## Regression evidence
A real temporary remote advances once before reconciliation and again immediately before the first push. The final remote retains both peer commits plus the generated Postman commit. Conflict and missing-remote-branch paths are also pinned.

## Validation
- `npm test` (708 core tests, 38 Windows-template tests, 13 monitor-dispatch tests)
- `npx vitest run tests/repo-mutation.test.ts` (26 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run verify:dist:assert`
- `actionlint`