### PR TITLE
feat: add generated asset sync control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add an opt-in workspace/spec-only mode that keeps workspace linking and spec state while skipping collections, environments, mocks, monitors, exported assets, generated CI, and generated-CI credential side effects.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ with:
 | `monitor-type` | Type of monitor to create ("cloud" or "cli"). "cli" will skip cloud monitor creation and rely on the CI workflow. | no | `cloud` |
 | `smoke-collection-id` | Smoke collection ID used for monitor creation. | no |  |
 | `contract-collection-id` | Contract collection ID used for exported artifacts. | no |  |
+| `sync-generated-assets` | Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged. | no | `true` |
 | `prebuilt-collections-json` | Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export. | no | `""` |
 | `collection-sync-mode` | Collection sync lifecycle mode (refresh or version). | no | `refresh` |
 | `spec-sync-mode` | Spec sync lifecycle mode (update or version). | no | `update` |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ with:
 | `monitor-type` | Type of monitor to create ("cloud" or "cli"). "cli" will skip cloud monitor creation and rely on the CI workflow. | no | `cloud` |
 | `smoke-collection-id` | Smoke collection ID used for monitor creation. | no |  |
 | `contract-collection-id` | Contract collection ID used for exported artifacts. | no |  |
-| `sync-generated-assets` | Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged. | no | `true` |
+| `onboarding-scope` | Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only. | no | `full` |
 | `prebuilt-collections-json` | Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export. | no | `""` |
 | `collection-sync-mode` | Collection sync lifecycle mode (refresh or version). | no | `refresh` |
 | `spec-sync-mode` | Spec sync lifecycle mode (update or version). | no | `update` |

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
   contract-collection-id:
     description: Contract collection ID used for exported artifacts.
     required: false
+  sync-generated-assets:
+    description: Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.
+    required: false
+    default: 'true'
   prebuilt-collections-json:
     description: Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,10 @@ inputs:
   contract-collection-id:
     description: Contract collection ID used for exported artifacts.
     required: false
-  sync-generated-assets:
-    description: Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.
+  onboarding-scope:
+    description: Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only.
     required: false
-    default: 'true'
+    default: full
   prebuilt-collections-json:
     description: Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.
     required: false

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -116961,6 +116961,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -119422,6 +119428,13 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
+function parseStrictBooleanInput(name, value, defaultValue) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  throw new Error(`${name} must be either true or false; received "${value}"`);
+}
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
 }
