### PR TITLE
fix(repo-mutation): resolve generated artifact conflicts

### DIFF
--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -114534,7 +114534,12 @@ var RepoMutationService = class {
             break;
           }
           if (fetch2.exitCode === 0) {
-            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            const rebase = await this.execute("git", [
+              "rebase",
+              "-X",
+              "theirs",
+              "FETCH_HEAD"
+            ]);
             if (rebase.exitCode !== 0) {
               await this.execute("git", ["rebase", "--abort"]);
               const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -112639,7 +112639,12 @@ var RepoMutationService = class {
             break;
           }
           if (fetch2.exitCode === 0) {
-            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            const rebase = await this.execute("git", [
+              "rebase",
+              "-X",
+              "theirs",
+              "FETCH_HEAD"
+            ]);
             if (rebase.exitCode !== 0) {
               await this.execute("git", ["rebase", "--abort"]);
               const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -114557,7 +114557,12 @@ var RepoMutationService = class {
             break;
           }
           if (fetch2.exitCode === 0) {
-            const rebase = await this.execute("git", ["rebase", "FETCH_HEAD"]);
+            const rebase = await this.execute("git", [
+              "rebase",
+              "-X",
+              "theirs",
+              "FETCH_HEAD"
+            ]);
             if (rebase.exitCode !== 0) {
               await this.execute("git", ["rebase", "--abort"]);
               const cause = rebase.stderr || rebase.stdout || "Failed to rebase generated changes";

--- a/src/lib/github/repo-mutation.ts
+++ b/src/lib/github/repo-mutation.ts
@@ -395,7 +395,13 @@ export class RepoMutationService {
           }
 
           if (fetch.exitCode === 0) {
-            const rebase = await this.execute('git', ['rebase', 'FETCH_HEAD']);
+            // During rebase, "theirs" is the replayed commit. Generated paths are authoritative.
+            const rebase = await this.execute('git', [
+              'rebase',
+              '-X',
+              'theirs',
+              'FETCH_HEAD'
+            ]);
             if (rebase.exitCode !== 0) {
               await this.execute('git', ['rebase', '--abort']);
               const cause = rebase.stderr || rebase.stdout || 'Failed to rebase generated changes';

--- a/tests/repo-mutation.test.ts
+++ b/tests/repo-mutation.test.ts
@@ -121,7 +121,7 @@ function createCommandMap(
       stdout: '',
       stderr: ''
     },
-    'git rebase FETCH_HEAD': {
+    'git rebase -X theirs FETCH_HEAD': {
       exitCode: 0,
       stdout: 'Current branch is up to date.\n',
       stderr: ''
@@ -592,13 +592,18 @@ describe('repo mutation helpers', () => {
     });
 
     expect(result.pushed).toBe(true);
-    expect(execute).not.toHaveBeenCalledWith('git', ['rebase', 'FETCH_HEAD']);
+    expect(execute).not.toHaveBeenCalledWith('git', [
+      'rebase',
+      '-X',
+      'theirs',
+      'FETCH_HEAD'
+    ]);
   });
 
-  it('aborts and fails closed when generated files conflict with the target branch', async () => {
+  it('aborts and fails closed when a generated conflict remains unresolved', async () => {
     const execute = createExecuteMock(
       createCommandMap({
-        'git rebase FETCH_HEAD': {
+        'git rebase -X theirs FETCH_HEAD': {
           exitCode: 1,
           stdout: '',
           stderr: 'CONFLICT (content): Merge conflict in postman/collection.yaml\n'
@@ -771,8 +776,14 @@ describe('repo mutation helpers', () => {
       await execFileAsync('git', ['clone', remoteRoot, peerRoot]);
       await execFileAsync('git', ['config', 'user.name', 'Peer'], { cwd: peerRoot });
       await execFileAsync('git', ['config', 'user.email', 'peer@example.com'], { cwd: peerRoot });
+      await mkdir(path.join(peerRoot, 'postman'), { recursive: true });
       await writeFile(path.join(peerRoot, 'peer.txt'), 'remote advance\n', 'utf8');
-      await execFileAsync('git', ['add', 'peer.txt'], { cwd: peerRoot });
+      await writeFile(
+        path.join(peerRoot, 'postman', 'collection.yaml'),
+        'name: previous export\n',
+        'utf8'
+      );
+      await execFileAsync('git', ['add', 'peer.txt', 'postman/collection.yaml'], { cwd: peerRoot });
       await execFileAsync('git', ['commit', '-m', 'peer advance'], { cwd: peerRoot });
       await execFileAsync('git', ['push', 'origin', 'main'], { cwd: peerRoot });
 
@@ -824,6 +835,12 @@ describe('repo mutation helpers', () => {
       expect(remoteLog.stdout).toContain('chore: sync Postman artifacts and metadata');
       expect(remoteLog.stdout).toContain('late peer advance');
       expect(remoteLog.stdout).toContain('peer advance');
+      const remoteCollection = await execFileAsync(
+        'git',
+        ['--git-dir', remoteRoot, 'show', 'main:postman/collection.yaml'],
+        { encoding: 'utf8' }
+      );
+      expect(remoteCollection.stdout).toBe('name: demo\n');
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- replay the scoped generated-artifact commit with current generated bytes winning conflicts
- retain remote history and unrelated concurrent changes
- continue aborting and failing closed if Git cannot resolve a conflict

## Regression evidence
The real git fixture now starts from an ancestor where `postman/collection.yaml` does not exist, advances the remote with an older generated version, writes a new version from the stale checkout, and advances the remote again during the first push. The final remote must retain both peer commits and contain the current generated bytes. This reproduces the add/add conflict from `postman-cs/fe-onsite-g02` run `30399527752`, attempt 3.

## Validation
- `npm test` (708 core tests, 38 Windows-template tests, 13 monitor-dispatch tests)
- `npm run lint`
- `npm run typecheck`
- `actionlint`
- `node scripts/verify-dist-artifact.mjs`