### PR TITLE
feat: add generated asset sync control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add an opt-in workspace/spec-only mode that keeps workspace linking and spec state while skipping collections, environments, mocks, monitors, exported assets, and generated CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-- Add an opt-in workspace/spec-only mode that keeps workspace linking and spec state while skipping collections, environments, mocks, monitors, exported assets, and generated CI.
+- Add an opt-in workspace/spec-only mode that keeps workspace linking and spec state while skipping collections, environments, mocks, monitors, exported assets, generated CI, and generated-CI credential side effects.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ with:
 | `monitor-type` | Type of monitor to create ("cloud" or "cli"). "cli" will skip cloud monitor creation and rely on the CI workflow. | no | `cloud` |
 | `smoke-collection-id` | Smoke collection ID used for monitor creation. | no |  |
 | `contract-collection-id` | Contract collection ID used for exported artifacts. | no |  |
+| `sync-generated-assets` | Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding. | no | `true` |
 | `prebuilt-collections-json` | Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export. | no | `""` |
 | `collection-sync-mode` | Collection sync lifecycle mode (refresh or version). | no | `refresh` |
 | `spec-sync-mode` | Spec sync lifecycle mode (update or version). | no | `update` |

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
   contract-collection-id:
     description: Contract collection ID used for exported artifacts.
     required: false