@@ -119578,6 +119591,11 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    syncGeneratedAssets: parseStrictBooleanInput(
+      "sync-generated-assets",
+      getInput2("sync-generated-assets", env),
+      true
+    ),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -119999,6 +120017,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120062,7 +120081,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }
@@ -120097,6 +120116,9 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -120364,7 +120386,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -120376,13 +120398,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -120933,8 +120960,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -120945,7 +120974,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -120953,6 +120982,41 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
+  if (inputs.syncGeneratedAssets === false) {
+    if (!options.isCanonicalWriter) {
+      dependencies.core.info(
+        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+      );
+      return;
+    }
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
+      options.priorState,
+      preservePriorWorkspaceResources
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -121049,12 +121113,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -121123,7 +121181,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121148,13 +121206,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -121178,7 +121236,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -121226,7 +121284,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -121251,7 +121312,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121265,29 +121326,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121322,10 +121403,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {
@@ -121684,6 +121765,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   await logger.phase(
     "export-artifacts",
     async () => exportArtifacts(inputs, dependencies, envUids, assetProjectName, {
+      isCanonicalWriter,
       workspaceLinkStatus: outputs["workspace-link-status"],
       priorWorkspaceId: resourcesState?.workspace?.id,
       existingSpecs: resourcesState?.cloudResources?.specs,
@@ -121810,7 +121892,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }
@@ -122172,6 +122257,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/dist/action.cjs
+++ b/dist/action.cjs
@@ -116961,11 +116961,11 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
-    "sync-generated-assets": {
-      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+    "onboarding-scope": {
+      description: "Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only.",
       required: false,
-      default: "true",
-      allowedValues: ["true", "false"]
+      default: "full",
+      allowedValues: ["full", "spec-only"]
     },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
@@ -119428,12 +119428,11 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
-function parseStrictBooleanInput(name, value, defaultValue) {
+function parseOnboardingScope(value) {
   const normalized = String(value || "").trim().toLowerCase();
-  if (!normalized) return defaultValue;
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  throw new Error(`${name} must be either true or false; received "${value}"`);
+  if (!normalized) return "full";
+  if (normalized === "full" || normalized === "spec-only") return normalized;
+  throw new Error(`onboarding-scope must be either full or spec-only; received "${value}"`);
 }
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
@@ -119591,11 +119590,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
-    syncGeneratedAssets: parseStrictBooleanInput(
-      "sync-generated-assets",
-      getInput2("sync-generated-assets", env),
-      true
-    ),
+    onboardingScope: parseOnboardingScope(getInput2("onboarding-scope", env)),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -120017,7 +120012,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
-    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
+    INPUT_ONBOARDING_SCOPE: readInput(actionCore, "onboarding-scope"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120081,7 +120076,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
+  if (inputs.onboardingScope === "full" && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }
@@ -120116,7 +120111,7 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === "spec-only") {
     return;
   }
   if (!inputs.sslClientCert) {
@@ -120960,10 +120955,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  if (inputs.syncGeneratedAssets !== false) {
+  if (inputs.onboardingScope === "full") {
     assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
   }
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -120974,7 +120969,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.onboardingScope === "spec-only" && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -120988,13 +120983,14 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const priorWorkspaceId = options.priorWorkspaceId?.trim();
   const preservePriorWorkspaceResources = Boolean(
-    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+    durableWorkspaceId && priorWorkspaceId && durableWorkspaceId === priorWorkspaceId
   );
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === "spec-only") {
     if (!options.isCanonicalWriter) {
       dependencies.core.info(
-        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+        "onboarding-scope=spec-only; skipping .postman/resources.yaml write on non-canonical run."
       );
       return;
     }
@@ -121013,7 +121009,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       preservePriorWorkspaceResources
     ));
     dependencies.core.info(
-      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+      "onboarding-scope=spec-only; updated only workspace/spec state in .postman/resources.yaml."
     );
     return;
   }
@@ -121181,7 +121177,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121206,7 +121202,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
+  const stagePaths = (inputs.onboardingScope === "spec-only" ? [".postman/resources.yaml"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
@@ -121236,7 +121232,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
+    removePaths: inputs.onboardingScope === "spec-only" || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -121281,11 +121277,12 @@ async function runRepoSync(inputs, dependencies, executionContext) {
   }
 }
 async function runRepoSyncInner(inputs, dependencies, executionContext) {
+  inputs = { ...inputs, onboardingScope: inputs.onboardingScope ?? "full" };
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
-  if (syncGeneratedAssets) {
+  const onboardingScope = inputs.onboardingScope;
+  if (onboardingScope === "full") {
     assertBranchAssetIds(inputs, branchDecision);
   }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
@@ -121312,7 +121309,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || onboardingScope === "full" && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121326,26 +121323,26 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
+    if (onboardingScope === "full" && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
+    if (onboardingScope === "full" && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.contractCollectionId) {
+    if (onboardingScope === "full" && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  if (!syncGeneratedAssets) {
+  if (onboardingScope === "spec-only") {
     inputs = {
       ...inputs,
       baselineCollectionId: "",
@@ -121365,10 +121362,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       mockEnvironmentEnabled: false
     };
     dependencies.core.info(
-      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+      "onboarding-scope=spec-only; skipping collections, environments, mocks, monitors, exports, and generated CI."
     );
   }
-  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
+  const preparedPrebuiltCollections = onboardingScope === "full" ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121403,7 +121400,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = syncGeneratedAssets ? await logger.phase(
+  const envUids = onboardingScope === "full" ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
   ) : {};
@@ -121894,7 +121891,7 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   }
   if (!keyValid && options.allowApiKeyCreation === false) {
     apiKey = "";
-    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+    actionCore.info("Skipping Postman API key creation because onboarding-scope=spec-only.");
   } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
@@ -122257,8 +122254,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
-    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
-    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
+    allowApiKeyCreation: inputs.onboardingScope === "full",
+    persistGeneratedApiKeySecret: inputs.onboardingScope === "full",
     env: process.env
   });
   const repository = inputs.repository;

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -115066,11 +115066,11 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
-    "sync-generated-assets": {
-      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+    "onboarding-scope": {
+      description: "Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only.",
       required: false,
-      default: "true",
-      allowedValues: ["true", "false"]
+      default: "full",
+      allowedValues: ["full", "spec-only"]
     },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
@@ -117481,12 +117481,11 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
-function parseStrictBooleanInput(name, value, defaultValue) {
+function parseOnboardingScope(value) {
   const normalized = String(value || "").trim().toLowerCase();
-  if (!normalized) return defaultValue;
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  throw new Error(`${name} must be either true or false; received "${value}"`);
+  if (!normalized) return "full";
+  if (normalized === "full" || normalized === "spec-only") return normalized;
+  throw new Error(`onboarding-scope must be either full or spec-only; received "${value}"`);
 }
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
@@ -117641,11 +117640,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput("baseline-collection-id", env),
     smokeCollectionId: getInput("smoke-collection-id", env),
     contractCollectionId: getInput("contract-collection-id", env),
-    syncGeneratedAssets: parseStrictBooleanInput(
-      "sync-generated-assets",
-      getInput("sync-generated-assets", env),
-      true
-    ),
+    onboardingScope: parseOnboardingScope(getInput("onboarding-scope", env)),
     prebuiltCollectionsJson: getInput("prebuilt-collections-json", env),
     specId: getInput("spec-id", env),
     specContentChanged: parseBooleanInput(getInput("spec-content-changed", env), true),
@@ -118864,10 +118859,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  if (inputs.syncGeneratedAssets !== false) {
+  if (inputs.onboardingScope === "full") {
     assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
   }
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -118878,7 +118873,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.onboardingScope === "spec-only" && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -118892,13 +118887,14 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const priorWorkspaceId = options.priorWorkspaceId?.trim();
   const preservePriorWorkspaceResources = Boolean(
-    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+    durableWorkspaceId && priorWorkspaceId && durableWorkspaceId === priorWorkspaceId
   );
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === "spec-only") {
     if (!options.isCanonicalWriter) {
       dependencies.core.info(
-        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+        "onboarding-scope=spec-only; skipping .postman/resources.yaml write on non-canonical run."
       );
       return;
     }
@@ -118917,7 +118913,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       preservePriorWorkspaceResources
     ));
     dependencies.core.info(
-      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+      "onboarding-scope=spec-only; updated only workspace/spec state in .postman/resources.yaml."
     );
     return;
   }
@@ -119085,7 +119081,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -119110,7 +119106,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
+  const stagePaths = (inputs.onboardingScope === "spec-only" ? [".postman/resources.yaml"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
@@ -119140,7 +119136,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
+    removePaths: inputs.onboardingScope === "spec-only" || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -119185,11 +119181,12 @@ async function runRepoSync(inputs, dependencies, executionContext) {
   }
 }
 async function runRepoSyncInner(inputs, dependencies, executionContext) {
+  inputs = { ...inputs, onboardingScope: inputs.onboardingScope ?? "full" };
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
-  if (syncGeneratedAssets) {
+  const onboardingScope = inputs.onboardingScope;
+  if (onboardingScope === "full") {
     assertBranchAssetIds(inputs, branchDecision);
   }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
@@ -119216,7 +119213,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || onboardingScope === "full" && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -119230,26 +119227,26 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
+    if (onboardingScope === "full" && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
+    if (onboardingScope === "full" && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.contractCollectionId) {
+    if (onboardingScope === "full" && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  if (!syncGeneratedAssets) {
+  if (onboardingScope === "spec-only") {
     inputs = {
       ...inputs,
       baselineCollectionId: "",
@@ -119269,10 +119266,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       mockEnvironmentEnabled: false
     };
     dependencies.core.info(
-      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+      "onboarding-scope=spec-only; skipping collections, environments, mocks, monitors, exports, and generated CI."
     );
   }
-  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
+  const preparedPrebuiltCollections = onboardingScope === "full" ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -119307,7 +119304,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = syncGeneratedAssets ? await logger.phase(
+  const envUids = onboardingScope === "full" ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
   ) : {};
@@ -119798,7 +119795,7 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   }
   if (!keyValid && options.allowApiKeyCreation === false) {
     apiKey = "";
-    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+    actionCore.info("Skipping Postman API key creation because onboarding-scope=spec-only.");
   } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
@@ -120493,7 +120490,7 @@ var CLI_INPUT_NAMES = [
   "baseline-collection-id",
   "smoke-collection-id",
   "contract-collection-id",
-  "sync-generated-assets",
+  "onboarding-scope",
   "prebuilt-collections-json",
   "collection-sync-mode",
   "spec-sync-mode",
@@ -120981,7 +120978,7 @@ async function runCli(argv = process.argv.slice(2), runtime = {}) {
     resolvingExec,
     initialMasker,
     {
-      allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+      allowApiKeyCreation: inputs.onboardingScope === "full",
       persistGeneratedApiKeySecret: false,
       env
     }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -115066,6 +115066,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -117475,6 +117481,13 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
+function parseStrictBooleanInput(name, value, defaultValue) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  throw new Error(`${name} must be either true or false; received "${value}"`);
+}
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
 }
@@ -117628,6 +117641,11 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput("baseline-collection-id", env),
     smokeCollectionId: getInput("smoke-collection-id", env),
     contractCollectionId: getInput("contract-collection-id", env),
+    syncGeneratedAssets: parseStrictBooleanInput(
+      "sync-generated-assets",
+      getInput("sync-generated-assets", env),
+      true
+    ),
     prebuiltCollectionsJson: getInput("prebuilt-collections-json", env),
     specId: getInput("spec-id", env),
     specContentChanged: parseBooleanInput(getInput("spec-content-changed", env), true),
@@ -118272,7 +118290,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -118284,13 +118302,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -118841,8 +118864,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -118853,7 +118878,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -118861,6 +118886,41 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
+  if (inputs.syncGeneratedAssets === false) {
+    if (!options.isCanonicalWriter) {
+      dependencies.core.info(
+        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+      );
+      return;
+    }
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
+      options.priorState,
+      preservePriorWorkspaceResources
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -118957,12 +119017,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -119031,7 +119085,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -119056,13 +119110,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -119086,7 +119140,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -119134,7 +119188,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -119159,7 +119216,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -119173,29 +119230,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -119230,10 +119307,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {
@@ -119592,6 +119669,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   await logger.phase(
     "export-artifacts",
     async () => exportArtifacts(inputs, dependencies, envUids, assetProjectName, {
+      isCanonicalWriter,
       workspaceLinkStatus: outputs["workspace-link-status"],
       priorWorkspaceId: resourcesState?.workspace?.id,
       existingSpecs: resourcesState?.cloudResources?.specs,
@@ -119718,7 +119796,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }
@@ -120412,6 +120493,7 @@ var CLI_INPUT_NAMES = [
   "baseline-collection-id",
   "smoke-collection-id",
   "contract-collection-id",
+  "sync-generated-assets",
   "prebuilt-collections-json",
   "collection-sync-mode",
   "spec-sync-mode",
@@ -120899,6 +120981,7 @@ async function runCli(argv = process.argv.slice(2), runtime = {}) {
     resolvingExec,
     initialMasker,
     {
+      allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
       persistGeneratedApiKeySecret: false,
       env
     }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -116987,11 +116987,11 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
-    "sync-generated-assets": {
-      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+    "onboarding-scope": {
+      description: "Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only.",
       required: false,
-      default: "true",
-      allowedValues: ["true", "false"]
+      default: "full",
+      allowedValues: ["full", "spec-only"]
     },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
@@ -119454,12 +119454,11 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
-function parseStrictBooleanInput(name, value, defaultValue) {
+function parseOnboardingScope(value) {
   const normalized = String(value || "").trim().toLowerCase();
-  if (!normalized) return defaultValue;
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  throw new Error(`${name} must be either true or false; received "${value}"`);
+  if (!normalized) return "full";
+  if (normalized === "full" || normalized === "spec-only") return normalized;
+  throw new Error(`onboarding-scope must be either full or spec-only; received "${value}"`);
 }
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
@@ -119617,11 +119616,7 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
-    syncGeneratedAssets: parseStrictBooleanInput(
-      "sync-generated-assets",
-      getInput2("sync-generated-assets", env),
-      true
-    ),
+    onboardingScope: parseOnboardingScope(getInput2("onboarding-scope", env)),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -120043,7 +120038,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
-    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
+    INPUT_ONBOARDING_SCOPE: readInput(actionCore, "onboarding-scope"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120107,7 +120102,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
+  if (inputs.onboardingScope === "full" && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }
@@ -120142,7 +120137,7 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === "spec-only") {
     return;
   }
   if (!inputs.sslClientCert) {
@@ -120986,10 +120981,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  if (inputs.syncGeneratedAssets !== false) {
+  if (inputs.onboardingScope === "full") {
     assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
   }
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -121000,7 +120995,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.onboardingScope === "spec-only" && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -121014,13 +121009,14 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const priorWorkspaceId = options.priorWorkspaceId?.trim();
   const preservePriorWorkspaceResources = Boolean(
-    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+    durableWorkspaceId && priorWorkspaceId && durableWorkspaceId === priorWorkspaceId
   );
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === "spec-only") {
     if (!options.isCanonicalWriter) {
       dependencies.core.info(
-        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+        "onboarding-scope=spec-only; skipping .postman/resources.yaml write on non-canonical run."
       );
       return;
     }
@@ -121039,7 +121035,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       preservePriorWorkspaceResources
     ));
     dependencies.core.info(
-      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+      "onboarding-scope=spec-only; updated only workspace/spec state in .postman/resources.yaml."
     );
     return;
   }
@@ -121207,7 +121203,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === "full" && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121232,7 +121228,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
+  const stagePaths = (inputs.onboardingScope === "spec-only" ? [".postman/resources.yaml"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
@@ -121262,7 +121258,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
+    removePaths: inputs.onboardingScope === "spec-only" || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -121307,11 +121303,12 @@ async function runRepoSync(inputs, dependencies, executionContext) {
   }
 }
 async function runRepoSyncInner(inputs, dependencies, executionContext) {
+  inputs = { ...inputs, onboardingScope: inputs.onboardingScope ?? "full" };
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
-  if (syncGeneratedAssets) {
+  const onboardingScope = inputs.onboardingScope;
+  if (onboardingScope === "full") {
     assertBranchAssetIds(inputs, branchDecision);
   }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
@@ -121338,7 +121335,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || onboardingScope === "full" && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121352,26 +121349,26 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
+    if (onboardingScope === "full" && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
+    if (onboardingScope === "full" && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (syncGeneratedAssets && !inputs.contractCollectionId) {
+    if (onboardingScope === "full" && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  if (!syncGeneratedAssets) {
+  if (onboardingScope === "spec-only") {
     inputs = {
       ...inputs,
       baselineCollectionId: "",
@@ -121391,10 +121388,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       mockEnvironmentEnabled: false
     };
     dependencies.core.info(
-      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+      "onboarding-scope=spec-only; skipping collections, environments, mocks, monitors, exports, and generated CI."
     );
   }
-  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
+  const preparedPrebuiltCollections = onboardingScope === "full" ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121429,7 +121426,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = syncGeneratedAssets ? await logger.phase(
+  const envUids = onboardingScope === "full" ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
   ) : {};
@@ -121920,7 +121917,7 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
   }
   if (!keyValid && options.allowApiKeyCreation === false) {
     apiKey = "";
-    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+    actionCore.info("Skipping Postman API key creation because onboarding-scope=spec-only.");
   } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
@@ -122283,8 +122280,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
-    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
-    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
+    allowApiKeyCreation: inputs.onboardingScope === "full",
+    persistGeneratedApiKeySecret: inputs.onboardingScope === "full",
     env: process.env
   });
   const repository = inputs.repository;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -116987,6 +116987,12 @@ var postmanRepoSyncActionContract = {
       description: "Contract collection ID used for exported artifacts.",
       required: false
     },
+    "sync-generated-assets": {
+      description: "Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.",
+      required: false,
+      default: "true",
+      allowedValues: ["true", "false"]
+    },
     "prebuilt-collections-json": {
       description: "Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.",
       required: false,
@@ -119448,6 +119454,13 @@ function parseBooleanInput(value, defaultValue) {
   if (["false", "0", "no", "off"].includes(normalized)) return false;
   return defaultValue;
 }
+function parseStrictBooleanInput(name, value, defaultValue) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  throw new Error(`${name} must be either true or false; received "${value}"`);
+}
 function normalizeInputValue(value) {
   return String(value ?? "").trim();
 }
@@ -119604,6 +119617,11 @@ function resolveInputs(env = process.env) {
     baselineCollectionId: getInput2("baseline-collection-id", env),
     smokeCollectionId: getInput2("smoke-collection-id", env),
     contractCollectionId: getInput2("contract-collection-id", env),
+    syncGeneratedAssets: parseStrictBooleanInput(
+      "sync-generated-assets",
+      getInput2("sync-generated-assets", env),
+      true
+    ),
     prebuiltCollectionsJson: getInput2("prebuilt-collections-json", env),
     specId: getInput2("spec-id", env),
     specContentChanged: parseBooleanInput(getInput2("spec-content-changed", env), true),
@@ -120025,6 +120043,7 @@ function readActionInputs(actionCore) {
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, "baseline-collection-id"),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, "smoke-collection-id"),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, "contract-collection-id"),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, "sync-generated-assets"),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, "prebuilt-collections-json"),
     INPUT_SPEC_ID: readInput(actionCore, "spec-id"),
     INPUT_SPEC_PATH: readInput(actionCore, "spec-path"),
@@ -120088,7 +120107,7 @@ function readActionInputs(actionCore) {
   if (inputs.sslClientKey) actionCore.setSecret(inputs.sslClientKey);
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error("ssl-client-key is required when ssl-client-cert is provided");
     }
@@ -120123,6 +120142,9 @@ function buildGhCliEnv(env, token) {
   return filtered;
 }
 async function persistSslSecrets(inputs, actionCore, actionExec, repository, env = process.env) {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -120390,7 +120412,7 @@ function resolveDurableWorkspaceId(options) {
   }
   return prior === candidate ? prior : void 0;
 }
-function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState) {
+function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir, localSpecRefs, mappedSpecRef, specId, existingSpecs, priorState, preserveGeneratedAssets = false) {
   const manifest = { ...priorState ?? {} };
   delete manifest.version;
   delete manifest.workspace;
@@ -120402,13 +120424,18 @@ function buildResourcesManifest(workspaceId, collectionMap, envMap, artifactDir,
     manifest.workspace = { id: workspaceId };
   }
   const cloudResources = {};
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.collections ?? {}, ...collectionMap } : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
+  const priorEnvironmentMap = preserveGeneratedAssets ? { ...priorState?.cloudResources?.environments ?? {} } : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -120959,8 +120986,10 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   if (!inputs.workspaceId) {
     return;
   }
-  assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, "artifact-dir");
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
   }
   const collectionsDir = `${inputs.artifactDir}/collections`;
@@ -120971,7 +121000,7 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
   const specsDir = `${inputs.artifactDir}/specs`;
   const manifestCollections = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, ".", {
+  const { discoveredSpecs, mappedSpec } = inputs.syncGeneratedAssets === false && !inputs.specId ? { discoveredSpecs: [], mappedSpec: void 0 } : resolveLocalSpecReferences(inputs.specPath, ".", {
     ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, ".postman"] : [".postman"]
   });
   const mappedSpecCloudKey = mappedSpec && inputs.specId ? buildMappedSpecCloudKey(
@@ -120979,6 +121008,41 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
     inputs.specSyncMode,
     options.releaseLabel
   ) : void 0;
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId && options.priorWorkspaceId && durableWorkspaceId === options.priorWorkspaceId
+  );
+  if (inputs.syncGeneratedAssets === false) {
+    if (!options.isCanonicalWriter) {
+      dependencies.core.info(
+        "Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run."
+      );
+      return;
+    }
+    ensureDir(".postman");
+    assertPathWithinCwd(".postman/resources.yaml", "resources state target");
+    (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || void 0,
+      preservePriorWorkspaceResources ? options.existingSpecs : void 0,
+      options.priorState,
+      preservePriorWorkspaceResources
+    ));
+    dependencies.core.info(
+      "Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml."
+    );
+    return;
+  }
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
   const collectionSpecs = [
@@ -121075,12 +121139,6 @@ async function exportArtifacts(inputs, dependencies, envUids, assetProjectName, 
       true
     );
   }
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
   assertPathWithinCwd(".postman/resources.yaml", "resources state target");
   (0, import_node_fs5.writeFileSync)(".postman/resources.yaml", buildResourcesManifest(
     durableWorkspaceId,
@@ -121149,7 +121207,7 @@ function createRepoSummary(outputs, envUids, pushed) {
   });
 }
 async function commitAndPushGeneratedFiles(inputs, dependencies) {
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, "ci-workflow-path");
     const parts = inputs.ciWorkflowPath.split("/");
@@ -121174,13 +121232,13 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
   const provisionExists = inputs.provider === "github" && (0, import_node_fs5.existsSync)(provisionPath);
   const gcWorkflowPath = ".github/workflows/postman-preview-gc.yml";
   const gcExists = inputs.generateCiWorkflow && (0, import_node_fs5.existsSync)(gcWorkflowPath);
-  const stagePaths = [
+  const stagePaths = (inputs.syncGeneratedAssets === false ? [".postman"] : [
     inputs.artifactDir,
     ".postman",
     inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
     gcExists ? gcWorkflowPath : null,
     provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
+  ]).filter((entry) => typeof entry === "string" && ((0, import_node_fs5.existsSync)(entry) || entry === provisionPath));
   if (stagePaths.length === 0) {
     dependencies.core.info("No generated repository paths were found; skipping repo mutation.");
     return {
@@ -121204,7 +121262,7 @@ async function commitAndPushGeneratedFiles(inputs, dependencies) {
     adoToken: inputs.provider === "azure-devops" ? inputs.adoToken : void 0,
     githubToken: inputs.provider === "azure-devops" ? void 0 : inputs.githubToken,
     fallbackToken: inputs.provider === "azure-devops" ? void 0 : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
   return {
@@ -121252,7 +121310,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   const mask = resolveRepoSyncMasker(dependencies);
   const logger = resolveRepoSyncLogger(dependencies);
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === "legacy" || branchDecision.tier === "canonical";
   if (!isCanonicalWriter) {
     if (branchDecision.tier === "preview" && branchDecision.identity.headBranch) {
@@ -121277,7 +121338,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     );
   }
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === "version" || inputs.specSyncMode === "version";
+  const versionRequested = inputs.specSyncMode === "version" || syncGeneratedAssets && inputs.collectionSyncMode === "version";
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error("release-label is required when collection-sync-mode or spec-sync-mode is version");
@@ -121291,29 +121352,49 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
       dependencies.core.info("Resolved workspace-id from .postman/resources.yaml");
     }
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId = findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || "";
       if (inputs.baselineCollectionId) {
         dependencies.core.info("Resolved baseline-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Smoke]")) || "";
       if (inputs.smokeCollectionId) {
         dependencies.core.info("Resolved smoke-collection-id from .postman/resources.yaml");
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId = findCloudResourceId(cloudCollections, (filePath) => filePath.includes("[Contract]")) || "";
       if (inputs.contractCollectionId) {
         dependencies.core.info("Resolved contract-collection-id from .postman/resources.yaml");
       }
     }
   }
-  const preparedPrebuiltCollections = await logger.phase(
-    "prepare-collections",
-    async () => preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: "",
+      smokeCollectionId: "",
+      contractCollectionId: "",
+      prebuiltCollectionsJson: void 0,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: "",
+      monitorCron: "",
+      monitorType: "cli",
+      mockUrl: "",
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      "Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI."
+    );
+  }
+  const preparedPrebuiltCollections = syncGeneratedAssets ? await logger.phase("prepare-collections", async () => preparePrebuiltCollections(inputs)) : /* @__PURE__ */ new Map();
   let skipRepositoryLinkPost = false;
   let repositoryLinkPreflightWasFree = false;
   if (inputs.workspaceLinkEnabled && inputs.workspaceId && inputs.repoUrl && dependencies.internalIntegration?.findWorkspaceForRepo) {
@@ -121348,10 +121429,10 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
     }
   }
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase(
+  const envUids = syncGeneratedAssets ? await logger.phase(
     "sync-environments",
     async () => upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  ) : {};
   outputs["environment-uids-json"] = JSON.stringify(envUids);
   dependencies.core.setOutput("environment-uids-json", outputs["environment-uids-json"]);
   if (inputs.environmentSyncEnabled && inputs.workspaceId && dependencies.internalIntegration) {
@@ -121710,6 +121791,7 @@ async function runRepoSyncInner(inputs, dependencies, executionContext) {
   await logger.phase(
     "export-artifacts",
     async () => exportArtifacts(inputs, dependencies, envUids, assetProjectName, {
+      isCanonicalWriter,
       workspaceLinkStatus: outputs["workspace-link-status"],
       priorWorkspaceId: resourcesState?.workspace?.id,
       existingSpecs: resourcesState?.cloudResources?.specs,
@@ -121836,7 +121918,10 @@ async function resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, mas
       }
     }
   }
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = "";
+    actionCore.info("Skipping Postman API key creation because generated assets are disabled.");
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error("postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.");
     }
@@ -122198,6 +122283,8 @@ async function runAction(actionCore = core_exports, actionExec = exec_exports) {
     }
   });
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ const CLI_INPUT_NAMES = [
   'baseline-collection-id',
   'smoke-collection-id',
   'contract-collection-id',
-  'sync-generated-assets',
+  'onboarding-scope',
   'prebuilt-collections-json',
   'collection-sync-mode',
   'spec-sync-mode',
@@ -626,7 +626,7 @@ export async function runCli(
       resolvingExec,
       initialMasker,
       {
-        allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+        allowApiKeyCreation: inputs.onboardingScope === 'full',
         persistGeneratedApiKeySecret: false,
         env
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ const CLI_INPUT_NAMES = [
   'baseline-collection-id',
   'smoke-collection-id',
   'contract-collection-id',
+  'sync-generated-assets',
   'prebuilt-collections-json',
   'collection-sync-mode',
   'spec-sync-mode',
@@ -625,6 +626,7 @@ export async function runCli(
       resolvingExec,
       initialMasker,
       {
+        allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
         persistGeneratedApiKeySecret: false,
         env
       }

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -132,11 +132,11 @@ export const postmanRepoSyncActionContract: {
       description: 'Contract collection ID used for exported artifacts.',
       required: false
     },
-    'sync-generated-assets': {
-      description: 'Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.',
+    'onboarding-scope': {
+      description: 'Onboarding scope. Use full for the complete pipeline or spec-only for repository linking and workspace/spec state only.',
       required: false,
-      default: 'true',
-      allowedValues: ['true', 'false']
+      default: 'full',
+      allowedValues: ['full', 'spec-only']
     },
     'prebuilt-collections-json': {
       description:

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -132,6 +132,12 @@ export const postmanRepoSyncActionContract: {
       description: 'Contract collection ID used for exported artifacts.',
       required: false
     },
+    'sync-generated-assets': {
+      description: 'Whether to create or update collections, environments, mocks, monitors, exported Postman assets, and generated CI. Set false for workspace/spec-only onboarding; existing generated assets are left unchanged.',
+      required: false,
+      default: 'true',
+      allowedValues: ['true', 'false']
+    },
     'prebuilt-collections-json': {
       description:
         'Optional digest-bound JSON manifest of unique baseline, smoke, or contract roles with confined repo-relative path, SHA-256 artifact digest of the on-disk v3 collection tree (sorted relative-path + NUL + bytes + NUL), and canonical cloud ID. The optional payloadDigest field is the semantic v2 payload digest carried for provenance (format-validated only, not the reuse gate). Exact role, path, cloudId, and artifactDigest matches reuse the on-disk tree without cloud export.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export interface ResolvedInputs {
   baselineCollectionId: string;
   smokeCollectionId: string;
   contractCollectionId: string;
-  syncGeneratedAssets?: boolean;
+  onboardingScope: 'full' | 'spec-only';
   /** Optional digest-bound prebuilt collection manifest JSON from bootstrap. */
   prebuiltCollectionsJson?: string;
   collectionSyncMode: 'refresh' | 'version';
@@ -401,16 +401,11 @@ function parseBooleanInput(value: string, defaultValue: boolean): boolean {
   return defaultValue;
 }
 
-function parseStrictBooleanInput(
-  name: string,
-  value: string,
-  defaultValue: boolean
-): boolean {
+function parseOnboardingScope(value: string): 'full' | 'spec-only' {
   const normalized = String(value || '').trim().toLowerCase();
-  if (!normalized) return defaultValue;
-  if (normalized === 'true') return true;
-  if (normalized === 'false') return false;
-  throw new Error(`${name} must be either true or false; received "${value}"`);
+  if (!normalized) return 'full';
+  if (normalized === 'full' || normalized === 'spec-only') return normalized;
+  throw new Error(`onboarding-scope must be either full or spec-only; received "${value}"`);
 }
 
 function normalizeInputValue(value: string | undefined): string {
@@ -613,11 +608,7 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     baselineCollectionId: getInput('baseline-collection-id', env),
     smokeCollectionId: getInput('smoke-collection-id', env),
     contractCollectionId: getInput('contract-collection-id', env),
-    syncGeneratedAssets: parseStrictBooleanInput(
-      'sync-generated-assets',
-      getInput('sync-generated-assets', env),
-      true
-    ),
+    onboardingScope: parseOnboardingScope(getInput('onboarding-scope', env)),
     prebuiltCollectionsJson: getInput('prebuilt-collections-json', env),
     specId: getInput('spec-id', env),
     specContentChanged: parseBooleanInput(getInput('spec-content-changed', env), true),
@@ -1224,7 +1215,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
-    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, 'sync-generated-assets'),
+    INPUT_ONBOARDING_SCOPE: readInput(actionCore, 'onboarding-scope'),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, 'prebuilt-collections-json'),
     INPUT_SPEC_ID: readInput(actionCore, 'spec-id'),
     INPUT_SPEC_PATH: readInput(actionCore, 'spec-path'),
@@ -1290,7 +1281,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
 
-  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
+  if (inputs.onboardingScope === 'full' && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error('ssl-client-key is required when ssl-client-cert is provided');
     }
@@ -1334,7 +1325,7 @@ export async function persistSslSecrets(
   repository: string,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === 'spec-only') {
     return;
   }
   if (!inputs.sslClientCert) {
@@ -2494,10 +2485,10 @@ async function exportArtifacts(
     return;
   }
 
-  if (inputs.syncGeneratedAssets !== false) {
+  if (inputs.onboardingScope === 'full') {
     assertPathWithinCwd(inputs.artifactDir, 'artifact-dir');
   }
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === 'full' && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
   }
 
@@ -2511,7 +2502,7 @@ async function exportArtifacts(
   const manifestCollections: Record<string, string> = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
   const { discoveredSpecs, mappedSpec } =
-    inputs.syncGeneratedAssets === false && !inputs.specId
+    inputs.onboardingScope === 'spec-only' && !inputs.specId
       ? { discoveredSpecs: [], mappedSpec: undefined }
       : resolveLocalSpecReferences(inputs.specPath, '.', {
           ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, '.postman'] : ['.postman']
@@ -2531,16 +2522,17 @@ async function exportArtifacts(
     workspaceLinkEnabled: inputs.workspaceLinkEnabled,
     workspaceLinkStatus: options.workspaceLinkStatus
   });
+  const priorWorkspaceId = options.priorWorkspaceId?.trim();
   const preservePriorWorkspaceResources = Boolean(
     durableWorkspaceId &&
-    options.priorWorkspaceId &&
-    durableWorkspaceId === options.priorWorkspaceId
+    priorWorkspaceId &&
+    durableWorkspaceId === priorWorkspaceId
   );
 
-  if (inputs.syncGeneratedAssets === false) {
+  if (inputs.onboardingScope === 'spec-only') {
     if (!options.isCanonicalWriter) {
       dependencies.core.info(
-        'Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run.'
+        'onboarding-scope=spec-only; skipping .postman/resources.yaml write on non-canonical run.'
       );
       return;
     }
@@ -2559,7 +2551,7 @@ async function exportArtifacts(
       preservePriorWorkspaceResources
     ));
     dependencies.core.info(
-      'Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml.'
+      'onboarding-scope=spec-only; updated only workspace/spec state in .postman/resources.yaml.'
     );
     return;
   }
@@ -2745,7 +2737,7 @@ async function commitAndPushGeneratedFiles(
 ): Promise<{ commitSha: string; resolvedCurrentRef: string; pushed: boolean }> {
   // File generation is independent of git mutation: mode=none still writes the
   // requested CI workflow, but never stages/commits/pushes.
-  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
+  if (inputs.onboardingScope === 'full' && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
 
@@ -2780,8 +2772,8 @@ async function commitAndPushGeneratedFiles(
   const gcWorkflowPath = '.github/workflows/postman-preview-gc.yml';
   const gcExists = inputs.generateCiWorkflow && existsSync(gcWorkflowPath);
 
-  const stagePaths = (inputs.syncGeneratedAssets === false
-    ? ['.postman']
+  const stagePaths = (inputs.onboardingScope === 'spec-only'
+    ? ['.postman/resources.yaml']
     : [
         inputs.artifactDir,
         '.postman',
@@ -2815,7 +2807,7 @@ async function commitAndPushGeneratedFiles(
     adoToken: inputs.provider === 'azure-devops' ? inputs.adoToken : undefined,
     githubToken: inputs.provider === 'azure-devops' ? undefined : inputs.githubToken,
     fallbackToken: inputs.provider === 'azure-devops' ? undefined : inputs.ghFallbackToken,
-    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
+    removePaths: inputs.onboardingScope === 'spec-only' || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
 
@@ -2875,6 +2867,7 @@ async function runRepoSyncInner(
   dependencies: RepoSyncDependencies,
   executionContext?: RepoSyncExecutionContext
 ): Promise<RepoSyncOutputs> {
+  inputs = { ...inputs, onboardingScope: inputs.onboardingScope ?? 'full' };
   const mask = resolveRepoSyncMasker(dependencies);
   // Normally the instance runRepoSync built and registered secrets on; the
   // fallback only matters for tests that call this path directly.
@@ -2885,8 +2878,8 @@ async function runRepoSyncInner(
   // inputs). Gated runs never reach here (runAction short-circuits), so the
   // non-canonical tiers seen here are preview and channel.
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
-  if (syncGeneratedAssets) {
+  const onboardingScope = inputs.onboardingScope;
+  if (onboardingScope === 'full') {
     assertBranchAssetIds(inputs, branchDecision);
   }
   const isCanonicalWriter = branchDecision.tier === 'legacy' || branchDecision.tier === 'canonical';
@@ -2918,7 +2911,7 @@ async function runRepoSyncInner(
   const outputs = createOutputs(inputs);
   const versionRequested =
     inputs.specSyncMode === 'version' ||
-    (syncGeneratedAssets && inputs.collectionSyncMode === 'version');
+    (onboardingScope === 'full' && inputs.collectionSyncMode === 'version');
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error('release-label is required when collection-sync-mode or spec-sync-mode is version');
@@ -2942,21 +2935,21 @@ async function runRepoSyncInner(
     }
 
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
+    if (onboardingScope === 'full' && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || '';
       if (inputs.baselineCollectionId) {
         dependencies.core.info('Resolved baseline-collection-id from .postman/resources.yaml');
       }
     }
-    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
+    if (onboardingScope === 'full' && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Smoke]')) || '';
       if (inputs.smokeCollectionId) {
         dependencies.core.info('Resolved smoke-collection-id from .postman/resources.yaml');
       }
     }
-    if (syncGeneratedAssets && !inputs.contractCollectionId) {
+    if (onboardingScope === 'full' && !inputs.contractCollectionId) {
       inputs.contractCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Contract]')) || '';
       if (inputs.contractCollectionId) {
@@ -2965,7 +2958,7 @@ async function runRepoSyncInner(
     }
   }
 
-  if (!syncGeneratedAssets) {
+  if (onboardingScope === 'spec-only') {
     inputs = {
       ...inputs,
       baselineCollectionId: '',
@@ -2985,11 +2978,11 @@ async function runRepoSyncInner(
       mockEnvironmentEnabled: false
     };
     dependencies.core.info(
-      'Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI.'
+      'onboarding-scope=spec-only; skipping collections, environments, mocks, monitors, exports, and generated CI.'
     );
   }
 
-  const preparedPrebuiltCollections = syncGeneratedAssets
+  const preparedPrebuiltCollections = onboardingScope === 'full'
     ? await logger.phase('prepare-collections', async () => preparePrebuiltCollections(inputs))
     : new Map<PrebuiltCollectionRole, PreparedPrebuiltCollectionEntry>();
 
@@ -3038,7 +3031,7 @@ async function runRepoSyncInner(
   }
 
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = syncGeneratedAssets
+  const envUids = onboardingScope === 'full'
     ? await logger.phase('sync-environments', async () =>
         upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
       )
@@ -3634,7 +3627,7 @@ export async function resolvePostmanApiKeyAndTeamId(
 
   if (!keyValid && options.allowApiKeyCreation === false) {
     apiKey = '';
-    actionCore.info('Skipping Postman API key creation because generated assets are disabled.');
+    actionCore.info('Skipping Postman API key creation because onboarding-scope=spec-only.');
   } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error('postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.');
@@ -4110,8 +4103,8 @@ export async function runAction(
   });
 
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
-    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
-    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
+    allowApiKeyCreation: inputs.onboardingScope === 'full',
+    persistGeneratedApiKeySecret: inputs.onboardingScope === 'full',
     env: process.env
   });
   const repository = inputs.repository;

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export interface ResolvedInputs {
   baselineCollectionId: string;
   smokeCollectionId: string;
   contractCollectionId: string;
+  syncGeneratedAssets?: boolean;
   /** Optional digest-bound prebuilt collection manifest JSON from bootstrap. */
   prebuiltCollectionsJson?: string;
   collectionSyncMode: 'refresh' | 'version';
@@ -400,6 +401,18 @@ function parseBooleanInput(value: string, defaultValue: boolean): boolean {
   return defaultValue;
 }
 
+function parseStrictBooleanInput(
+  name: string,
+  value: string,
+  defaultValue: boolean
+): boolean {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  throw new Error(`${name} must be either true or false; received "${value}"`);
+}
+
 function normalizeInputValue(value: string | undefined): string {
   return String(value ?? '').trim();
 }
@@ -600,6 +613,11 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     baselineCollectionId: getInput('baseline-collection-id', env),
     smokeCollectionId: getInput('smoke-collection-id', env),
     contractCollectionId: getInput('contract-collection-id', env),
+    syncGeneratedAssets: parseStrictBooleanInput(
+      'sync-generated-assets',
+      getInput('sync-generated-assets', env),
+      true
+    ),
     prebuiltCollectionsJson: getInput('prebuilt-collections-json', env),
     specId: getInput('spec-id', env),
     specContentChanged: parseBooleanInput(getInput('spec-content-changed', env), true),
@@ -1206,6 +1224,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
     INPUT_BASELINE_COLLECTION_ID: readInput(actionCore, 'baseline-collection-id'),
     INPUT_SMOKE_COLLECTION_ID: readInput(actionCore, 'smoke-collection-id'),
     INPUT_CONTRACT_COLLECTION_ID: readInput(actionCore, 'contract-collection-id'),
+    INPUT_SYNC_GENERATED_ASSETS: readInput(actionCore, 'sync-generated-assets'),
     INPUT_PREBUILT_COLLECTIONS_JSON: readInput(actionCore, 'prebuilt-collections-json'),
     INPUT_SPEC_ID: readInput(actionCore, 'spec-id'),
     INPUT_SPEC_PATH: readInput(actionCore, 'spec-path'),
@@ -1271,7 +1290,7 @@ export function readActionInputs(actionCore: Pick<CoreLike, 'getInput' | 'setSec
   if (inputs.sslClientPassphrase) actionCore.setSecret(inputs.sslClientPassphrase);
   if (inputs.sslExtraCaCerts) actionCore.setSecret(inputs.sslExtraCaCerts);
 
-  if (inputs.sslClientCert) {
+  if (inputs.syncGeneratedAssets !== false && inputs.sslClientCert) {
     if (!inputs.sslClientKey) {
       throw new Error('ssl-client-key is required when ssl-client-cert is provided');
     }
@@ -1315,6 +1334,9 @@ export async function persistSslSecrets(
   repository: string,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
+  if (inputs.syncGeneratedAssets === false) {
+    return;
+  }
   if (!inputs.sslClientCert) {
     return;
   }
@@ -1670,7 +1692,8 @@ function buildResourcesManifest(
   mappedSpecRef?: string,
   specId?: string,
   existingSpecs?: CloudResourceMap,
-  priorState?: PostmanResourcesState | null
+  priorState?: PostmanResourcesState | null,
+  preserveGeneratedAssets = false
 ): string {
   // Merge-preserving writer (state v2): round-trip every unknown field from
   // the prior tracked state instead of rebuilding the document from scratch,
@@ -1689,15 +1712,24 @@ function buildResourcesManifest(
   const cloudResources: Record<string, Record<string, string>> = {};
 
   // Collections
-  const collectionKeys = Object.keys(collectionMap);
+  const effectiveCollectionMap = preserveGeneratedAssets
+    ? { ...(priorState?.cloudResources?.collections ?? {}), ...collectionMap }
+    : collectionMap;
+  const collectionKeys = Object.keys(effectiveCollectionMap);
   if (collectionKeys.length > 0) {
-    cloudResources.collections = collectionMap;
+    cloudResources.collections = effectiveCollectionMap;
   }
 
   // Environments
+  const priorEnvironmentMap = preserveGeneratedAssets
+    ? { ...(priorState?.cloudResources?.environments ?? {}) }
+    : {};
   const envEntries = Object.entries(envMap);
+  if (Object.keys(priorEnvironmentMap).length > 0 || envEntries.length > 0) {
+    cloudResources.environments = priorEnvironmentMap;
+  }
   if (envEntries.length > 0) {
-    cloudResources.environments = {};
+    cloudResources.environments ??= {};
     for (const [envName, envUid] of envEntries) {
       cloudResources.environments[`../${artifactDir}/environments/${envName}.postman_environment.json`] = envUid;
     }
@@ -2447,6 +2479,7 @@ async function exportArtifacts(
   envUids: Record<string, string>,
   assetProjectName: string,
   options: {
+    isCanonicalWriter: boolean;
     workspaceLinkStatus: Status;
     priorWorkspaceId?: string;
     existingSpecs?: CloudResourceMap;
@@ -2461,8 +2494,10 @@ async function exportArtifacts(
     return;
   }
 
-  assertPathWithinCwd(inputs.artifactDir, 'artifact-dir');
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false) {
+    assertPathWithinCwd(inputs.artifactDir, 'artifact-dir');
+  }
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
   }
 
@@ -2475,9 +2510,12 @@ async function exportArtifacts(
 
   const manifestCollections: Record<string, string> = {};
   const artifactDirPrefix = canonicalizeRelativePath(inputs.artifactDir);
-  const { discoveredSpecs, mappedSpec } = resolveLocalSpecReferences(inputs.specPath, '.', {
-    ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, '.postman'] : ['.postman']
-  });
+  const { discoveredSpecs, mappedSpec } =
+    inputs.syncGeneratedAssets === false && !inputs.specId
+      ? { discoveredSpecs: [], mappedSpec: undefined }
+      : resolveLocalSpecReferences(inputs.specPath, '.', {
+          ignoredPrefixes: artifactDirPrefix ? [artifactDirPrefix, '.postman'] : ['.postman']
+        });
   const mappedSpecCloudKey =
     mappedSpec && inputs.specId
       ? buildMappedSpecCloudKey(
@@ -2486,6 +2524,45 @@ async function exportArtifacts(
           options.releaseLabel
         )
       : undefined;
+
+  const durableWorkspaceId = resolveDurableWorkspaceId({
+    candidateId: inputs.workspaceId,
+    priorId: options.priorWorkspaceId,
+    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
+    workspaceLinkStatus: options.workspaceLinkStatus
+  });
+  const preservePriorWorkspaceResources = Boolean(
+    durableWorkspaceId &&
+    options.priorWorkspaceId &&
+    durableWorkspaceId === options.priorWorkspaceId
+  );
+
+  if (inputs.syncGeneratedAssets === false) {
+    if (!options.isCanonicalWriter) {
+      dependencies.core.info(
+        'Generated asset sync disabled; skipping .postman/resources.yaml write on non-canonical run.'
+      );
+      return;
+    }
+    ensureDir('.postman');
+    assertPathWithinCwd('.postman/resources.yaml', 'resources state target');
+    writeFileSync('.postman/resources.yaml', buildResourcesManifest(
+      durableWorkspaceId,
+      {},
+      {},
+      inputs.artifactDir,
+      discoveredSpecs.map((spec) => spec.configRelativePath),
+      mappedSpecCloudKey,
+      inputs.specId || undefined,
+      preservePriorWorkspaceResources ? options.existingSpecs : undefined,
+      options.priorState,
+      preservePriorWorkspaceResources
+    ));
+    dependencies.core.info(
+      'Generated asset sync disabled; updated only workspace/spec state in .postman/resources.yaml.'
+    );
+    return;
+  }
 
   const prebuiltByRole = options.preparedPrebuiltCollections;
   const privateMockAuth = options.privateMockAuth === true;
@@ -2585,13 +2662,6 @@ async function exportArtifacts(
     );
   }
 
-  const durableWorkspaceId = resolveDurableWorkspaceId({
-    candidateId: inputs.workspaceId,
-    priorId: options.priorWorkspaceId,
-    workspaceLinkEnabled: inputs.workspaceLinkEnabled,
-    workspaceLinkStatus: options.workspaceLinkStatus
-  });
-
   assertPathWithinCwd('.postman/resources.yaml', 'resources state target');
   writeFileSync('.postman/resources.yaml', buildResourcesManifest(
     durableWorkspaceId,
@@ -2675,7 +2745,7 @@ async function commitAndPushGeneratedFiles(
 ): Promise<{ commitSha: string; resolvedCurrentRef: string; pushed: boolean }> {
   // File generation is independent of git mutation: mode=none still writes the
   // requested CI workflow, but never stages/commits/pushes.
-  if (inputs.generateCiWorkflow) {
+  if (inputs.syncGeneratedAssets !== false && inputs.generateCiWorkflow) {
     const ciWorkflow = renderCiWorkflow(inputs);
     assertPathWithinCwd(inputs.ciWorkflowPath, 'ci-workflow-path');
 
@@ -2710,13 +2780,16 @@ async function commitAndPushGeneratedFiles(
   const gcWorkflowPath = '.github/workflows/postman-preview-gc.yml';
   const gcExists = inputs.generateCiWorkflow && existsSync(gcWorkflowPath);
 
-  const stagePaths = [
-    inputs.artifactDir,
-    '.postman',
-    inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
-    gcExists ? gcWorkflowPath : null,
-    provisionExists ? provisionPath : null
-  ].filter((entry) => typeof entry === 'string' && (existsSync(entry) || entry === provisionPath)) as string[];
+  const stagePaths = (inputs.syncGeneratedAssets === false
+    ? ['.postman']
+    : [
+        inputs.artifactDir,
+        '.postman',
+        inputs.generateCiWorkflow ? inputs.ciWorkflowPath : null,
+        gcExists ? gcWorkflowPath : null,
+        provisionExists ? provisionPath : null
+      ]
+  ).filter((entry) => typeof entry === 'string' && (existsSync(entry) || entry === provisionPath)) as string[];
 
   if (stagePaths.length === 0) {
     dependencies.core.info('No generated repository paths were found; skipping repo mutation.');
@@ -2742,7 +2815,7 @@ async function commitAndPushGeneratedFiles(
     adoToken: inputs.provider === 'azure-devops' ? inputs.adoToken : undefined,
     githubToken: inputs.provider === 'azure-devops' ? undefined : inputs.githubToken,
     fallbackToken: inputs.provider === 'azure-devops' ? undefined : inputs.ghFallbackToken,
-    removePaths: provisionExists ? [provisionPath] : [],
+    removePaths: inputs.syncGeneratedAssets === false || !provisionExists ? [] : [provisionPath],
     stagePaths
   });
 
@@ -2812,7 +2885,10 @@ async function runRepoSyncInner(
   // inputs). Gated runs never reach here (runAction short-circuits), so the
   // non-canonical tiers seen here are preview and channel.
   const branchDecision = executionContext?.branchDecision ?? decideBranchTier(inputs);
-  assertBranchAssetIds(inputs, branchDecision);
+  const syncGeneratedAssets = inputs.syncGeneratedAssets !== false;
+  if (syncGeneratedAssets) {
+    assertBranchAssetIds(inputs, branchDecision);
+  }
   const isCanonicalWriter = branchDecision.tier === 'legacy' || branchDecision.tier === 'canonical';
   if (!isCanonicalWriter) {
     // Preview/channel runs: branch-scoped asset names; no repo-link mutation;
@@ -2840,7 +2916,9 @@ async function runRepoSyncInner(
   }
 
   const outputs = createOutputs(inputs);
-  const versionRequested = inputs.collectionSyncMode === 'version' || inputs.specSyncMode === 'version';
+  const versionRequested =
+    inputs.specSyncMode === 'version' ||
+    (syncGeneratedAssets && inputs.collectionSyncMode === 'version');
   const releaseLabel = deriveReleaseLabel(inputs);
   if (versionRequested && !releaseLabel) {
     throw new Error('release-label is required when collection-sync-mode or spec-sync-mode is version');
@@ -2864,21 +2942,21 @@ async function runRepoSyncInner(
     }
 
     const cloudCollections = resourcesState.cloudResources?.collections;
-    if (!inputs.baselineCollectionId) {
+    if (syncGeneratedAssets && !inputs.baselineCollectionId) {
       inputs.baselineCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => matchesBaselineCollectionResource(filePath, assetProjectName)) || '';
       if (inputs.baselineCollectionId) {
         dependencies.core.info('Resolved baseline-collection-id from .postman/resources.yaml');
       }
     }
-    if (!inputs.smokeCollectionId) {
+    if (syncGeneratedAssets && !inputs.smokeCollectionId) {
       inputs.smokeCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Smoke]')) || '';
       if (inputs.smokeCollectionId) {
         dependencies.core.info('Resolved smoke-collection-id from .postman/resources.yaml');
       }
     }
-    if (!inputs.contractCollectionId) {
+    if (syncGeneratedAssets && !inputs.contractCollectionId) {
       inputs.contractCollectionId =
         findCloudResourceId(cloudCollections, (filePath) => filePath.includes('[Contract]')) || '';
       if (inputs.contractCollectionId) {
@@ -2887,9 +2965,33 @@ async function runRepoSyncInner(
     }
   }
 
-  const preparedPrebuiltCollections = await logger.phase('prepare-collections', async () =>
-    preparePrebuiltCollections(inputs)
-  );
+  if (!syncGeneratedAssets) {
+    inputs = {
+      ...inputs,
+      baselineCollectionId: '',
+      smokeCollectionId: '',
+      contractCollectionId: '',
+      prebuiltCollectionsJson: undefined,
+      environments: [],
+      environmentUids: {},
+      envRuntimeUrls: {},
+      environmentSyncEnabled: false,
+      systemEnvMap: {},
+      generateCiWorkflow: false,
+      monitorId: '',
+      monitorCron: '',
+      monitorType: 'cli',
+      mockUrl: '',
+      mockEnvironmentEnabled: false
+    };
+    dependencies.core.info(
+      'Generated asset sync disabled; skipping collections, environments, mocks, monitors, exports, and generated CI.'
+    );
+  }
+
+  const preparedPrebuiltCollections = syncGeneratedAssets
+    ? await logger.phase('prepare-collections', async () => preparePrebuiltCollections(inputs))
+    : new Map<PrebuiltCollectionRole, PreparedPrebuiltCollectionEntry>();
 
   // Repo-link admission guard: Bifrost enforces global uniqueness of
   // (repository URL, path) -> workspace. Probe before any asset writes so a
@@ -2936,9 +3038,11 @@ async function runRepoSyncInner(
   }
 
   const branchAssetMarker = buildBranchAssetMarker(branchDecision, inputs);
-  const envUids = await logger.phase('sync-environments', async () =>
-    upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
-  );
+  const envUids = syncGeneratedAssets
+    ? await logger.phase('sync-environments', async () =>
+        upsertEnvironments(inputs, dependencies, resourcesState, branchAssetMarker)
+      )
+    : {};
   outputs['environment-uids-json'] = JSON.stringify(envUids);
   dependencies.core.setOutput('environment-uids-json', outputs['environment-uids-json']);
 
@@ -3356,6 +3460,7 @@ async function runRepoSyncInner(
 
   await logger.phase('export-artifacts', async () =>
     exportArtifacts(inputs, dependencies, envUids, assetProjectName, {
+      isCanonicalWriter,
       workspaceLinkStatus: outputs['workspace-link-status'],
       priorWorkspaceId: resourcesState?.workspace?.id,
       existingSpecs: resourcesState?.cloudResources?.specs,
@@ -3475,6 +3580,7 @@ export async function resolvePostmanApiKeyAndTeamId(
   actionExec: ExecLike,
   masker: SecretMasker,
   options: {
+    allowApiKeyCreation?: boolean;
     persistGeneratedApiKeySecret?: boolean;
     env: NodeJS.ProcessEnv;
   }
@@ -3526,7 +3632,10 @@ export async function resolvePostmanApiKeyAndTeamId(
     }
   }
 
-  if (!keyValid) {
+  if (!keyValid && options.allowApiKeyCreation === false) {
+    apiKey = '';
+    actionCore.info('Skipping Postman API key creation because generated assets are disabled.');
+  } else if (!keyValid) {
     if (!inputs.postmanAccessToken) {
       throw new Error('postman-api-key is missing or invalid, and no postman-access-token provided to generate a new one.');
     }
@@ -4001,6 +4110,8 @@ export async function runAction(
   });
 
   const resolved = await resolvePostmanApiKeyAndTeamId(inputs, actionCore, actionExec, masker, {
+    allowApiKeyCreation: inputs.syncGeneratedAssets !== false,
+    persistGeneratedApiKeySecret: inputs.syncGeneratedAssets !== false,
     env: process.env
   });
   const repository = inputs.repository;

--- a/tests/access-token-routing.test.ts
+++ b/tests/access-token-routing.test.ts
@@ -19,6 +19,7 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',
     releaseLabel: undefined,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -432,6 +432,42 @@ describe('runCli credential preflight seam', () => {
     expect(logged).toMatch(/\[repo-sync timing\] \{"stage":"runRepoSync finalize","ms":\d+(?:\.\d+)?,"status":"success"\}/);
   });
 
+  it('does not mint a Postman API key in specs-only CLI mode', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/current')) {
+        return new Response(
+          JSON.stringify({ identity: { team: 333 }, data: { user: { id: 'u-sess' } } }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      throw new Error(`unexpected fetch in specs-only CLI test: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const executeRepoSync = vi.fn(async () => fullRepoSyncOutputs());
+
+    await withTempCwd(async () => {
+      await runCli(
+        [
+          '--project-name', 'specs-only',
+          '--postman-access-token', 'tok-only',
+          '--team-id', '333',
+          '--org-mode', 'true',
+          '--sync-generated-assets', 'false',
+          '--credential-preflight', 'warn',
+          '--repo-write-mode', 'none'
+        ],
+        { env: {}, executeRepoSync, writeStdout: () => undefined }
+      );
+    });
+
+    expect(executeRepoSync).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+      'https://iapub.postman.co/api/sessions/current'
+    ]);
+  });
+
   it.each([
     {
       name: 'preview',

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -432,7 +432,7 @@ describe('runCli credential preflight seam', () => {
     expect(logged).toMatch(/\[repo-sync timing\] \{"stage":"runRepoSync finalize","ms":\d+(?:\.\d+)?,"status":"success"\}/);
   });
 
-  it('does not mint a Postman API key in specs-only CLI mode', async () => {
+  it('does not mint a Postman API key in spec-only CLI mode', async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.includes('/api/sessions/current')) {
@@ -441,7 +441,7 @@ describe('runCli credential preflight seam', () => {
           { status: 200, headers: { 'content-type': 'application/json' } }
         );
       }
-      throw new Error(`unexpected fetch in specs-only CLI test: ${url}`);
+      throw new Error(`unexpected fetch in spec-only CLI test: ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -450,11 +450,11 @@ describe('runCli credential preflight seam', () => {
     await withTempCwd(async () => {
       await runCli(
         [
-          '--project-name', 'specs-only',
+          '--project-name', 'spec-only',
           '--postman-access-token', 'tok-only',
           '--team-id', '333',
           '--org-mode', 'true',
-          '--sync-generated-assets', 'false',
+          '--onboarding-scope', 'spec-only',
           '--credential-preflight', 'warn',
           '--repo-write-mode', 'none'
         ],

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -40,6 +40,7 @@ describe('postman-repo-sync-action contract', () => {
       'monitor-type',
       'smoke-collection-id',
       'contract-collection-id',
+      'sync-generated-assets',
       'prebuilt-collections-json',
       'collection-sync-mode',
       'spec-sync-mode',
@@ -420,5 +421,27 @@ describe('postman-repo-sync-action contract', () => {
     // Standalone behavior absent input unchanged
     const plan = createExecutionPlan();
     expect(plan.outputs).toBeDefined();
+  });
+
+  it('defaults generated asset sync on and supports a specs-only opt-in', () => {
+    const inputDef = postmanRepoSyncActionContract.inputs['sync-generated-assets'];
+    const actionYaml = parse(readFileSync(resolve(repoRoot, 'action.yml'), 'utf8')) as {
+      inputs: Record<string, { required?: boolean; default?: string }>;
+    };
+
+    expect(inputDef).toMatchObject({
+      required: false,
+      default: 'true',
+      allowedValues: ['true', 'false']
+    });
+    expect(actionYaml.inputs['sync-generated-assets']).toMatchObject({
+      required: false,
+      default: 'true'
+    });
+    expect(resolveInputs({}).syncGeneratedAssets).toBe(true);
+    expect(resolveInputs({ INPUT_SYNC_GENERATED_ASSETS: 'false' }).syncGeneratedAssets).toBe(false);
+    expect(() =>
+      resolveInputs({ INPUT_SYNC_GENERATED_ASSETS: 'flase' })
+    ).toThrow('sync-generated-assets must be either true or false');
   });
 });

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -40,7 +40,7 @@ describe('postman-repo-sync-action contract', () => {
       'monitor-type',
       'smoke-collection-id',
       'contract-collection-id',
-      'sync-generated-assets',
+      'onboarding-scope',
       'prebuilt-collections-json',
       'collection-sync-mode',
       'spec-sync-mode',
@@ -423,25 +423,25 @@ describe('postman-repo-sync-action contract', () => {
     expect(plan.outputs).toBeDefined();
   });
 
-  it('defaults generated asset sync on and supports a specs-only opt-in', () => {
-    const inputDef = postmanRepoSyncActionContract.inputs['sync-generated-assets'];
+  it('defaults onboarding scope to full and supports a spec-only opt-in', () => {
+    const inputDef = postmanRepoSyncActionContract.inputs['onboarding-scope'];
     const actionYaml = parse(readFileSync(resolve(repoRoot, 'action.yml'), 'utf8')) as {
       inputs: Record<string, { required?: boolean; default?: string }>;
     };
 
     expect(inputDef).toMatchObject({
       required: false,
-      default: 'true',
-      allowedValues: ['true', 'false']
+      default: 'full',
+      allowedValues: ['full', 'spec-only']
     });
-    expect(actionYaml.inputs['sync-generated-assets']).toMatchObject({
+    expect(actionYaml.inputs['onboarding-scope']).toMatchObject({
       required: false,
-      default: 'true'
+      default: 'full'
     });
-    expect(resolveInputs({}).syncGeneratedAssets).toBe(true);
-    expect(resolveInputs({ INPUT_SYNC_GENERATED_ASSETS: 'false' }).syncGeneratedAssets).toBe(false);
+    expect(resolveInputs({}).onboardingScope).toBe('full');
+    expect(resolveInputs({ INPUT_ONBOARDING_SCOPE: 'spec-only' }).onboardingScope).toBe('spec-only');
     expect(() =>
-      resolveInputs({ INPUT_SYNC_GENERATED_ASSETS: 'flase' })
-    ).toThrow('sync-generated-assets must be either true or false');
+      resolveInputs({ INPUT_ONBOARDING_SCOPE: 'specs-only' })
+    ).toThrow('onboarding-scope must be either full or spec-only');
   });
 });

--- a/tests/create-reconciliation.test.ts
+++ b/tests/create-reconciliation.test.ts
@@ -588,6 +588,7 @@ describe('fresh-process orchestration live discovery reuse', () => {
       baselineCollectionId: COLLECTION_UID,
       smokeCollectionId: '10490519-smoke-uid-0000-0000-000000000001',
       contractCollectionId: '',
+      onboardingScope: 'full',
       collectionSyncMode: 'refresh',
       specSyncMode: 'update',
       releaseLabel: undefined,

--- a/tests/credential-slot-preservation.test.ts
+++ b/tests/credential-slot-preservation.test.ts
@@ -46,6 +46,7 @@ function createInputs(overrides: Record<string, unknown> = {}) {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full' as const,
     collectionSyncMode: 'refresh' as const,
     specSyncMode: 'update' as const,
     environments: ['prod'],

--- a/tests/gh-secret-persistence-contract.test.ts
+++ b/tests/gh-secret-persistence-contract.test.ts
@@ -260,6 +260,22 @@ describe('persistSslSecrets — argv/stdin/GH_TOKEN/env contract', () => {
     expect(actionCore.info).toHaveBeenCalledWith('SSL certificate inputs persisted to repository secrets');
   });
 
+  it('does not persist SSL secrets when generated assets are disabled', async () => {
+    const actionCore = { info: vi.fn(), warning: vi.fn() };
+    const inputs = baseInputs({
+      syncGeneratedAssets: false,
+      sslClientCert: 'CERT-B64',
+      sslClientKey: 'KEY-B64',
+      githubToken: 'ghp_ssl_token'
+    });
+
+    await persistSslSecrets(inputs, actionCore, createCapturingExec(calls), 'acme/payments', {});
+
+    expect(calls).toEqual([]);
+    expect(actionCore.info).not.toHaveBeenCalled();
+    expect(actionCore.warning).not.toHaveBeenCalled();
+  });
+
   it('prefers ghFallbackToken over githubToken for the GH_TOKEN value', async () => {
     const actionCore = { info: vi.fn(), warning: vi.fn() };
     const inputs = baseInputs({

--- a/tests/gh-secret-persistence-contract.test.ts
+++ b/tests/gh-secret-persistence-contract.test.ts
@@ -90,6 +90,7 @@ function baseInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full',
     prebuiltCollectionsJson: '',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',
@@ -260,10 +261,10 @@ describe('persistSslSecrets — argv/stdin/GH_TOKEN/env contract', () => {
     expect(actionCore.info).toHaveBeenCalledWith('SSL certificate inputs persisted to repository secrets');
   });
 
-  it('does not persist SSL secrets when generated assets are disabled', async () => {
+  it('does not persist SSL secrets in spec-only scope', async () => {
     const actionCore = { info: vi.fn(), warning: vi.fn() };
     const inputs = baseInputs({
-      syncGeneratedAssets: false,
+      onboardingScope: 'spec-only',
       sslClientCert: 'CERT-B64',
       sslClientKey: 'KEY-B64',
       githubToken: 'ghp_ssl_token'

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -36,6 +36,7 @@ function createInputs(): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full',
     prebuiltCollectionsJson: '',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',

--- a/tests/private-mock-wiring-contract.test.ts
+++ b/tests/private-mock-wiring-contract.test.ts
@@ -129,6 +129,7 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full',
     prebuiltCollectionsJson: '',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -112,6 +112,7 @@ function createInputs(overrides: Partial<ResolvedInputs> = {}): ResolvedInputs {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full',
     prebuiltCollectionsJson: '',
     collectionSyncMode: 'refresh',
     specSyncMode: 'update',
@@ -585,12 +586,12 @@ describe('repo sync action', () => {
     );
   });
 
-  it('skips generated-CI SSL validation when generated assets are disabled', () => {
+  it('skips generated-CI SSL validation in spec-only scope', () => {
     const sslClientCert = Buffer.from('stale-cert').toString('base64');
     const { core, secrets } = createCoreStub({
       'project-name': 'core-payments',
       'postman-access-token': 'postman-access-token',
-      'sync-generated-assets': 'false',
+      'onboarding-scope': 'spec-only',
       'ssl-client-cert': sslClientCert,
       'environments-json': '["prod"]',
       'system-env-map-json': '{}',
@@ -600,7 +601,7 @@ describe('repo sync action', () => {
 
     const inputs = readActionInputs(core);
 
-    expect(inputs.syncGeneratedAssets).toBe(false);
+    expect(inputs.onboardingScope).toBe('spec-only');
     expect(secrets).toContain(sslClientCert);
   });
 
@@ -2240,7 +2241,44 @@ describe('repo sync action', () => {
       );
     });
 
-    it('skips local spec discovery for workspace-only runs when generated assets are disabled', async () => {
+    it('preserves legacy tracked collection ids in full scope without workspace state', async () => {
+      mkdirSync('.postman', { recursive: true });
+      writeFileSync(
+        '.postman/resources.yaml',
+        [
+          'version: 2',
+          'canonical:',
+          '  collections:',
+          '    ../postman/collections/core-payments: col-baseline-tracked',
+          '    ../postman/collections/[Smoke] core-payments: col-smoke-tracked',
+          '    ../postman/collections/[Contract] core-payments: col-contract-tracked',
+          ''
+        ].join('\n')
+      );
+      const postman = createExportPostmanStub();
+
+      await runRepoSync(
+        createInputs({
+          baselineCollectionId: '',
+          smokeCollectionId: '',
+          contractCollectionId: '',
+          onboardingScope: 'full',
+          environments: [],
+          environmentSyncEnabled: false,
+          workspaceLinkEnabled: false,
+          generateCiWorkflow: false,
+          repoWriteMode: 'none'
+        }),
+        deps(postman)
+      );
+
+      expect(postman.getCollection).toHaveBeenCalledTimes(3);
+      expect(postman.getCollection).toHaveBeenCalledWith('col-baseline-tracked');
+      expect(postman.getCollection).toHaveBeenCalledWith('col-smoke-tracked');
+      expect(postman.getCollection).toHaveBeenCalledWith('col-contract-tracked');
+    });
+
+    it('skips local spec discovery for workspace-only runs in spec-only scope', async () => {
       seedCandidateJsonFiles(201);
 
       await expect(
@@ -2248,7 +2286,7 @@ describe('repo sync action', () => {
           createInputs({
             specId: '',
             specPath: '',
-            syncGeneratedAssets: false,
+            onboardingScope: 'spec-only',
             generateCiWorkflow: false
           }),
           deps(createExportPostmanStub())
@@ -2260,7 +2298,7 @@ describe('repo sync action', () => {
       expect(resources.canonical?.specs).toBeUndefined();
     });
 
-    it('does not preserve generated resource ids when specs-only sync targets a different workspace', async () => {
+    it('does not preserve generated resource ids when spec-only sync targets a different workspace', async () => {
       mkdirSync('.postman', { recursive: true });
       writeFileSync(
         '.postman/resources.yaml',
@@ -2285,7 +2323,7 @@ describe('repo sync action', () => {
           workspaceId: 'ws-new',
           specId: 'spec-new',
           specPath: 'openapi.yaml',
-          syncGeneratedAssets: false,
+          onboardingScope: 'spec-only',
           generateCiWorkflow: false
         }),
         deps(createExportPostmanStub())
@@ -2299,7 +2337,48 @@ describe('repo sync action', () => {
       });
     });
 
-    it('does not rewrite canonical resources during a specs-only preview run', async () => {
+    it('does not attach legacy generated mappings to a new workspace when state has no workspace id', async () => {
+      mkdirSync('.postman', { recursive: true });
+      writeFileSync(
+        '.postman/resources.yaml',
+        [
+          'version: 2',
+          'canonical:',
+          '  collections:',
+          '    ../postman/collections/old: col-old',
+          '  environments:',
+          '    ../postman/environments/prod.postman_environment.json: env-old',
+          '  specs:',
+          '    ../old.yaml: spec-old',
+          ''
+        ].join('\n')
+      );
+      seedOpenApiSpec('openapi.yaml');
+
+      await runRepoSync(
+        createInputs({
+          workspaceId: 'ws-new',
+          specId: 'spec-new',
+          specPath: 'openapi.yaml',
+          onboardingScope: 'spec-only',
+          generateCiWorkflow: false
+        }),
+        deps(createExportPostmanStub())
+      );
+
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(resources).toEqual({
+        version: 2,
+        workspace: { id: 'ws-new' },
+        canonical: {
+          specs: {
+            '../openapi.yaml': 'spec-new'
+          }
+        }
+      });
+    });
+
+    it('does not rewrite canonical resources during a spec-only preview run', async () => {
       mkdirSync('.postman', { recursive: true });
       const originalResources = [
         'version: 2',
@@ -2325,13 +2404,44 @@ describe('repo sync action', () => {
           githubRefName: 'feature/spec-only',
           specId: 'spec-preview',
           specPath: 'openapi.yaml',
-          syncGeneratedAssets: false,
+          onboardingScope: 'spec-only',
           generateCiWorkflow: false
         }),
         deps(createExportPostmanStub())
       );
 
       expect(readFileSync('.postman/resources.yaml', 'utf8')).toBe(originalResources);
+    });
+
+    it('stages only the resources state file during spec-only sync', async () => {
+      seedOpenApiSpec('openapi.yaml');
+      const dependencies = deps(createExportPostmanStub());
+      const commitAndPush = vi.fn().mockResolvedValue({
+        commitSha: 'commit-spec-only',
+        pushed: false,
+        resolvedCurrentRef: 'feature/repo-sync'
+      });
+      dependencies.repoMutation = {
+        commitAndPush
+      } as unknown as NonNullable<RepoSyncDependencies['repoMutation']>;
+
+      await runRepoSync(
+        createInputs({
+          specId: 'spec-new',
+          specPath: 'openapi.yaml',
+          onboardingScope: 'spec-only',
+          generateCiWorkflow: false,
+          repoWriteMode: 'commit-only'
+        }),
+        dependencies
+      );
+
+      expect(commitAndPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          removePaths: [],
+          stagePaths: ['.postman/resources.yaml']
+        })
+      );
     });
 
     it('fails closed when local spec discovery exceeds the directory-depth budget', async () => {
@@ -2879,7 +2989,7 @@ describe('repo sync action', () => {
       createInputs({
         specId: 'spec-new',
         specPath: 'openapi.yaml',
-        syncGeneratedAssets: false
+        onboardingScope: 'spec-only'
       }),
       {
         core: createCoreStub().core,
@@ -2932,7 +3042,7 @@ describe('repo sync action', () => {
       }
     });
     expect(repoMutation.commitAndPush).toHaveBeenCalledWith(
-      expect.objectContaining({ stagePaths: ['.postman'], removePaths: [] })
+      expect.objectContaining({ stagePaths: ['.postman/resources.yaml'], removePaths: [] })
     );
   });
 
@@ -5090,7 +5200,7 @@ describe('org-mode auto-detection', () => {
     });
   }
 
-  it('does not create or persist a Postman API key when generated assets are disabled', async () => {
+  it('does not create or persist a Postman API key in spec-only scope', async () => {
     const actionCore = {
       info: vi.fn(),
       setSecret: vi.fn(),

--- a/tests/repo-sync-action.test.ts
+++ b/tests/repo-sync-action.test.ts
@@ -585,6 +585,25 @@ describe('repo sync action', () => {
     );
   });
 
+  it('skips generated-CI SSL validation when generated assets are disabled', () => {
+    const sslClientCert = Buffer.from('stale-cert').toString('base64');
+    const { core, secrets } = createCoreStub({
+      'project-name': 'core-payments',
+      'postman-access-token': 'postman-access-token',
+      'sync-generated-assets': 'false',
+      'ssl-client-cert': sslClientCert,
+      'environments-json': '["prod"]',
+      'system-env-map-json': '{}',
+      'environment-uids-json': '{}',
+      'env-runtime-urls-json': '{}'
+    });
+
+    const inputs = readActionInputs(core);
+
+    expect(inputs.syncGeneratedAssets).toBe(false);
+    expect(secrets).toContain(sslClientCert);
+  });
+
   it('materializes repo sync outputs and files', async () => {
     const { core, outputs } = createCoreStub();
     const postman = {
@@ -2221,6 +2240,100 @@ describe('repo sync action', () => {
       );
     });
 
+    it('skips local spec discovery for workspace-only runs when generated assets are disabled', async () => {
+      seedCandidateJsonFiles(201);
+
+      await expect(
+        runRepoSync(
+          createInputs({
+            specId: '',
+            specPath: '',
+            syncGeneratedAssets: false,
+            generateCiWorkflow: false
+          }),
+          deps(createExportPostmanStub())
+        )
+      ).resolves.toBeDefined();
+
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(resources.workspace).toEqual({ id: 'ws-123' });
+      expect(resources.canonical?.specs).toBeUndefined();
+    });
+
+    it('does not preserve generated resource ids when specs-only sync targets a different workspace', async () => {
+      mkdirSync('.postman', { recursive: true });
+      writeFileSync(
+        '.postman/resources.yaml',
+        [
+          'version: 2',
+          'workspace:',
+          '  id: ws-old',
+          'canonical:',
+          '  collections:',
+          '    ../postman/collections/old: col-old',
+          '  environments:',
+          '    ../postman/environments/prod.postman_environment.json: env-old',
+          '  specs:',
+          '    ../old.yaml: spec-old',
+          ''
+        ].join('\n')
+      );
+      seedOpenApiSpec('openapi.yaml');
+
+      await runRepoSync(
+        createInputs({
+          workspaceId: 'ws-new',
+          specId: 'spec-new',
+          specPath: 'openapi.yaml',
+          syncGeneratedAssets: false,
+          generateCiWorkflow: false
+        }),
+        deps(createExportPostmanStub())
+      );
+
+      const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+      expect(resources).toEqual({
+        version: 2,
+        workspace: { id: 'ws-new' },
+        canonical: { specs: { '../openapi.yaml': 'spec-new' } }
+      });
+    });
+
+    it('does not rewrite canonical resources during a specs-only preview run', async () => {
+      mkdirSync('.postman', { recursive: true });
+      const originalResources = [
+        'version: 2',
+        'workspace:',
+        '  id: ws-123',
+        'canonical:',
+        '  collections:',
+        '    ../postman/collections/existing: col-existing',
+        '  environments:',
+        '    ../postman/environments/prod.postman_environment.json: env-existing',
+        '  specs:',
+        '    ../openapi.yaml: spec-existing',
+        ''
+      ].join('\n');
+      writeFileSync('.postman/resources.yaml', originalResources);
+      seedOpenApiSpec('openapi.yaml');
+
+      await runRepoSync(
+        createInputs({
+          branchStrategy: 'preview',
+          canonicalBranch: 'main',
+          currentRef: 'refs/heads/feature/spec-only',
+          githubRefName: 'feature/spec-only',
+          specId: 'spec-preview',
+          specPath: 'openapi.yaml',
+          syncGeneratedAssets: false,
+          generateCiWorkflow: false
+        }),
+        deps(createExportPostmanStub())
+      );
+
+      expect(readFileSync('.postman/resources.yaml', 'utf8')).toBe(originalResources);
+    });
+
     it('fails closed when local spec discovery exceeds the directory-depth budget', async () => {
       const deepDir = seedDeepDirectoryChain(7);
       seedOpenApiSpec(join(deepDir, 'openapi.json'));
@@ -2710,6 +2823,117 @@ describe('repo sync action', () => {
     expect(postman.createEnvironment).not.toHaveBeenCalled();
     expect(postman.findEnvironmentByName).not.toHaveBeenCalled();
     expect(postman.updateEnvironment).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports workspace and spec sync without generated assets or cloud monitors', async () => {
+    mkdirSync('.github/workflows', { recursive: true });
+    writeFileSync('.github/workflows/provision.yml', 'name: Existing Provision\n');
+    mkdirSync('.postman', { recursive: true });
+    writeFileSync(
+      '.postman/resources.yaml',
+      [
+        'version: 2',
+        'workspace:',
+        '  id: ws-123',
+        'canonical:',
+        '  collections:',
+        '    ../postman/collections/existing: col-existing',
+        '  environments:',
+        '    ../postman/environments/prod.postman_environment.json: env-existing',
+        '  specs:',
+        '    ../existing.yaml: spec-existing',
+        ''
+      ].join('\n')
+    );
+    writeFileSync(
+      'openapi.yaml',
+      'openapi: 3.1.0\ninfo:\n  title: Specs Only\n  version: 1.0.0\npaths: {}\n'
+    );
+
+    const postman = {
+      createEnvironment: vi.fn(),
+      updateEnvironment: vi.fn(),
+      findEnvironmentByName: vi.fn(),
+      createMock: vi.fn(),
+      findMockByCollection: vi.fn(),
+      createMonitor: vi.fn(),
+      findMonitorByCollection: vi.fn(),
+      runMonitor: vi.fn(),
+      getCollection: vi.fn(),
+      getEnvironment: vi.fn()
+    } as unknown as RepoSyncDependencies['postman'];
+    const internalIntegration = {
+      associateSystemEnvironments: vi.fn(),
+      connectWorkspaceToRepository: vi.fn().mockResolvedValue(undefined),
+      findWorkspaceForRepo: vi.fn().mockResolvedValue({ state: 'free' })
+    };
+    const repoMutation = {
+      commitAndPush: vi.fn().mockResolvedValue({
+        commitSha: 'spec-only-commit',
+        pushed: false,
+        resolvedCurrentRef: 'feature/repo-sync'
+      })
+    };
+
+    const result = await runRepoSync(
+      createInputs({
+        specId: 'spec-new',
+        specPath: 'openapi.yaml',
+        syncGeneratedAssets: false
+      }),
+      {
+        core: createCoreStub().core,
+        postman,
+        internalIntegration,
+        repoMutation: repoMutation as unknown as RepoSyncDependencies['repoMutation']
+      }
+    );
+
+    expect(result).toMatchObject({
+      'workspace-link-status': 'success',
+      'environment-sync-status': 'skipped',
+      'environment-uids-json': '{}',
+      'mock-url': '',
+      'monitor-id': ''
+    });
+    expect(internalIntegration.connectWorkspaceToRepository).toHaveBeenCalledWith(
+      'ws-123',
+      'https://github.com/postman-cs/repo-sync-demo',
+      { preflightWasFree: true }
+    );
+    expect(internalIntegration.associateSystemEnvironments).not.toHaveBeenCalled();
+    expect(postman.createEnvironment).not.toHaveBeenCalled();
+    expect(postman.updateEnvironment).not.toHaveBeenCalled();
+    expect(postman.findEnvironmentByName).not.toHaveBeenCalled();
+    expect(postman.createMock).not.toHaveBeenCalled();
+    expect(postman.findMockByCollection).not.toHaveBeenCalled();
+    expect(postman.createMonitor).not.toHaveBeenCalled();
+    expect(postman.findMonitorByCollection).not.toHaveBeenCalled();
+    expect(postman.runMonitor).not.toHaveBeenCalled();
+    expect(postman.getCollection).not.toHaveBeenCalled();
+    expect(postman.getEnvironment).not.toHaveBeenCalled();
+    expect(existsSync('postman')).toBe(false);
+    expect(existsSync('.github/workflows/ci.yml')).toBe(false);
+    expect(readFileSync('.github/workflows/provision.yml', 'utf8')).toBe('name: Existing Provision\n');
+
+    const resources = loadYaml(readFileSync('.postman/resources.yaml', 'utf8')) as ResourcesYamlShape;
+    expect(resources).toEqual({
+      version: 2,
+      workspace: { id: 'ws-123' },
+      canonical: {
+        collections: { '../postman/collections/existing': 'col-existing' },
+        environments: {
+          '../postman/environments/prod.postman_environment.json': 'env-existing'
+        },
+        specs: {
+          '../existing.yaml': 'spec-existing',
+          '../openapi.yaml': 'spec-new'
+        }
+      }
+    });
+    expect(repoMutation.commitAndPush).toHaveBeenCalledWith(
+      expect.objectContaining({ stagePaths: ['.postman'], removePaths: [] })
+    );
   });
 
   it('refresh reruns keep the same tracked collection ids in .postman/resources.yaml', async () => {
@@ -4865,6 +5089,42 @@ describe('org-mode auto-detection', () => {
       return new Response('', { status: 404 });
     });
   }
+
+  it('does not create or persist a Postman API key when generated assets are disabled', async () => {
+    const actionCore = {
+      info: vi.fn(),
+      setSecret: vi.fn(),
+      warning: vi.fn()
+    };
+    const execLike = {
+      getExecOutput: vi.fn().mockResolvedValue({ exitCode: 0, stderr: '', stdout: '' })
+    };
+    const masker = createSecretMasker(['postman-access-token']);
+    const inputs = createInputs({
+      postmanApiKey: '',
+      postmanAccessToken: 'postman-access-token',
+      teamId: '10490519',
+      orgMode: true
+    });
+    vi.mocked(createInternalIntegrationAdapter).mockClear();
+
+    const result = await resolvePostmanApiKeyAndTeamId(
+      inputs,
+      actionCore,
+      execLike,
+      masker,
+      {
+        allowApiKeyCreation: false,
+        persistGeneratedApiKeySecret: false,
+        env: {}
+      }
+    );
+
+    expect(result).toEqual({ apiKey: '', teamId: '10490519' });
+    expect(createInternalIntegrationAdapter).not.toHaveBeenCalled();
+    expect(execLike.getExecOutput).not.toHaveBeenCalled();
+    expect(actionCore.setSecret).not.toHaveBeenCalled();
+  });
 
   it('sets orgMode=true when ums squads returns a non-empty squad list (org-mode team)', async () => {
     const actionCore = {

--- a/tests/secrets-resolver-provider.test.ts
+++ b/tests/secrets-resolver-provider.test.ts
@@ -47,6 +47,7 @@ function createInputs(overrides: Record<string, unknown> = {}) {
     baselineCollectionId: 'col-baseline',
     smokeCollectionId: 'col-smoke',
     contractCollectionId: 'col-contract',
+    onboardingScope: 'full' as const,
     collectionSyncMode: 'refresh' as const,
     specSyncMode: 'update' as const,
     environments: ['prod'],

--- a/tests/verify-dist-artifact.test.ts
+++ b/tests/verify-dist-artifact.test.ts
@@ -212,7 +212,9 @@ describe('verify-dist-artifact canonical contract', () => {
       const bundle = await readFile(path.join(repoRoot, entrypoint), 'utf8');
       const collectionAcquisition = bundle.indexOf('collection-acquisition count=');
       const environmentAcquisition = bundle.indexOf('environment-artifact-acquisition count=');
-      const resourcesMaterialization = bundle.indexOf(
+      // Specs-only mode has an earlier state-only write. The final occurrence
+      // remains the generated-assets path whose ordering this contract protects.
+      const resourcesMaterialization = bundle.lastIndexOf(
         'writeFileSync)(".postman/resources.yaml", buildResourcesManifest('
       );
 


### PR DESCRIPTION
## Summary

- Add the opt-in `sync-generated-assets` control, defaulting to `true` for backward compatibility.
- When disabled, retain workspace linking and spec resource state while skipping collections, environments, mocks, monitors, exported assets, and generated CI.
- Avoid generated-CI SSL secret writes and Postman API key minting in specs-only mode.
- Preserve prior generated resource mappings only when the target workspace is unchanged.

## Validation

- `npm run lint`
- `npm run build`
- `node scripts/verify-dist-artifact.mjs`
- Eight focused Vitest cases covering the specs-only action, CLI, credential, state, and side-effect boundaries
- Full diff reviewed locally with no unresolved findings

Supersedes #122.