+  sync-generated-assets:
+    description: Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding.
+    required: false
+    default: 'true'
   prebuilt-collections-json:
     description: Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.
     required: false

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -120027,7 +120027,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -116961,6 +116961,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -119535,6 +119541,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    syncGeneratedAssets: parseBooleanInput(getInput2("sync-generated-assets", env), true),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -119956,6 +119963,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120321,7 +120329,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -120333,13 +120341,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -120890,8 +120903,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -120910,6 +120925,32 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  if (inputs.syncGeneratedAssets === false) {
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      options.existingSpecs,
+      options.priorState,
+      true
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -121006,12 +121047,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -121080,7 +121115,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121105,13 +121140,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -121183,7 +121218,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -121208,7 +121246,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121222,29 +121260,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121279,10 +121337,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -120934,6 +120934,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
   if (inputs.syncGeneratedAssets === false) {
     ensureDir(".postman");
     assertPathWithinCwd(".postman/resources.yaml", "resources state target");
@@ -120945,9 +120948,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       discoveredSpecs.map((spec) => spec.configRelativePath),
       mappedSpecCloudKey,
       inputs.specId || void 0,
-      options.existingSpecs,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
       options.priorState,
-      true
+      preservePriorWorkspaceResources
     ));
     dependencies.core.info(
       "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
@@ -121828,7 +121831,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }
@@ -122190,6 +122196,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -120062,6 +120062,9 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -120917,7 +120920,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -121170,7 +121173,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -118838,6 +118838,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
   if (inputs.syncGeneratedAssets === false) {
     ensureDir(".postman");
     assertPathWithinCwd(".postman/resources.yaml", "resources state target");
@@ -118849,9 +118852,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       discoveredSpecs.map((spec) => spec.configRelativePath),
       mappedSpecCloudKey,
       inputs.specId || void 0,
-      options.existingSpecs,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
       options.priorState,
-      true
+      preservePriorWorkspaceResources
     ));
     dependencies.core.info(
       "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
@@ -119732,7 +119735,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -115066,6 +115066,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -117585,6 +117591,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput("baseline-collection-id", env),
     smokeCollectionId: getInput("smoke-collection-id", env),
     contractCollectionId: getInput("contract-collection-id", env),
+    syncGeneratedAssets: parseBooleanInput(getInput("sync-generated-assets", env), true),
     prebuiltCollectionsJson: getInput("prebuilt-collections-json", env),
     specId: getInput("spec-id", env),
     specContentChanged: parseBooleanInput(getInput("spec-content-changed", env), true),
@@ -118229,7 +118236,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -118241,13 +118248,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -118798,8 +118810,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -118818,6 +118832,32 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  if (inputs.syncGeneratedAssets === false) {
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      options.existingSpecs,
+      options.priorState,
+      true
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -118914,12 +118954,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -118988,7 +119022,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -119013,13 +119047,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -119091,7 +119125,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -119116,7 +119153,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -119130,29 +119167,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -119187,10 +119244,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {
@@ -120369,6 +120426,7 @@ var CLI_INPUT_NAMES = [
   "baseline-collection-id",
   "smoke-collection-id",
   "contract-collection-id",
+  "sync-generated-assets",
   "prebuilt-collections-json",
   "collection-sync-mode",
   "spec-sync-mode",

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -120920,6 +120920,7 @@ async function runCli(argv = process.argv.slice(2), runtime = {}) {
     resolvingExec,
     initialMasker,
     {
+      allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
       persistGeneratedApiKeySecret: false,
       env
     }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -118824,7 +118824,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -119077,7 +119077,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -116987,6 +116987,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -119561,6 +119567,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    syncGeneratedAssets: parseBooleanInput(getInput2("sync-generated-assets", env), true),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -119982,6 +119989,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120347,7 +120355,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -120359,13 +120367,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -120916,8 +120929,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -120936,6 +120951,32 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  if (inputs.syncGeneratedAssets === false) {
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      options.existingSpecs,
+      options.priorState,
+      true
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -121032,12 +121073,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -121106,7 +121141,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121131,13 +121166,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -121209,7 +121244,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -121234,7 +121272,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121248,29 +121286,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121305,10 +121363,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -120053,7 +120053,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -120960,6 +120960,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
   if (inputs.syncGeneratedAssets === false) {
     ensureDir(".postman");
     assertPathWithinCwd(".postman/resources.yaml", "resources state target");
@@ -120971,9 +120974,9 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       discoveredSpecs.map((spec) => spec.configRelativePath),
       mappedSpecCloudKey,
       inputs.specId || void 0,
-      options.existingSpecs,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
       options.priorState,
-      true
+      preservePriorWorkspaceResources
     ));
     dependencies.core.info(
       "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
@@ -121854,7 +121857,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }
@@ -122216,6 +122222,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -120088,6 +120088,9 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -120943,7 +120946,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -121196,7 +121199,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -626,6 +626,7 @@ export async function runCli(
       resolvingExec,
       initialMasker,
       {
+        allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
         persistGeneratedApiKeySecret: false,
         env
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ const CLI_INPUT_NAMES = [
   'baseline-collection-id',
   'smoke-collection-id',
   'contract-collection-id',
+  'sync-generated-assets',
   'prebuilt-collections-json',
   'collection-sync-mode',
   'spec-sync-mode',

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -132,6 +132,12 @@ export const postmanRepoSyncActionContract: {
       description: 'Contract collection ID used for exported artifacts.',
       required: false
     },
+    'sync-generated-assets': {
+      description: 'Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding.',
+      required: false,
+      default: 'true',
+      allowedValues: ['true', 'false']
+    },
     'prebuilt-collections-json': {
       description:
         'Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2514,6 +2514,11 @@ async function exportArtifacts(
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId &&
+    options.priorWorkspaceId &&
+    durableWorkspaceId === options.priorWorkspaceId
+  );
 
   if (inputs.syncGeneratedAssets === false) {
     ensureDir('.postman');
@@ -2526,9 +2531,9 @@ async function exportArtifacts(
       discoveredSpecs.map((spec) => spec.configRelativePath),
       mappedSpecCloudKey,
       inputs.specId || undefined,
-      options.existingSpecs,
+      preservePriorWorkspaceResources ? options.existingSpecs : undefined,
       options.priorState,
-      true
+      preservePriorWorkspaceResources
     ));
     dependencies.core.info(
       'Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml.'
@@ -3551,6 +3556,7 @@ export async function resolvePostmanApiKeyAndTeamId(
   actionExec: ExecLike,
   masker: SecretMasker,
   options: {
+    allowApiKeyCreation?: boolean;
     persistGeneratedApiKeySecret?: boolean;
     env: NodeJS.ProcessEnv;
   }
@@ -3602,7 +3608,10 @@ export async function resolvePostmanApiKeyAndTeamId(
     }
   }
 
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = '';
+    actionCore.info('Skipping Postman API key creation because generated assets are disabled.');
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error('postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.');
     }
@@ -4077,6 +4086,8 @@ export async function runAction(
   });
 
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1318,6 +1318,9 @@ export async function persistSslSecrets(
   repository: string,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -2490,9 +2493,12 @@ async function exportArtifacts(
 
   const manifestCollections: Record<string, string> = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, '.', {
-    ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, '.postman'] : ['.postman']
-  });
+  const { discoveredSpecs, mappedSpec } =
+    inputs.syncGeneratedAssets === false && !inputs.specId
+      ? { discoveredSpecs: [], mappedSpec: undefined }
+      : resolveLocalSpecReferences(inputs.specPath, '.', {
+          ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, '.postman'] : ['.postman']
+        });
   const mappedSpecCloudKey =
     mappedSpec && inputs.specId
       ? buildMappedSpecCloudKey(
@@ -2781,7 +2787,7 @@ async function commitAndPushGeneratedFiles(
     adoToken: inputs.provider === 'azure-devops' ? inputs.adoToken : undefined,
     githubToken: inputs.provider === 'azure-devops' ? undefined : inputs.githubToken,
     fallbackToken: inputs.provider === 'azure-devops' ? undefined : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1274,7 +1274,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
 
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error('ssl-client-key is required when ssl-client-cert is provided');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export interface ResolvedInputs {
   baselineCollectionId: string;
   smokeCollectionId: string;
   contractCollectionId: string;
+  syncGeneratedAssets?: boolean;
   /** Optional digest-bound prebuilt collection manifest JSON from bootstrap. */
   prebuiltCollectionsJson?: string;
   collectionSyncMode: 'refresh' | 'version';
@@ -600,6 +601,7 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     baselineCollectionId: getInput('baseline-collection-id', env),
     smokeCollectionId: getInput('smoke-collection-id', env),
     contractCollectionId: getInput('contract-collection-id', env),
+    syncGeneratedAssets: parseBooleanInput(getInput('sync-generated-assets', env), true),
     prebuiltCollectionsJson: getInput('prebuilt-collections-json', env),
     specId: getInput('spec-id', env),
     specContentChanged: parseBooleanInput(getInput('spec-content-changed', env), true),
@@ -1206,6 +1208,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, 'sync-generated-assets'),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, 'prebuilt-collections-json'),
     INPUT_SPEC_ID: readInput(actionCore, 'spec-id'),
     INPUT_SPEC_PATH: readInput(actionCore, 'spec-path'),
@@ -1670,7 +1673,8 @@ function buildResourcesManifest(
   mappedSpecRef?: string,
   specId?: string,
   existingSpecs?: CloudResourceMap,
-  priorState?: PostmanResourcesState | null
+  priorState?: PostmanResourcesState | null,
+  preserveGeneratedAssets = false
 ): string {
   // Merge-preserving writer (state v2): round-trip every unknown field from
   // the prior tracked state instead of rebuilding the document from scratch,
@@ -1689,15 +1693,24 @@ function buildResourcesManifest(
   const cloudResources: Record<string, Record<string, string>> = {};
 
   // Collections
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets
+    ? { ...(priorState?.cloudResources?.collections ?? {}), ...collectionMap }
+    : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
 
   // Environments
+  const priorEnvironmentMap = preserveGeneratedAssets
+    ? { ...(priorState?.cloudResources?.environments ?? {}) }
+    : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -2461,8 +2474,10 @@ async function exportArtifacts(
     return;
   }
 
-  assertPathWithinCwd(inputs.artifactDir, 'artifact-dir');
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, 'artifact-dir');
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
   }
 
@@ -2486,6 +2501,34 @@ async function exportArtifacts(
           options.releaseLabel
         )
       : undefined;
+
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+
+  if (inputs.syncGeneratedAssets === false) {
+    ensureDir('.postman');
+    assertPathWithinCwd('.postman/resources.yaml', 'resources state target');
+    writeFileSync('.postman/resources.yaml', buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || undefined,
+      options.existingSpecs,
+      options.priorState,
+      true
+    ));
+    dependencies.core.info(
+      'Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml.'
+    );
+    return;
+  }
 
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
@@ -2585,13 +2628,6 @@ async function exportArtifacts(
     );
   }
 
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
-
   assertPathWithinCwd('.postman/resources.yaml', 'resources state target');
   writeFileSync('.postman/resources.yaml', buildResourcesManifest(
     durableWorkspaceId,
@@ -2675,7 +2711,7 @@ async function commitAndPushGeneratedFiles(
 ): Promise<{ commitSha: string; resolvedCurrentRef: string; pushed: boolean }> {
   // File generation is independent of git mutation: mode=none still writes the
   // requested CI workflow, but never stages/commits/pushes.
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
 
@@ -2710,13 +2746,16 @@ async function commitAndPushGeneratedFiles(
   const gcWorkflowPath = '.github/workflows/postman-preview-gc.yml';
   const gcExists = inputs.generateCiWorkflow && existsSync(gcWorkflowPath);
 
-  const stagePaths = [
-    inputs.artifactDir,
-    '.postman',
-    inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
-    gcExists ? gcWorkflowPath : null,
-    provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === 'string' && (existsSync(entry) || entry === provisionPath)) as string[];
+  const stagePaths = (inputs.syncGeneratedAssets === false
+    ? ['.postman']
+    : [
+        inputs.artifactDir,
+        '.postman',
+        inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
+        gcExists ? gcWorkflowPath : null,
+        provisionExists ? provisionPath : null
+      ]
+  ).filter((entry) => typeof entry === 'string' && (existsSync(entry) || entry === provisionPath)) as string[];
 
   if (stagePaths.length === 0) {
     dependencies.core.info('No generated repository paths were found; skipping repo mutation.');
@@ -2812,7 +2851,10 @@ async function runRepoSyncInner(
   // inputs). Gated runs never reach here (runAction short-circuits), so the
   // non-canonical tiers seen here are preview and channel.
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === 'legacy' || branchDecision.tier === 'canonical';
   if (!isCanonicalWriter) {
     // Preview/channel runs: branch-scoped asset names; no repo-link mutation;
@@ -2840,7 +2882,9 @@ async function runRepoSyncInner(
   }
 
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === 'version' || inputs.specSyncMode === 'version';
+  const versionRequested =
+    inputs.specSyncMode === 'version' ||
+    (syncGeneratedAssets && inputs.collectionSyncMode === 'version');
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error('release-label is required when collection-sync-mode or spec-sync-mode is version');
@@ -2864,21 +2908,21 @@ async function runRepoSyncInner(
     }
 
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || '';
       if (inputs.baselineCollectionId) {
         dependencies.core.info('Resolved baseline-collection-id from .postman/resources.yaml');
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Smoke]')) || '';
       if (inputs.smokeCollectionId) {
         dependencies.core.info('Resolved smoke-collection-id from .postman/resources.yaml');
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Contract]')) || '';
       if (inputs.contractCollectionId) {
@@ -2887,9 +2931,33 @@ async function runRepoSyncInner(
     }
   }
 
-  const preparedPrebuiltCollections = await logger.phase('prepare-collections', async () =>
-    preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: '',
+      smokeCollectionId: '',
+      contractCollectionId: '',
+      prebuiltCollectionsJson: undefined,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: '',
+      monitorCron: '',
+      monitorType: 'cli',
+      mockUrl: '',
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      'Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI.'
+    );
+  }
+
+  const preparedPrebuiltCollections = syncGeneratedAssets
+    ? await logger.phase('prepare-collections', async () => preparePrebuiltCollections(inputs))
+    : new Map<PrebuiltCollectionRole, PreparedPrebuiltCollectionEntry>();
 
   // Repo-link admission guard: Bifrost enforces global uniqueness of
   // (repository URL, path) -> workspace. Probe before any asset writes so a
@@ -2936,9 +3004,11 @@ async function runRepoSyncInner(
   }
 
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase('sync-environments', async () =>
-    upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  const envUids = syncGeneratedAssets
+    ? await logger.phase('sync-environments', async () =>
+        upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
+      )
+    : {};
   outputs['environment-uids-json'] = JSON.stringify(envUids);
   dependencies.core.setOutput('environment-uids-json', outputs['environment-uids-json']);
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -432,6 +432,42 @@ describe('runCli credential preflight seam', () => {
     expect(logged).toMatch(/\[repo-sync timing\] \{"stage":"runRepoSync finalize","ms":\d+(?:\.\d+)?,"status":"success"\}/);
   });
 
+  it('does not mint a Postman API key in specs-only CLI mode', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/current')) {
+        return new Response(
+          JSON.stringify({ identity: { team: 333 }, data: { user: { id: 'u-sess' } } }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      throw new Error(`unexpected fetch in specs-only CLI test: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const executeRepoSync = vi.fn(async () => fullRepoSyncOutputs());
+
+    await withTempCwd(async () => {
+      await runCli(
+        [
+          '--project-name', 'specs-only',
+          '--postman-access-token', 'tok-only',
+          '--team-id', '333',
+          '--org-mode', 'true',
+          '--sync-generated-assets', 'false',
+          '--credential-preflight', 'warn',
+          '--repo-write-mode', 'none'
+        ],
+        { env: {}, executeRepoSync, writeStdout: () => undefined }
+      );
+    });
+
+    expect(executeRepoSync).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+      'https://iapub.postman.co/api/sessions/current'
+    ]);
+  });
+
   it.each([
     {
       name: 'preview',

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -40,6 +40,7 @@ describe('postman-repo-sync-action contract', () => {
       'monitor-type',
       'smoke-collection-id',
       'contract-collection-id',
+      'sync-generated-assets',
       'prebuilt-collections-json',
       'collection-sync-mode',
       'spec-sync-mode',
@@ -420,5 +421,24 @@ describe('postman-repo-sync-action contract', () => {
     // Standalone behavior absent input unchanged
     const plan = createExecutionPlan();
     expect(plan.outputs).toBeDefined();
+  });
+
+  it('defaults generated asset sync on and supports a specs-only opt-in', () => {
+    const inputDef = postmanRepoSyncActionContract.inputs['sync-generated-assets'];
+    const actionYaml = parse(readFileSync(resolve(repoRoot, 'action.yml'), 'utf8')) as {
+      inputs: Record<string, { required?: boolean; default?: string }>;
+    };
+
+    expect(inputDef).toMatchObject({
+      required: false,
+      default: 'true',
+      allowedValues: ['true', 'false']
+    });
+    expect(actionYaml.inputs['sync-generated-assets']).toMatchObject({
+      required: false,
+      default: 'true'
+    });
+    expect(resolveInputs({}).syncGeneratedAssets).toBe(true);
+    expect(resolveInputs({ INPUT_SYNC_GENERATED_ASSETS: 'false' }).syncGeneratedAssets).toBe(false);
   });
 });

--- a/tests/gh-secret-persistence-contract.test.ts
+++ b/tests/gh-secret-persistence-contract.test.ts
@@ -260,6 +260,22 @@ describe('persistSslSecrets — argv/stdin/GH_TOKEN/env contract', () => {
     expect(actionCore.info).toHaveBeenCalledWith('SSL certificate inputs persisted to repository secrets');
   });
 
+  it('does not persist SSL secrets when generated assets are disabled', async () => {
+    const actionCore = { info: vi.fn(), warning: vi.fn() };
+    const inputs = baseInputs({
+      syncGeneratedAssets: false,
+      sslClientCert: 'CERT-B64',
+      sslClientKey: 'KEY-B64',
+      githubToken: 'ghp_ssl_token'
+    });
+
+    await persistSslSecrets(inputs, actionCore, createCapturingExec(calls), 'acme/payments', {});
+
+    expect(calls).toEqual([]);
+    expect(actionCore.info).not.toHaveBeenCalled();
+    expect(actionCore.warning).not.toHaveBeenCalled();
+  });
+
   it('prefers ghFallbackToken over githubToken for the GH_TOKEN value', async () => {
     const actionCore = { info: vi.fn(), warning: vi.fn() };
     const inputs = baseInputs({

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -585,6 +585,25 @@ describe('repo sync action', () => {
     );
   });
 
+  it('skips generated-CI SSL validation when generated assets are disabled', () => {
+    const sslClientCert = Buffer.from('stale-cert').toString('base64');
+    const { core, secrets } = createCoreStub({
+      'project-name': 'core-payments',
+      'postman-access-token': 'postman-access-token',
+      'sync-generated-assets': 'false',
+      'ssl-client-cert': sslClientCert,
+      'environments-json': '["prod"]',
+      'system-env-map-json': '{}',
+      'environment-uids-json': '{}',
+      'env-runtime-urls-json': '{}'
+    });
+
+    const inputs = readActionInputs(core);
+
+    expect(inputs.syncGeneratedAssets).toBe(false);
+    expect(secrets).toContain(sslClientCert);
+  });
+
   it('materializes repo sync outputs and files', async () => {
     const { core, outputs } = createCoreStub();
     const postman = {

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -2241,6 +2241,45 @@ describe('repo sync action', () => {
       expect(resources.canonical?.specs).toBeUndefined();
     });
 
+    it('does not preserve generated resource ids when specs-only sync targets a different workspace', async () => {
+      mkdirSync('.postman', { recursive: true });
+      writeFileSync(
+        '.postman/resources.yaml',
+        [
+          'version: 2',
+          'workspace:',
+          '  id: ws-old',
+          'canonical:',
+          '  collections:',
+          '    ../postman/collections/old: col-old',
+          '  environments:',
+          '    ../postman/environments/prod.postman_environment.json: env-old',
+          '  specs:',
+          '    ../old.yaml: spec-old',
+          ''
+        ].join('\n')
+      );
+      seedOpenApiSpec('openapi.yaml');
+
+      await runRepoSync(
+        createInputs({
+          workspaceId: 'ws-new',
+          specId: 'spec-new',
+          specPath: 'openapi.yaml',
+          syncGeneratedAssets: false,
+          generateCiWorkflow: false
+        }),
+        deps(createExportPostmanStub())
+      );
+
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(resources).toEqual({
+        version: 2,
+        workspace: { id: 'ws-new' },
+        canonical: { specs: { '../openapi.yaml': 'spec-new' } }
+      });
+    });
+
     it('fails closed when local spec discovery exceeds the directory-depth budget', async () => {
       const deepDir = seedDeepDirectoryChain(7);
       seedOpenApiSpec(join(deepDir, 'openapi.json'));
@@ -4996,6 +5035,42 @@ describe('org-mode auto-detection', () => {
       return new Response('', { status: 404 });
     });
   }
+
+  it('does not create or persist a Postman API key when generated assets are disabled', async () => {
+    const actionCore = {
+      info: vi.fn(),
+      setSecret: vi.fn(),
+      warning: vi.fn()
+    };
+    const execLike = {
+      getExecOutput: vi.fn().mockResolvedValue({ exitCode: 0, stderr: '', stdout: '' })
+    };
+    const masker = createSecretMasker(['postman-access-token']);
+    const inputs = createInputs({
+      postmanApiKey: '',
+      postmanAccessToken: 'postman-access-token',
+      teamId: '10490519',
+      orgMode: true
+    });
+    vi.mocked(createInternalIntegrationAdapter).mockClear();
+
+    const result = await resolvePostmanApiKeyAndTeamId(
+      inputs,
+      actionCore,
+      execLike,
+      masker,
+      {
+        allowApiKeyCreation: false,
+        persistGeneratedApiKeySecret: false,
+        env: {}
+      }
+    );
+
+    expect(result).toEqual({ apiKey: '', teamId: '10490519' });
+    expect(createInternalIntegrationAdapter).not.toHaveBeenCalled();
+    expect(execLike.getExecOutput).not.toHaveBeenCalled();
+    expect(actionCore.setSecret).not.toHaveBeenCalled();
+  });
 
   it('sets orgMode=true when ums squads returns a non-empty squad list (org-mode team)', async () => {
     const actionCore = {

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -2221,6 +2221,26 @@ describe('repo sync action', () => {
       );
     });
 
+    it('skips local spec discovery for workspace-only runs when generated assets are disabled', async () => {
+      seedCandidateJsonFiles(201);
+
+      await expect(
+        runRepoSync(
+          createInputs({
+            specId: '',
+            specPath: '',
+            syncGeneratedAssets: false,
+            generateCiWorkflow: false
+          }),
+          deps(createExportPostmanStub())
+        )
+      ).resolves.toBeDefined();
+
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(resources.workspace).toEqual({ id: 'ws-123' });
+      expect(resources.canonical?.specs).toBeUndefined();
+    });
+
     it('fails closed when local spec discovery exceeds the directory-depth budget', async () => {
       const deepDir = seedDeepDirectoryChain(7);
       seedOpenApiSpec(join(deepDir, 'openapi.json'));
@@ -2713,6 +2733,8 @@ describe('repo sync action', () => {
   });
 
   it('supports workspace and spec sync without generated assets or cloud monitors', async () => {
+    mkdirSync('.github/workflows', { recursive: true });
+    writeFileSync('.github/workflows/provision.yml', 'name: Existing Provision\n');
     mkdirSync('.postman', { recursive: true });
     writeFileSync(
       '.postman/resources.yaml',
@@ -2799,6 +2821,7 @@ describe('repo sync action', () => {
     expect(postman.getEnvironment).not.toHaveBeenCalled();
     expect(existsSync('postman')).toBe(false);
     expect(existsSync('.github/workflows/ci.yml')).toBe(false);
+    expect(readFileSync('.github/workflows/provision.yml', 'utf8')).toBe('name: Existing Provision\n');
 
     const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
     expect(resources).toEqual({
@@ -2816,7 +2839,7 @@ describe('repo sync action', () => {
       }
     });
     expect(repoMutation.commitAndPush).toHaveBeenCalledWith(
-      expect.objectContaining({ stagePaths: ['.postman'] })
+      expect.objectContaining({ stagePaths: ['.postman'], removePaths: [] })
     );
   });
 

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -2712,6 +2712,114 @@ describe('repo sync action', () => {
     expect(postman.updateEnvironment).toHaveBeenCalledTimes(2);
   });
 
+  it('supports workspace and spec sync without generated assets or cloud monitors', async () => {
+    mkdirSync('.postman', { recursive: true });
+    writeFileSync(
+      '.postman/resources.yaml',
+      [
+        'version: 2',
+        'workspace:',
+        '  id: ws-123',
+        'canonical:',
+        '  collections:',
+        '    ../postman/collections/existing: col-existing',
+        '  environments:',
+        '    ../postman/environments/prod.postman_environment.json: env-existing',
+        '  specs:',
+        '    ../existing.yaml: spec-existing',
+        ''
+      ].join('\n')
+    );
+    writeFileSync(
+      'openapi.yaml',
+      'openapi: 3.1.0\ninfo:\n  title: Specs Only\n  version: 1.0.0\npaths: {}\n'
+    );
+
+    const postman = {
+      createEnvironment: vi.fn(),
+      updateEnvironment: vi.fn(),
+      findEnvironmentByName: vi.fn(),
+      createMock: vi.fn(),
+      findMockByCollection: vi.fn(),
+      createMonitor: vi.fn(),
+      findMonitorByCollection: vi.fn(),
+      runMonitor: vi.fn(),
+      getCollection: vi.fn(),
+      getEnvironment: vi.fn()
+    } as unknown as RepoSyncDependencies['postman'];
+    const internalIntegration = {
+      associateSystemEnvironments: vi.fn(),
+      connectWorkspaceToRepository: vi.fn().mockResolvedValue(undefined),
+      findWorkspaceForRepo: vi.fn().mockResolvedValue({ state: 'free' })
+    };
+    const repoMutation = {
+      commitAndPush: vi.fn().mockResolvedValue({
+        commitSha: 'spec-only-commit',
+        pushed: false,
+        resolvedCurrentRef: 'feature/repo-sync'
+      })
+    };
+
+    const result = await runRepoSync(
+      createInputs({
+        specId: 'spec-new',
+        specPath: 'openapi.yaml',
+        syncGeneratedAssets: false
+      }),
+      {
+        core: createCoreStub().core,
+        postman,
+        internalIntegration,
+        repoMutation: repoMutation as unknown as RepoSyncDependencies['repoMutation']
+      }
+    );
+
+    expect(result).toMatchObject({
+      'workspace-link-status': 'success',
+      'environment-sync-status': 'skipped',
+      'environment-uids-json': '{}',
+      'mock-url': '',
+      'monitor-id': ''
+    });
+    expect(internalIntegration.connectWorkspaceToRepository).toHaveBeenCalledWith(
+      'ws-123',
+      'https://github.com/postman-cs/repo-sync-demo',
+      { preflightWasFree: true }
+    );
+    expect(internalIntegration.associateSystemEnvironments).not.toHaveBeenCalled();
+    expect(postman.createEnvironment).not.toHaveBeenCalled();
+    expect(postman.updateEnvironment).not.toHaveBeenCalled();
+    expect(postman.findEnvironmentByName).not.toHaveBeenCalled();
+    expect(postman.createMock).not.toHaveBeenCalled();
+    expect(postman.findMockByCollection).not.toHaveBeenCalled();
+    expect(postman.createMonitor).not.toHaveBeenCalled();
+    expect(postman.findMonitorByCollection).not.toHaveBeenCalled();
+    expect(postman.runMonitor).not.toHaveBeenCalled();
+    expect(postman.getCollection).not.toHaveBeenCalled();
+    expect(postman.getEnvironment).not.toHaveBeenCalled();
+    expect(existsSync('postman')).toBe(false);
+    expect(existsSync('.github/workflows/ci.yml')).toBe(false);
+
+    const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+    expect(resources).toEqual({
+      version: 2,
+      workspace: { id: 'ws-123' },
+      canonical: {
+        collections: { '../postman/collections/existing': 'col-existing' },
+        environments: {
+          '../postman/environments/prod.postman_environment.json': 'env-existing'
+        },
+        specs: {
+          '../existing.yaml': 'spec-existing',
+          '../openapi.yaml': 'spec-new'
+        }
+      }
+    });
+    expect(repoMutation.commitAndPush).toHaveBeenCalledWith(
+      expect.objectContaining({ stagePaths: ['.postman'] })
+    );
+  });
+
   it('refresh reruns keep the same tracked collection ids in .postman/resources.yaml', async () => {
     const postman = {
       createEnvironment: vi.fn().mockResolvedValue('env-prod'),

--- a/tests/verify-dist-artifact.test.ts
+++ b/tests/verify-dist-artifact.test.ts
@@ -212,7 +212,9 @@ describe('verify-dist-artifact canonical contract', () => {
       const bundle = await readFile(path.join(repoRoot, entrypoint), 'utf8');
       const collectionAcquisition = bundle.indexOf('collection-acquisition count=');
       const environmentAcquisition = bundle.indexOf('environment-artifact-acquisition count=');
-      const resourcesMaterialization = bundle.indexOf(
+      // Specs-only mode has an earlier state-only write. The final occurrence
+      // remains the generated-assets path whose ordering this contract protects.
+      const resourcesMaterialization = bundle.lastIndexOf(
         'writeFileSync)(".postman/resources.yaml", buildResourcesManifest('
       );
 


### PR DESCRIPTION
## Summary

- add the `sync-generated-assets` input with a backward-compatible default of `true`
- keep workspace repository linking and workspace and spec state when disabled
- skip collections, environments, mocks, monitors, exports, and generated CI while preserving existing mappings

## Validation

- `npm run typecheck`
- `npm run lint`
- focused specification-only, contract, and distribution tests
- `npm run verify:dist:assert`
- validated through the pinned composite action in a successful sandbox run: https://github.com/postman-cs/api-catalog-onboarding-template/actions/runs/30942150238